### PR TITLE
Fix bug relating to freeing sga buf for lwip

### DIFF
--- a/src/c++/libos/lwip/lwip_queue.cc
+++ b/src/c++/libos/lwip/lwip_queue.cc
@@ -1117,7 +1117,8 @@ dmtr::lwip_queue::parse_packet(struct sockaddr_in &src,
 
         void *buf = NULL;
         DMTR_OK(dmtr_malloc(&buf, seg_len));
-        sga.sga_buf = buf;
+        // for DPDK, pointers are scattered
+        sga.sga_buf = NULL;
         sga.sga_segs[i].sgaseg_buf = buf;
         // todo: remove copy if possible.
         rte_memcpy(buf, p, seg_len);


### PR DESCRIPTION
Fixes issue where right now, for the DPDK lwip stack, the entire SGA won't be freed properly (only the last segment).