### PR TITLE
[catnip] Bad Scatter-Gather Allocation/Free

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ clean:
 
 export CONFIG_PATH ?= $(HOME)/config.yaml
 export MTU ?= 1500
-export MSS ?= 9000
+export MSS ?= 1500
 export PEER ?= server
 export TEST ?= udp_push_pop
 export TIMEOUT ?= 30

--- a/Makefile
+++ b/Makefile
@@ -59,5 +59,13 @@ export PEER ?= server
 export TEST ?= udp_push_pop
 export TIMEOUT ?= 30
 
+# Runs system tests.
 test-system: all-tests
 	timeout $(TIMEOUT) $(CARGO) test $(BUILD) $(CARGO_FEATURES) $(CARGO_FLAGS) -- --nocapture $(TEST)
+
+# Runs unit tests.
+# TODO: Find out a way of launching all unit tests without having to explicity state all of them.
+test-unit:
+	$(CARGO) test $(BUILD) $(CARGO_FEATURES) -- --nocapture --test-threads=1 test_unit_sga_alloc_free_single
+	$(CARGO) test $(BUILD) $(CARGO_FEATURES) -- --nocapture --test-threads=1 test_unit_sga_alloc_free_loop_tight
+	$(CARGO) test $(BUILD) $(CARGO_FEATURES) -- --nocapture --test-threads=1 test_unit_sga_alloc_free_loop_decoupled

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,9 @@ test-system: all-tests
 # Runs unit tests.
 # TODO: Find out a way of launching all unit tests without having to explicity state all of them.
 test-unit:
-	$(CARGO) test $(BUILD) $(CARGO_FEATURES) -- --nocapture --test-threads=1 test_unit_sga_alloc_free_single
-	$(CARGO) test $(BUILD) $(CARGO_FEATURES) -- --nocapture --test-threads=1 test_unit_sga_alloc_free_loop_tight
-	$(CARGO) test $(BUILD) $(CARGO_FEATURES) -- --nocapture --test-threads=1 test_unit_sga_alloc_free_loop_decoupled
+	$(CARGO) test $(BUILD) $(CARGO_FEATURES) -- --nocapture --test-threads=1 test_unit_sga_alloc_free_single_small
+	$(CARGO) test $(BUILD) $(CARGO_FEATURES) -- --nocapture --test-threads=1 test_unit_sga_alloc_free_loop_tight_small
+	$(CARGO) test $(BUILD) $(CARGO_FEATURES) -- --nocapture --test-threads=1 test_unit_sga_alloc_free_loop_decoupled_small
+	$(CARGO) test $(BUILD) $(CARGO_FEATURES) -- --nocapture --test-threads=1 test_unit_sga_alloc_free_single_big
+	$(CARGO) test $(BUILD) $(CARGO_FEATURES) -- --nocapture --test-threads=1 test_unit_sga_alloc_free_loop_tight_big
+	$(CARGO) test $(BUILD) $(CARGO_FEATURES) -- --nocapture --test-threads=1 test_unit_sga_alloc_free_loop_decoupled_big

