### PR TITLE
[demikernel] Support for `getaddrinfo()` and `freeaddrinfo()`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,3 +61,6 @@ export TIMEOUT ?= 30
 
 test-system: all-tests
 	timeout $(TIMEOUT) $(CARGO) test $(BUILD) $(CARGO_FEATURES) $(CARGO_FLAGS) -- --nocapture $(TEST)
+
+test-unit:
+	$(CARGO) test $(BUILD) $(CARGO_FEATURES) -- --test-threads=1 test_unit_getaddrinfo

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,11 @@ export SRCDIR = $(CURDIR)/src
 # Toolchain Configuration
 #===============================================================================
 
+export VERBOSE = yes
+ifeq ($(VERBOSE),yes)
+export CARGO_VERBOSE = --nocapture
+endif
+
 export BUILD ?= --release
 export CARGO ?= $(HOME)/.cargo/bin/cargo
 export CARGO_FLAGS ?=
@@ -60,7 +65,7 @@ export TEST ?= udp_push_pop
 export TIMEOUT ?= 30
 
 test-system: all-tests
-	timeout $(TIMEOUT) $(CARGO) test $(BUILD) $(CARGO_FEATURES) $(CARGO_FLAGS) -- --nocapture $(TEST)
+	timeout $(TIMEOUT) $(CARGO) test $(BUILD) $(CARGO_FEATURES) $(CARGO_FLAGS) -- $(CARGO_VERBOSE) $(TEST)
 
 test-unit:
-	$(CARGO) test $(BUILD) $(CARGO_FEATURES) -- --test-threads=1 test_unit_getaddrinfo
+	$(CARGO) test $(BUILD) $(CARGO_FEATURES) -- $(CARGO_VERBOSE) --test-threads=1 test_unit_getaddrinfo

--- a/include/dmtr/libos.h
+++ b/include/dmtr/libos.h
@@ -6,6 +6,8 @@
 
 #include <dmtr/sys/gcc.h>
 #include <dmtr/types.h>
+#include <netdb.h>
+#include <sys/socket.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -211,6 +213,30 @@ DMTR_EXPORT int dmtr_poll(dmtr_qresult_t *qr_out, dmtr_qtoken_t qt);
  * is returned instead.
  */
 DMTR_EXPORT int dmtr_drop(dmtr_qtoken_t qt);
+
+    /**
+     * @brief Gets address information
+     *
+     * @param node Internet host.
+     * @param service Internet service.
+     * @param hints Socket purpose hints.
+     * @param res Store location for address information
+     *
+     * @return On successful completion zero is returned. On failure, an error code
+     * is returned instead.
+     */
+    DMTR_EXPORT int dmtr_getaddrinfo(const char *node, const char *service, const struct addrinfo *hints,
+                                     struct addrinfo **res);
+
+    /**
+     * @brief Releases address information
+     *
+     * @param ai List of address information to release.
+     *
+     * @return On successful completion zero is returned. On failure, an error code
+     * is returned instead.
+     */
+    DMTR_EXPORT int dmtr_freeaddrinfo(struct addrinfo *ai);
 
 #ifdef __cplusplus
 }

--- a/src/catnip/mod.rs
+++ b/src/catnip/mod.rs
@@ -11,6 +11,7 @@ use self::runtime::DPDKRuntime;
 use crate::demikernel::config::Config;
 use ::catnip::Catnip;
 use ::dpdk_rs::load_mlx_driver;
+use ::runtime::fail::Fail;
 use ::std::ops::{
     Deref,
     DerefMut,
@@ -52,6 +53,21 @@ impl CatnipLibOS {
         );
         let libos: Catnip<DPDKRuntime> = Catnip::new(rt).unwrap();
         CatnipLibOS(libos)
+    }
+
+    // Gets address information.
+    pub fn getaddrinfo(
+        &self,
+        _node: Option<&str>,
+        _service: Option<&str>,
+        _hints: Option<&libc::addrinfo>,
+    ) -> Result<*mut libc::addrinfo, Fail> {
+        unimplemented!();
+    }
+
+    // Releases address information.
+    pub fn freeaddrinfo(&self, _ai: *mut libc::addrinfo) -> Result<(), Fail> {
+        unimplemented!();
     }
 }
 

--- a/src/catpowder/mod.rs
+++ b/src/catpowder/mod.rs
@@ -11,6 +11,7 @@ mod socket;
 use self::runtime::LinuxRuntime;
 use crate::demikernel::config::Config;
 use ::catnip::Catnip;
