### PR TITLE
[demikernel] Uniform `OperationResult` Across LibOSes

### DIFF
--- a/src/catnap/futures/mod.rs
+++ b/src/catnap/futures/mod.rs
@@ -22,6 +22,7 @@ use self::{
     push::PushFuture,
     pushto::PushtoFuture,
 };
+use crate::Ipv4Endpoint;
 use ::catwalk::{
     FutureResult,
     SchedulerFuture,
@@ -29,10 +30,6 @@ use ::catwalk::{
 use ::runtime::{
     fail::Fail,
     memory::Bytes,
-    network::types::{
-        Ipv4Addr,
-        Port16,
-    },
     QDesc,
 };
 use ::std::{
@@ -55,7 +52,7 @@ pub enum OperationResult {
     Connect,
     Accept(RawFd),
     Push,
-    Pop(Option<(Ipv4Addr, Port16)>, Bytes),
+    Pop(Option<Ipv4Endpoint>, Bytes),
     Failed(Fail),
 }
 

--- a/src/catnap/mod.rs
+++ b/src/catnap/mod.rs
@@ -462,9 +462,10 @@ fn pack_result(rt: &PosixRuntime, result: OperationResult, qd: QDesc, qt: u64) -
         },
         OperationResult::Pop(addr, bytes) => match rt.into_sgarray(bytes) {
             Ok(mut sga) => {
-                if let Some((ipv4, port16)) = addr {
-                    sga.sga_addr.sin_port = port16.into();
-                    sga.sga_addr.sin_addr.s_addr = u32::from_le_bytes(ipv4.octets());
+                if let Some(endpoint) = addr {
+                    sga.sga_addr.sin_port = endpoint.get_port().into();
+                    sga.sga_addr.sin_addr.s_addr =
+                        u32::from_le_bytes(endpoint.get_address().octets());
                 }
                 let qr_value: dmtr_qr_value_t = dmtr_qr_value_t { sga };
                 dmtr_qresult_t {


### PR DESCRIPTION
Description
========

In this Pull Request, I fixed issue https://github.com/demikernel/demikernel/issues/54.