--- a/src/catnip/runtime/memory/manager.rs
+++ b/src/catnip/runtime/memory/manager.rs
@@ -34,7 +34,6 @@ use ::dpdk_rs::{
 use ::libc::{
     c_uint,
     c_void,
-    ENOMEM,
 };
 use ::runtime::{
     fail::Fail,

--- a/src/catnip/runtime/memory/manager.rs
+++ b/src/catnip/runtime/memory/manager.rs
@@ -124,12 +124,6 @@ impl MemoryManager {
         Mbuf::new(self.inner.clone_mbuf(mbuf.get_ptr()), self.clone())
     }
 
-    fn is_body_ptr(&self, ptr: *mut c_void) -> bool {
-        let ptr_int = ptr as usize;
-        let body_end = self.inner.body_region_addr + self.inner.body_region_len;
-        ptr_int >= self.inner.body_region_addr && ptr_int < body_end
-    }
-
     pub fn into_sgarray(&self, buf: DPDKBuf) -> Result<dmtr_sgarray_t, Fail> {
         let sgaseg = match buf {
             DPDKBuf::External(bytes) => {

--- a/src/catnip/runtime/memory/manager.rs
+++ b/src/catnip/runtime/memory/manager.rs
@@ -278,7 +278,7 @@ impl MemoryManager {
             let body_clone: *mut rte_mbuf = self.inner.clone_mbuf(mbuf_ptr);
             let mut mbuf: Mbuf = Mbuf::new(body_clone, self.clone());
             // Adjust buffer length.
-            // TODO: Replace the following method for computing the length of a mbuf once we have a propor Mbuf abstraction.
+            // TODO: Replace the following method for computing the length of a mbuf once we have a proper Mbuf abstraction.
             let orig_len: usize = unsafe { ((*mbuf_ptr).buf_len - (*mbuf_ptr).data_off).into() };
             let trim: usize = orig_len - len;
             mbuf.trim(trim);

--- a/src/catnip/runtime/memory/manager.rs
+++ b/src/catnip/runtime/memory/manager.rs
@@ -124,28 +124,6 @@ impl MemoryManager {
         Mbuf::new(self.inner.clone_mbuf(mbuf.get_ptr()), self.clone())
     }
 
-
-    fn recover_body_mbuf(&self, ptr: *mut c_void) -> Result<*mut rte_mbuf, Error> {
-        if !self.is_body_ptr(ptr) {
-            anyhow::bail!("Out of bounds ptr {:?}", ptr);
-        }
-
-        let ptr_int = ptr as usize;
-        let ptr_offset = ptr_int - self.inner.body_region_addr;
-        let offset_within_alloc = ptr_offset % self.inner.body_alloc_size();
-
-        if offset_within_alloc < (64 + 128) {
-            anyhow::bail!(
-                "Data pointer within allocation header: {:?} in {:?}",
-                ptr,
-                self.inner
-            );
-        }
-
-        let mbuf_ptr = (ptr_int - offset_within_alloc + 64) as *mut rte_mbuf;
-        Ok(mbuf_ptr)
-    }
-
     fn is_body_ptr(&self, ptr: *mut c_void) -> bool {
         let ptr_int = ptr as usize;
         let body_end = self.inner.body_region_addr + self.inner.body_region_len;

--- a/src/catnip/runtime/memory/manager.rs
+++ b/src/catnip/runtime/memory/manager.rs
@@ -416,10 +416,6 @@ impl Inner {
         })
     }
 
-    fn body_alloc_size(&self) -> usize {
-        64 + 128 + self.config.get_max_body_size()
-    }
-
     pub fn alloc_indirect_empty(&self) -> *mut rte_mbuf {
         let ptr = unsafe { rte_pktmbuf_alloc(self.indirect_pool) };
         assert!(!ptr.is_null());

--- a/src/catnip/runtime/memory/manager.rs
+++ b/src/catnip/runtime/memory/manager.rs
@@ -124,42 +124,6 @@ impl MemoryManager {
         Mbuf::new(self.inner.clone_mbuf(mbuf.get_ptr()), self.clone())
     }
 
-    /// Given a pointer and length into a body `mbuf`, return a fresh indirect `mbuf` that points to
-    /// the same memory region, incrementing the refcount of the body `mbuf`.
-    pub fn clone_body(&self, ptr: *mut c_void, len: usize) -> Result<Mbuf, Error> {
-        let mbuf_ptr = self.recover_body_mbuf(ptr)?;
-        let body_clone = self.inner.clone_mbuf(mbuf_ptr);
-
-        // Wrap the mbuf first so we free it on early exit.
-        let mut mbuf = Mbuf::new(body_clone, self.clone());
-
-        let orig_ptr = mbuf.data_ptr();
-        let orig_len = mbuf.len();
-
-        if (ptr as usize) < (orig_ptr as usize) {
-            anyhow::bail!(
-                "Trying to recover data pointer outside original body: {:?} vs. {:?}",
-                ptr,
-                orig_ptr
-            );
-        }
-        let adjust = ptr as usize - orig_ptr as usize;
-
-        if adjust + len > orig_len {
-            anyhow::bail!(
-                "Recovering too many bytes: {} + {} > {}",
-                adjust,
-                len,
-                orig_len
-            );
-        }
-        let trim = orig_len - (adjust + len);
-
-        mbuf.adjust(adjust);
-        mbuf.trim(trim);
-
-        Ok(mbuf)
-    }
 
     fn recover_body_mbuf(&self, ptr: *mut c_void) -> Result<*mut rte_mbuf, Error> {
         if !self.is_body_ptr(ptr) {

--- a/tests/sga.rs
+++ b/tests/sga.rs
@@ -1,0 +1,84 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//==============================================================================
+// Imports
+//==============================================================================
+
+use ::demikernel::LibOS;
+use ::runtime::types::dmtr_sgarray_t;
+
+//==============================================================================
+// Constants
+//==============================================================================
+
+/// Size of scatter-gather arrays.
+const SGA_MAX_SIZE: usize = 1280;
+
+//==============================================================================
+// Unit Tests for Memory Allocation
+//==============================================================================
+
+/// Tests for a single scatter-gather array allocation and deallocation.
+#[test]
+fn test_unit_sga_alloc_free_single() {
+    let size: usize = SGA_MAX_SIZE;
+    let libos: LibOS = LibOS::new();
+
+    let sga: dmtr_sgarray_t = match libos.sgaalloc(size) {
+        Ok(sga) => sga,
+        Err(e) => panic!("failed to allocated sga: {:?}", e.cause),
+    };
+    match libos.sgafree(sga) {
+        Ok(()) => (),
+        Err(e) => panic!("failed to release sga: {:?}", e.cause),
+    };
+}
+
+/// Tests looped allocation and deallocation of scatter-gather arrays.
+#[test]
+fn test_unit_sga_alloc_free_loop_tight() {
+    let size: usize = SGA_MAX_SIZE;
+    let libos: LibOS = LibOS::new();
+
+    // Allocate and deallocate several times.
+    for _ in 0..1_000_000 {
+        let sga: dmtr_sgarray_t = match libos.sgaalloc(size) {
+            Ok(sga) => sga,
+            Err(e) => panic!("failed to allocated sga: {:?}", e.cause),
+        };
+        match libos.sgafree(sga) {
+            Ok(()) => (),
+            Err(e) => panic!("failed to release sga: {:?}", e.cause),
+        };
+    }
+}
+
+/// Tests decoupled looped allocation and deallocation of scatter-gather arrays.
+#[test]
+fn test_unit_sga_alloc_free_loop_decoupled() {
+    let size: usize = SGA_MAX_SIZE;
+    let mut sgas: Vec<dmtr_sgarray_t> = Vec::with_capacity(1_000);
+    let libos: LibOS = LibOS::new();
+
+    // Allocate and deallocate several times.
+    for _ in 0..1_000 {
+        // Allocate many scatter-gather arrays.
+        for _ in 0..1_000 {
+            let sga: dmtr_sgarray_t = match libos.sgaalloc(size) {
+                Ok(sga) => sga,
+                Err(e) => panic!("failed to allocated sga: {:?}", e.cause),
+            };
+            sgas.push(sga);
+        }
+
+        // Deallocate all scatter-gather arrays.
+        for _ in 0..1_000 {
+            let sga: dmtr_sgarray_t = sgas.pop().expect("pop from empty vector?");
+            match libos.sgafree(sga) {
+                Ok(()) => (),
+                Err(e) => panic!("failed to release sga: {:?}", e.cause),
+            };
+        }
+    }
+}

--- a/tests/sga.rs
+++ b/tests/sga.rs
@@ -12,17 +12,18 @@ use ::runtime::types::dmtr_sgarray_t;
 // Constants
 //==============================================================================
 
-/// Size of scatter-gather arrays.
-const SGA_MAX_SIZE: usize = 1280;
+/// Size for small scatter-gather arrays.
+const SGA_SIZE_SMALL: usize = 64;
+
+/// Size for big scatter-gather arrays.
+const SGA_SIZE_BIG: usize = 1280;
 
 //==============================================================================
-// Unit Tests for Memory Allocation
+// test_unit_sga_alloc_free_single()
 //==============================================================================
 
 /// Tests for a single scatter-gather array allocation and deallocation.
-#[test]
-fn test_unit_sga_alloc_free_single() {
-    let size: usize = SGA_MAX_SIZE;
+fn do_test_unit_sga_alloc_free_single(size: usize) {
     let libos: LibOS = LibOS::new();
 
     let sga: dmtr_sgarray_t = match libos.sgaalloc(size) {
@@ -35,10 +36,24 @@ fn test_unit_sga_alloc_free_single() {
     };
 }
 
-/// Tests looped allocation and deallocation of scatter-gather arrays.
+/// Tests a single allocation and deallocation of a small scatter-gather array.
 #[test]
-fn test_unit_sga_alloc_free_loop_tight() {
-    let size: usize = SGA_MAX_SIZE;
+fn test_unit_sga_alloc_free_single_small() {
+    do_test_unit_sga_alloc_free_single(SGA_SIZE_SMALL)
+}
+
+/// Tests a single allocation and deallocation of a big scatter-gather array.
+#[test]
+fn test_unit_sga_alloc_free_single_big() {
+    do_test_unit_sga_alloc_free_single(SGA_SIZE_BIG)
+}
+
+//==============================================================================
+// test_unit_sga_alloc_free_loop_tight()
+//==============================================================================
+
+/// Tests looped allocation and deallocation of scatter-gather arrays.
+fn do_test_unit_sga_alloc_free_loop_tight(size: usize) {
     let libos: LibOS = LibOS::new();
 
     // Allocate and deallocate several times.
@@ -54,10 +69,24 @@ fn test_unit_sga_alloc_free_loop_tight() {
     }
 }
 
-/// Tests decoupled looped allocation and deallocation of scatter-gather arrays.
+/// Tests looped allocation and deallocation of small scatter-gather arrays.
 #[test]
-fn test_unit_sga_alloc_free_loop_decoupled() {
-    let size: usize = SGA_MAX_SIZE;
+fn test_unit_sga_alloc_free_loop_tight_small() {
+    do_test_unit_sga_alloc_free_loop_tight(SGA_SIZE_SMALL)
+}
+
+/// Tests looped allocation and deallocation of big scatter-gather arrays.
+#[test]
+fn test_unit_sga_alloc_free_loop_tight_big() {
+    do_test_unit_sga_alloc_free_loop_tight(SGA_SIZE_BIG)
+}
+
+//==============================================================================
+// test_unit_sga_alloc_free_loop_decoupled()
+//==============================================================================
+
+/// Tests decoupled looped allocation and deallocation of scatter-gather arrays.
+fn do_test_unit_sga_alloc_free_loop_decoupled(size: usize) {
     let mut sgas: Vec<dmtr_sgarray_t> = Vec::with_capacity(1_000);
     let libos: LibOS = LibOS::new();
 
@@ -81,4 +110,16 @@ fn test_unit_sga_alloc_free_loop_decoupled() {
             };
         }
     }
+}
+
+/// Tests decoupled looped allocation and deallocation of small scatter-gather arrays.
+#[test]
+fn test_unit_sga_alloc_free_loop_decoupled_small() {
+    do_test_unit_sga_alloc_free_loop_decoupled(SGA_SIZE_SMALL)
+}
+
+/// Tests decoupled looped allocation and deallocation of big scatter-gather arrays.
+#[test]
+fn test_unit_sga_alloc_free_loop_decoupled_big() {
+    do_test_unit_sga_alloc_free_loop_decoupled(SGA_SIZE_BIG)
 }


### PR DESCRIPTION
Description
========

This PR fixes issue https://github.com/demikernel/demikernel/issues/51.

In summary, the pointer arithmetic used for releasing allocated `mbufs` is bad. Instead of relying on this technique, I simply changed current code to use the returned `mbuf` pointer.

Since the management of DPDK buffers is not well design, I've also placed a warning, so that we know when we are relying on this allocation strategy.

Finally, I introduce unit-tests that ensure that the current logic works as expected.

This component will be strongly re-architected in a next PR.