+use ::runtime::fail::Fail;
 use ::std::{
     ops::{
         Deref,
@@ -45,6 +46,21 @@ impl CatpowderLibOS {
         );
         let libos: Catnip<LinuxRuntime> = Catnip::new(rt).unwrap();
         CatpowderLibOS(libos)
+    }
+
+    // Gets address information.
+    pub fn getaddrinfo(
+        &self,
+        _node: Option<&str>,
+        _service: Option<&str>,
+        _hints: Option<&libc::addrinfo>,
+    ) -> Result<*mut libc::addrinfo, Fail> {
+        unimplemented!();
+    }
+
+    // Releases address information.
+    pub fn freeaddrinfo(&self, _ai: *mut libc::addrinfo) -> Result<(), Fail> {
+        unimplemented!();
     }
 }
 

--- a/src/demikernel/bindings.rs
+++ b/src/demikernel/bindings.rs
@@ -44,6 +44,37 @@ use ::std::{
 };
 
 //==============================================================================
+// Macros
+//==============================================================================
+
+// Asserts an expression or returns.
+macro_rules! valid_or_return {
+    ( $e:expr, $c:expr ) => {
+        if !$e {
+            return $c;
+        };
+    };
+}
+
+// Unwraps a result or returns.
+macro_rules! ok_or_return {
+    ( $e:expr, $c:expr ) => {
+        match $e {
+            Ok(x) => x,
+            Err(_) => return $c,
+        }
+    };
+}
+
+/// Unwraps an option or returns.
+macro_rules! some_or_return {
+    ( $e:expr, $c:expr ) => {
+        match $e {
+            Some(x) => x,
+            None => return $c,
+        }
+    };
+}
 
 //==============================================================================
 //

--- a/src/demikernel/libos.rs
+++ b/src/demikernel/libos.rs
@@ -185,6 +185,25 @@ impl LibOS {
         }
     }
 
+    /// Gets address information.
+    pub fn getaddrinfo(
+        &self,
+        node: Option<&str>,
+        service: Option<&str>,
+        hints: Option<&libc::addrinfo>,
+    ) -> Result<*mut libc::addrinfo, Fail> {
+        match self {
+            LibOS::NetworkLibOS(libos) => libos.getaddrinfo(node, service, hints),
+        }
+    }
+
+    /// Releases address information.
+    pub fn freeaddrinfo(&self, ai: *mut libc::addrinfo) -> Result<(), Fail> {
+        match self {
+            LibOS::NetworkLibOS(libos) => libos.freeaddrinfo(ai),
+        }
+    }
+
     pub fn wait(&mut self, qt: QToken) -> Result<dmtr_qresult_t, Fail> {
         match self {
             LibOS::NetworkLibOS(libos) => Ok(libos.wait(qt)),

--- a/tests/network.rs
+++ b/tests/network.rs
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//==============================================================================
+// Imports
+//==============================================================================
+
+use ::demikernel::LibOS;
+use std::ptr::null_mut;
+
+//==============================================================================
+// Unit Various Network Helper Functions
+//==============================================================================
+
+/// Tests getaddrinfo().
+#[test]
+fn test_unit_getaddrinfo() {
+    let libos: LibOS = LibOS::new();
+
+    let hints: libc::addrinfo = libc::addrinfo {
+        ai_flags: libc::AI_PASSIVE,
+        ai_family: libc::AF_UNSPEC,
+        ai_socktype: libc::SOCK_DGRAM,
+        ai_protocol: 0,
+        ai_addrlen: 0,
+        ai_addr: null_mut(),
+        ai_canonname: null_mut(),
+        ai_next: null_mut(),
+    };
+
+    let node: Option<&str> = None;
+    let service: Option<&str> = Some("80");
+    let hints: Option<&libc::addrinfo> = Some(&hints);
+
+    let ai: *mut libc::addrinfo = match libos.getaddrinfo(node, service, hints) {
+        Ok(ai) => ai,
+        Err(e) => panic!("{:?}", e.cause),
+    };
+
+    // Print address information list.
+    let mut next: *mut libc::addrinfo = ai;
+    while !next.is_null() {
+        unsafe {
+            println!("{:?}", (*next));
+            next = (*next).ai_next;
+        }
+    }
+
+    match libos.freeaddrinfo(ai) {
+        Ok(_) => (),
+        Err(e) => panic!("{:?}", e.cause),
+    };
+}


### PR DESCRIPTION
Description
========

In this PR I introduce support in Catnap for `getaddrinfo()` and `freeaddrinfo()`.

Related Issues
==========

- https://github.com/demikernel/demikernel/issues/53