### PR TITLE
[catnip] Memory Pool Abstraction

### DIFF
--- a/.github/workflows/catnap-unit-tests.yml
+++ b/.github/workflows/catnap-unit-tests.yml
@@ -1,0 +1,188 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+name: Catnap TCP Ping Pong
+
+concurrency:
+  group: azure
+  cancel-in-progress: true
+
+on:
+  push:
+    branches:
+      - bugfix-*
+      - enhancement-*
+      - feature-*
+      - workaround-*
+      - dev
+      - unstable
+      - master
+  workflow_dispatch:
+    branches:
+      - bugfix-*
+      - enhancement-*
+      - feature-*
+      - workaround-*
+      - dev
+      - unstable
+      - master
+
+env:
+  CARGO_TERM_COLOR: always
+  GITHUB_REPOSITORY: $GITHUB_REPOSITORY
+  GITHUB_SHA: $GITHUB_SHA
+
+jobs:
+
+  #====================
+  # Setup
+  #====================
+
+  # Demikernel 0
+  setup-demikernel0:
+    name: Demikernel 0
+    uses: demikernel/workflows/.github/workflows/setup.yml@dev
+    secrets:
+      host: ${{ secrets.HOSTNAME_A }}
+      port: ${{ secrets.PORTNUM_A }}
+      key: ${{ secrets.SSHKEY }}
+      username: ${{ secrets.USERNAME }}
+
+  # Demikernel 1
+  setup-demikernel1:
+    name: Demikernel 1
+    uses: demikernel/workflows/.github/workflows/setup.yml@dev
+    secrets:
+      host: ${{ secrets.HOSTNAME_B }}
+      port: ${{ secrets.PORTNUM_B }}
+      key: ${{ secrets.SSHKEY }}
+      username: ${{ secrets.USERNAME }}
+
+
+  #====================
+  # Compile
+  #====================
+
+  # Demikernel 0
+  build-demikernel0:
+    name: Demikernel 0
+    needs: [setup-demikernel0]
+    uses: demikernel/workflows/.github/workflows/compile.yml@dev
+    with:
+      target: "all-tests LIBOS=catnap"
+    secrets:
+      host: ${{ secrets.HOSTNAME_A }}
+      port: ${{ secrets.PORTNUM_A }}
+      key: ${{ secrets.SSHKEY }}
+      username: ${{ secrets.USERNAME }}
+
+  # Demikernel 1
+  build-demikernel1:
+    name: Demikernel 1
+    needs: [setup-demikernel1]
+    uses: demikernel/workflows/.github/workflows/compile.yml@dev
+    with:
+      target: "all-tests LIBOS=catnap"
+    secrets:
+      host: ${{ secrets.HOSTNAME_B }}
+      port: ${{ secrets.PORTNUM_B }}
+      key: ${{ secrets.SSHKEY }}
+      username: ${{ secrets.USERNAME }}
+
+  #====================
+  # Run
+  #====================
+
+  # Demikernel 0
+  launch-demikernel0:
+    name: Demikernel0
+    runs-on: ubuntu-latest
+    needs: [build-demikernel0, build-demikernel1]
+    steps:
+    - name: Launch
+      uses: appleboy/ssh-action@master
+      with:
+        host: ${{ secrets.HOSTNAME_A }}
+        username: ${{ secrets.USERNAME }}
+        key: ${{ secrets.SSHKEY }}
+        port: ${{ secrets.PORTNUM_A }}
+        envs: GITHUB_REPOSITORY,GITHUB_SHA
+        script: |
+          source $HOME/setup-env-catnap.sh
+          cd $GITHUB_REPOSITORY
+          TIMEOUT=300 sudo -E make LIBOS=catnap test-unit > nohup.out 2> nohup.err < /dev/null  &
+
+  # Demikernel 1
+  launch-demikernel1:
+    name: Demikernel 1
+    runs-on: ubuntu-latest
+    needs: [build-demikernel1, launch-demikernel0]
+    steps:
+    - name: Launch
+      uses: appleboy/ssh-action@master
+      with:
+        host: ${{ secrets.HOSTNAME_B }}
+        username: ${{ secrets.USERNAME }}
+        key: ${{ secrets.SSHKEY }}
+        port: ${{ secrets.PORTNUM_B }}
+        envs: GITHUB_REPOSITORY,GITHUB_SHA
+        script: |
+          source $HOME/setup-env-catnap.sh
+          cd $GITHUB_REPOSITORY
+          TIMEOUT=300 sudo -E make LIBOS=catnap test-unit > nohup.out 2> nohup.err < /dev/null
+
+  #====================
+  # Post-Run
+  #====================
+
+  # Demikernel 0
+  postrun-demikernel0:
+    name: Demikernel 0
+    needs: [launch-demikernel1]
+    uses: demikernel/workflows/.github/workflows/postrun.yml@dev
+    with:
+      process-name: pingpong
+    secrets:
+      host: ${{ secrets.HOSTNAME_A }}
+      port: ${{ secrets.PORTNUM_A }}
+      key: ${{ secrets.SSHKEY }}
+      username: ${{ secrets.USERNAME }}
+
+  # Demikernel 1
+  postrun-demikernel1:
+    name: Demikernel 1
+    needs: [launch-demikernel1]
+    uses: demikernel/workflows/.github/workflows/postrun.yml@dev
+    with:
+      process-name: pingpong
+    secrets:
+      host: ${{ secrets.HOSTNAME_B }}
+      port: ${{ secrets.PORTNUM_B }}
+      key: ${{ secrets.SSHKEY }}
+      username: ${{ secrets.USERNAME }}
+
+  #====================
+  # Cleanup
+  #====================
+
+  # Demikernel 0
+  cleanup-demikernel0:
+    name: Demikernel 0
+    needs: [postrun-demikernel0]
+    uses: demikernel/workflows/.github/workflows/cleanup.yml@dev
+    secrets:
+      host: ${{ secrets.HOSTNAME_A }}
+      port: ${{ secrets.PORTNUM_A }}
+      key: ${{ secrets.SSHKEY }}
+      username: ${{ secrets.USERNAME }}
+
+  # Demikernel 1
+  cleanup-demikernel1:
+    name: Demikernel 1
+    needs: [postrun-demikernel1]
+    uses: demikernel/workflows/.github/workflows/cleanup.yml@dev
+    secrets:
+      host: ${{ secrets.HOSTNAME_B }}
+      port: ${{ secrets.PORTNUM_B }}
+      key: ${{ secrets.SSHKEY }}
+      username: ${{ secrets.USERNAME }}

--- a/.github/workflows/catnip-unit-test.yml
+++ b/.github/workflows/catnip-unit-test.yml
@@ -1,0 +1,188 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+name: Catnip TCP Ping Pong
+
+concurrency:
+  group: azure
+  cancel-in-progress: true
+
+on:
+  push:
+    branches:
+      - bugfix-*
+      - enhancement-*
+      - feature-*
+      - workaround-*
+      - dev
+      - unstable
+      - master
+  workflow_dispatch:
+    branches:
+      - bugfix-*
+      - enhancement-*
+      - feature-*
+      - workaround-*
+      - dev
+      - unstable
+      - master
+
+env:
+  CARGO_TERM_COLOR: always
+  GITHUB_REPOSITORY: $GITHUB_REPOSITORY
+  GITHUB_SHA: $GITHUB_SHA
+
+jobs:
+
+  #====================
+  # Setup
+  #====================
+
+  # Demikernel 0
+  setup-demikernel0:
+    name: Demikernel 0
+    uses: demikernel/workflows/.github/workflows/setup.yml@dev
+    secrets:
+      host: ${{ secrets.HOSTNAME_A }}
+      port: ${{ secrets.PORTNUM_A }}
+      key: ${{ secrets.SSHKEY }}
+      username: ${{ secrets.USERNAME }}
+
+  # Demikernel 1
+  setup-demikernel1:
+    name: Demikernel 1
+    uses: demikernel/workflows/.github/workflows/setup.yml@dev
+    secrets:
+      host: ${{ secrets.HOSTNAME_B }}
+      port: ${{ secrets.PORTNUM_B }}
+      key: ${{ secrets.SSHKEY }}
+      username: ${{ secrets.USERNAME }}
+
+
+  #====================
+  # Compile
+  #====================
+
+  # Demikernel 0
+  build-demikernel0:
+    name: Demikernel 0
+    needs: [setup-demikernel0]
+    uses: demikernel/workflows/.github/workflows/compile.yml@dev
+    with:
+      target: "all-tests LIBOS=catnip"
+    secrets:
+      host: ${{ secrets.HOSTNAME_A }}
+      port: ${{ secrets.PORTNUM_A }}
+      key: ${{ secrets.SSHKEY }}
+      username: ${{ secrets.USERNAME }}
+
+  # Demikernel 1
+  build-demikernel1:
+    name: Demikernel 1
+    needs: [setup-demikernel1]
+    uses: demikernel/workflows/.github/workflows/compile.yml@dev
+    with:
+      target: "all-tests LIBOS=catnip"
+    secrets:
+      host: ${{ secrets.HOSTNAME_B }}
+      port: ${{ secrets.PORTNUM_B }}
+      key: ${{ secrets.SSHKEY }}
+      username: ${{ secrets.USERNAME }}
+
+  #====================
+  # Run
+  #====================
+
+  # Demikernel 0
+  launch-demikernel0:
+    name: Demikernel0
+    runs-on: ubuntu-latest
+    needs: [build-demikernel0, build-demikernel1]
+    steps:
+    - name: Launch
+      uses: appleboy/ssh-action@master
+      with:
+        host: ${{ secrets.HOSTNAME_A }}
+        username: ${{ secrets.USERNAME }}
+        key: ${{ secrets.SSHKEY }}
+        port: ${{ secrets.PORTNUM_A }}
+        envs: GITHUB_REPOSITORY,GITHUB_SHA
+        script: |
+          source $HOME/setup-env.sh
+          cd $GITHUB_REPOSITORY
+          TIMEOUT=300 sudo -E make LIBOS=catnip test-unit > nohup.out 2> nohup.err < /dev/null  &
+
+  # Demikernel 1
+  launch-demikernel1:
+    name: Demikernel 1
+    runs-on: ubuntu-latest
+    needs: [build-demikernel1, launch-demikernel0]
+    steps:
+    - name: Launch
+      uses: appleboy/ssh-action@master
+      with:
+        host: ${{ secrets.HOSTNAME_B }}
+        username: ${{ secrets.USERNAME }}
+        key: ${{ secrets.SSHKEY }}
+        port: ${{ secrets.PORTNUM_B }}
+        envs: GITHUB_REPOSITORY,GITHUB_SHA
+        script: |
+          source $HOME/setup-env.sh
+          cd $GITHUB_REPOSITORY
+          TIMEOUT=300 sudo -E make LIBOS=catnip test-unit > nohup.out 2> nohup.err < /dev/null
+
+  #====================
+  # Post-Run
+  #====================
+
+  # Demikernel 0
+  postrun-demikernel0:
+    name: Demikernel 0
+    needs: [launch-demikernel1]
+    uses: demikernel/workflows/.github/workflows/postrun.yml@dev
+    with:
+      process-name: pingpong
+    secrets:
+      host: ${{ secrets.HOSTNAME_A }}
+      port: ${{ secrets.PORTNUM_A }}
+      key: ${{ secrets.SSHKEY }}
+      username: ${{ secrets.USERNAME }}
+
+  # Demikernel 1
+  postrun-demikernel1:
+    name: Demikernel 1
+    needs: [launch-demikernel1]
+    uses: demikernel/workflows/.github/workflows/postrun.yml@dev
+    with:
+      process-name: pingpong
+    secrets:
+      host: ${{ secrets.HOSTNAME_B }}
+      port: ${{ secrets.PORTNUM_B }}
+      key: ${{ secrets.SSHKEY }}
+      username: ${{ secrets.USERNAME }}
+
+  #====================
+  # Cleanup
+  #====================
+
+  # Demikernel 0
+  cleanup-demikernel0:
+    name: Demikernel 0
+    needs: [postrun-demikernel0]
+    uses: demikernel/workflows/.github/workflows/cleanup.yml@dev
+    secrets:
+      host: ${{ secrets.HOSTNAME_A }}
+      port: ${{ secrets.PORTNUM_A }}
+      key: ${{ secrets.SSHKEY }}
+      username: ${{ secrets.USERNAME }}
+
+  # Demikernel 1
+  cleanup-demikernel1:
+    name: Demikernel 1
+    needs: [postrun-demikernel1]
+    uses: demikernel/workflows/.github/workflows/cleanup.yml@dev
+    secrets:
+      host: ${{ secrets.HOSTNAME_B }}
+      port: ${{ secrets.PORTNUM_B }}
+      key: ${{ secrets.SSHKEY }}
+      username: ${{ secrets.USERNAME }}

--- a/.github/workflows/catpowder-unit-test.yml
+++ b/.github/workflows/catpowder-unit-test.yml
@@ -1,0 +1,188 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+name: Catpowder TCP Ping Pong
+
+concurrency:
+  group: azure
+  cancel-in-progress: true
+
+on:
+  push:
+    branches:
+      - bugfix-*
+      - enhancement-*
+      - feature-*
+      - workaround-*
+      - dev
+      - unstable
+      - master
+  workflow_dispatch:
+    branches:
+      - bugfix-*
+      - enhancement-*
+      - feature-*
+      - workaround-*
+      - dev
+      - unstable
+      - master
+
+env:
+  CARGO_TERM_COLOR: always
+  GITHUB_REPOSITORY: $GITHUB_REPOSITORY
+  GITHUB_SHA: $GITHUB_SHA
+
+jobs:
+
+  #====================
+  # Setup
+  #====================
+
+  # Demikernel 0
+  setup-demikernel0:
+    name: Demikernel 0
+    uses: demikernel/workflows/.github/workflows/setup.yml@dev
+    secrets:
+      host: ${{ secrets.HOSTNAME_A }}
+      port: ${{ secrets.PORTNUM_A }}
+      key: ${{ secrets.SSHKEY }}
+      username: ${{ secrets.USERNAME }}
+
+  # Demikernel 1
+  setup-demikernel1:
+    name: Demikernel 1
+    uses: demikernel/workflows/.github/workflows/setup.yml@dev
+    secrets:
+      host: ${{ secrets.HOSTNAME_B }}
+      port: ${{ secrets.PORTNUM_B }}
+      key: ${{ secrets.SSHKEY }}
+      username: ${{ secrets.USERNAME }}
+
+
+  #====================
+  # Compile
+  #====================
+
+  # Demikernel 0
+  build-demikernel0:
+    name: Demikernel 0
+    needs: [setup-demikernel0]
+    uses: demikernel/workflows/.github/workflows/compile.yml@dev
+    with:
+      target: "all-tests LIBOS=catpowder"
+    secrets:
+      host: ${{ secrets.HOSTNAME_A }}
+      port: ${{ secrets.PORTNUM_A }}
+      key: ${{ secrets.SSHKEY }}
+      username: ${{ secrets.USERNAME }}
+
+  # Demikernel 1
+  build-demikernel1:
+    name: Demikernel 1
+    needs: [setup-demikernel1]
+    uses: demikernel/workflows/.github/workflows/compile.yml@dev
+    with:
+      target: "all-tests LIBOS=catpowder"
+    secrets:
+      host: ${{ secrets.HOSTNAME_B }}
+      port: ${{ secrets.PORTNUM_B }}
+      key: ${{ secrets.SSHKEY }}
+      username: ${{ secrets.USERNAME }}
+
+  #====================
+  # Run
+  #====================
+
+  # Demikernel 0
+  launch-demikernel0:
+    name: Demikernel0
+    runs-on: ubuntu-latest
+    needs: [build-demikernel0, build-demikernel1]
+    steps:
+    - name: Launch
+      uses: appleboy/ssh-action@master
+      with:
+        host: ${{ secrets.HOSTNAME_A }}
+        username: ${{ secrets.USERNAME }}
+        key: ${{ secrets.SSHKEY }}
+        port: ${{ secrets.PORTNUM_A }}
+        envs: GITHUB_REPOSITORY,GITHUB_SHA
+        script: |
+          source $HOME/setup-env.sh
+          cd $GITHUB_REPOSITORY
+          TIMEOUT=300 sudo -E make LIBOS=catpowder test-unit > nohup.out 2> nohup.err < /dev/null  &
+
+  # Demikernel 1
+  launch-demikernel1:
+    name: Demikernel 1
+    runs-on: ubuntu-latest
+    needs: [build-demikernel1, launch-demikernel0]
+    steps:
+    - name: Launch
+      uses: appleboy/ssh-action@master
+      with:
+        host: ${{ secrets.HOSTNAME_B }}
+        username: ${{ secrets.USERNAME }}
+        key: ${{ secrets.SSHKEY }}
+        port: ${{ secrets.PORTNUM_B }}
+        envs: GITHUB_REPOSITORY,GITHUB_SHA
+        script: |
+          source $HOME/setup-env.sh
+          cd $GITHUB_REPOSITORY
+          TIMEOUT=300 sudo -E make LIBOS=catpowder test-unit > nohup.out 2> nohup.err < /dev/null
+
+  #====================
+  # Post-Run
+  #====================
+
+  # Demikernel 0
+  postrun-demikernel0:
+    name: Demikernel 0
+    needs: [launch-demikernel1]
+    uses: demikernel/workflows/.github/workflows/postrun.yml@dev
+    with:
+      process-name: pingpong
+    secrets:
+      host: ${{ secrets.HOSTNAME_A }}
+      port: ${{ secrets.PORTNUM_A }}
+      key: ${{ secrets.SSHKEY }}
+      username: ${{ secrets.USERNAME }}
+
+  # Demikernel 1
+  postrun-demikernel1:
+    name: Demikernel 1
+    needs: [launch-demikernel1]
+    uses: demikernel/workflows/.github/workflows/postrun.yml@dev
+    with:
+      process-name: pingpong
+    secrets:
+      host: ${{ secrets.HOSTNAME_B }}
+      port: ${{ secrets.PORTNUM_B }}
+      key: ${{ secrets.SSHKEY }}
+      username: ${{ secrets.USERNAME }}
+
+  #====================
+  # Cleanup
+  #====================
+
+  # Demikernel 0
+  cleanup-demikernel0:
+    name: Demikernel 0
+    needs: [postrun-demikernel0]
+    uses: demikernel/workflows/.github/workflows/cleanup.yml@dev
+    secrets:
+      host: ${{ secrets.HOSTNAME_A }}
+      port: ${{ secrets.PORTNUM_A }}
+      key: ${{ secrets.SSHKEY }}
+      username: ${{ secrets.USERNAME }}
+
+  # Demikernel 1
+  cleanup-demikernel1:
+    name: Demikernel 1
+    needs: [postrun-demikernel1]
+    uses: demikernel/workflows/.github/workflows/cleanup.yml@dev
+    secrets:
+      host: ${{ secrets.HOSTNAME_B }}
+      port: ${{ secrets.PORTNUM_B }}
+      key: ${{ secrets.SSHKEY }}
+      username: ${{ secrets.USERNAME }}

--- a/src/catnip/runtime/memory/config.rs
+++ b/src/catnip/runtime/memory/config.rs
@@ -9,7 +9,6 @@ use super::consts::{
     DEFAULT_BODY_POOL_SIZE,
     DEFAULT_CACHE_SIZE,
     DEFAULT_HEADER_POOL_SIZE,
-    DEFAULT_INDIRECT_POOL_SIZE,
     DEFAULT_INLINE_BODY_SIZE,
     DEFAULT_MAX_BODY_SIZE,
 };
@@ -19,8 +18,6 @@ use super::consts::{
 //==============================================================================
 
 //// Memory Configuration Descriptor
-///
-/// TODO: Introduce Setters for field member of this structure.
 #[derive(Debug)]
 pub struct MemoryConfig {
     /// What is the cutoff point for copying application buffers into reserved body space within a
@@ -30,9 +27,6 @@ pub struct MemoryConfig {
 
     /// How many buffers are within the header pool?
     header_pool_size: usize,
-
-    /// How many buffers are within the indirect pool?
-    indirect_pool_size: usize,
 
     /// What is the maximum body size? This should effectively be the MSS + RTE_PKTMBUF_HEADROOM.
     max_body_size: usize,
@@ -53,7 +47,6 @@ impl MemoryConfig {
     pub fn new(
         inline_body_size: Option<usize>,
         header_pool_size: Option<usize>,
-        indirect_pool_size: Option<usize>,
         max_body_size: Option<usize>,
         body_pool_size: Option<usize>,
         cache_size: Option<usize>,
@@ -68,11 +61,6 @@ impl MemoryConfig {
         // Sets the header pool size config option.
         if let Some(header_pool_size) = header_pool_size {
             config.header_pool_size = header_pool_size;
-        }
-
-        // Sets the indirect pool size config option.
-        if let Some(indirect_pool_size) = indirect_pool_size {
-            config.indirect_pool_size = indirect_pool_size;
         }
 
         // Sets the max body pool size config option.
@@ -103,11 +91,6 @@ impl MemoryConfig {
         self.header_pool_size
     }
 
-    /// Returns the indirect pool size config stored in the target [MemoryConfig].
-    pub fn get_indirect_pool_size(&self) -> usize {
-        self.indirect_pool_size
-    }
-
     /// Returns the max body size config stored in the target [MemoryConfig].
     pub fn get_max_body_size(&self) -> usize {
         self.max_body_size
@@ -134,7 +117,6 @@ impl Default for MemoryConfig {
         Self {
             inline_body_size: DEFAULT_INLINE_BODY_SIZE,
             header_pool_size: DEFAULT_HEADER_POOL_SIZE,
-            indirect_pool_size: DEFAULT_INDIRECT_POOL_SIZE,
             max_body_size: DEFAULT_MAX_BODY_SIZE,
             body_pool_size: DEFAULT_BODY_POOL_SIZE,
             cache_size: DEFAULT_CACHE_SIZE,

--- a/src/catnip/runtime/memory/consts.rs
+++ b/src/catnip/runtime/memory/consts.rs
@@ -20,9 +20,6 @@ pub const DEFAULT_INLINE_BODY_SIZE: usize = 1024;
 /// Default number of buffers in the header pool.
 pub const DEFAULT_HEADER_POOL_SIZE: usize = 8192 - 1;
 
-/// Default number of buffers in the indirect pool.
-pub const DEFAULT_INDIRECT_POOL_SIZE: usize = 8192 - 1;
-
 /// Default number of buffers in the body pool.
 pub const DEFAULT_BODY_POOL_SIZE: usize = 8192 - 1;
 

--- a/src/catnip/runtime/memory/manager.rs
+++ b/src/catnip/runtime/memory/manager.rs
@@ -55,10 +55,6 @@ pub struct Inner {
     // internally within the network stack.
     header_pool: Rc<MemoryPool>,
 
-    // Used by networking stack for cloning buffers passed in from the application. There buffers
-    // are also only used internally within the networking stack.
-    indirect_pool: Rc<MemoryPool>,
-
     // Large body pool for buffers given to the application for zero-copy.
     body_pool: Rc<MemoryPool>,
 }
@@ -75,7 +71,7 @@ pub struct MemoryManager {
 impl MemoryManager {
     pub fn new(max_body_size: usize) -> Result<Self, Error> {
         let memory_config: MemoryConfig =
-            MemoryConfig::new(None, None, None, Some(max_body_size), None, None);
+            MemoryConfig::new(None, None, Some(max_body_size), None, None);
 
         Ok(Self {
             inner: Rc::new(Inner::new(memory_config)?),
@@ -263,16 +259,6 @@ impl Inner {
             config.get_cache_size(),
         )?;
 
-        // Create memory pool for holding indirect buffers.
-        let indirect_pool: MemoryPool = MemoryPool::new(
-            CString::new("indirect_pool")?,
-            // These mbufs have no body -- they're just for indirect mbufs to point to
-            // allocations from the body pool.
-            0,
-            config.get_indirect_pool_size(),
-            config.get_cache_size(),
-        )?;
-
         // Create memory pool for holding packet bodies.
         let body_pool: MemoryPool = MemoryPool::new(
             CString::new("body_pool")?,
@@ -284,7 +270,6 @@ impl Inner {
         Ok(Self {
             config,
             header_pool: Rc::new(header_pool),
-            indirect_pool: Rc::new(indirect_pool),
             body_pool: Rc::new(body_pool),
         })
     }

--- a/src/catnip/runtime/memory/manager.rs
+++ b/src/catnip/runtime/memory/manager.rs
@@ -65,7 +65,7 @@ pub struct Inner {
 
 #[derive(Clone, Debug)]
 pub struct MemoryManager {
-    pub inner: Rc<Inner>,
+    inner: Rc<Inner>,
 }
 
 //==============================================================================
@@ -80,10 +80,6 @@ impl MemoryManager {
         Ok(Self {
             inner: Rc::new(Inner::new(memory_config)?),
         })
-    }
-
-    pub fn make_buffer(&self, packet: *mut rte_mbuf) -> DPDKBuf {
-        DPDKBuf::Managed(Mbuf::new(packet))
     }
 
     /// Converts a runtime buffer into a scatter-gather array.
@@ -291,19 +287,5 @@ impl Inner {
             indirect_pool: Rc::new(indirect_pool),
             body_pool: Rc::new(body_pool),
         })
-    }
-
-    pub fn alloc_indirect_empty(&self) -> *mut rte_mbuf {
-        match self.indirect_pool.alloc_mbuf(None) {
-            Ok(mbuf_ptr) => mbuf_ptr,
-            Err(e) => panic!("failed to allocate mbuf: {:?}", e.cause),
-        }
-    }
-
-    pub fn clone_mbuf(&self, ptr: *mut rte_mbuf) -> *mut rte_mbuf {
-        match MemoryPool::clone_mbuf(ptr) {
-            Ok(mbuf_ptr) => mbuf_ptr,
-            Err(e) => panic!("failed to clone mbuf: {:?}", e.cause),
-        }
     }
 }

--- a/src/catnip/runtime/memory/manager.rs
+++ b/src/catnip/runtime/memory/manager.rs
@@ -248,8 +248,9 @@ impl MemoryManager {
 
 impl Inner {
     fn new(config: MemoryConfig) -> Result<Self, Error> {
-        let header_size = ETHERNET2_HEADER_SIZE + IPV4_HEADER_DEFAULT_SIZE + MAX_TCP_HEADER_SIZE;
-        let header_mbuf_size = header_size + config.get_inline_body_size();
+        let header_size: usize =
+            ETHERNET2_HEADER_SIZE + IPV4_HEADER_DEFAULT_SIZE + MAX_TCP_HEADER_SIZE;
+        let header_mbuf_size: usize = header_size + config.get_inline_body_size();
 
         // Create memory pool for holding packet headers.
         let header_pool: MemoryPool = MemoryPool::new(

--- a/src/catnip/runtime/memory/manager.rs
+++ b/src/catnip/runtime/memory/manager.rs
@@ -5,11 +5,7 @@
 // Imports
 //==============================================================================
 
-pub use super::{
-    config::MemoryConfig,
-    dpdkbuf::DPDKBuf,
-    mbuf::Mbuf,
-};
+use super::mempool::MemoryPool;
 use ::anyhow::Error;
 use ::catnip::protocols::{
     ethernet2::ETHERNET2_HEADER_SIZE,
@@ -17,15 +13,8 @@ use ::catnip::protocols::{
     tcp::MAX_TCP_HEADER_SIZE,
 };
 use ::dpdk_rs::{
-    rte_errno,
     rte_mbuf,
     rte_mempool,
-    rte_pktmbuf_alloc,
-    rte_pktmbuf_clone,
-    rte_pktmbuf_free,
-    rte_pktmbuf_pool_create,
-    rte_socket_id,
-    rte_strerror,
 };
 use ::libc::c_void;
 use ::runtime::{
@@ -45,10 +34,14 @@ use ::std::{
 };
 
 //==============================================================================
-// Constants
+// Exports
 //==============================================================================
 
-const _RTE_PKTMBUF_HEADROOM: usize = 128;
+pub use super::{
+    config::MemoryConfig,
+    dpdkbuf::DPDKBuf,
+    mbuf::Mbuf,
+};
 
 //==============================================================================
 // Structures
@@ -60,14 +53,14 @@ pub struct Inner {
 
     // Used by networking stack for protocol headers + inline bodies. These buffers are only used
     // internally within the network stack.
-    header_pool: *mut rte_mempool,
+    header_pool: Rc<MemoryPool>,
 
     // Used by networking stack for cloning buffers passed in from the application. There buffers
     // are also only used internally within the networking stack.
-    indirect_pool: *mut rte_mempool,
+    indirect_pool: Rc<MemoryPool>,
 
     // Large body pool for buffers given to the application for zero-copy.
-    body_pool: *mut rte_mempool,
+    body_pool: Rc<MemoryPool>,
 }
 
 #[derive(Clone, Debug)]
@@ -84,73 +77,64 @@ impl MemoryManager {
         let memory_config: MemoryConfig =
             MemoryConfig::new(None, None, None, Some(max_body_size), None, None);
 
-        MemoryManager::new_from_config(memory_config)
-    }
-
-    fn new_from_config(config: MemoryConfig) -> Result<Self, Error> {
         Ok(Self {
-            inner: Rc::new(Inner::new(config)?),
+            inner: Rc::new(Inner::new(memory_config)?),
         })
     }
 
     pub fn make_buffer(&self, packet: *mut rte_mbuf) -> DPDKBuf {
-        DPDKBuf::Managed(Mbuf::new(packet, self.clone()))
+        DPDKBuf::Managed(Mbuf::new(packet))
     }
 
-    pub fn clone_mbuf(&self, mbuf: &Mbuf) -> Mbuf {
-        Mbuf::new(self.inner.clone_mbuf(mbuf.get_ptr()), self.clone())
-    }
-
+    /// Converts a runtime buffer into a scatter-gather array.
     pub fn into_sgarray(&self, buf: DPDKBuf) -> Result<dmtr_sgarray_t, Fail> {
-        let sgaseg = match buf {
+        let (mbuf_ptr, sgaseg): (*mut rte_mbuf, dmtr_sgaseg_t) = match buf {
+            // Heap-managed buffer.
             DPDKBuf::External(bytes) => {
                 // We have to do a copy here since `Bytes` uses an `Arc<[u8]>` internally and has
                 // some additional bookkeeping for an offset and length, but we want to be able to
                 // hand off a raw pointer up the application that they can free later.
                 let buf_copy: Box<[u8]> = (&bytes[..]).into();
-                let ptr = Box::into_raw(buf_copy);
-                dmtr_sgaseg_t {
-                    sgaseg_buf: ptr as *mut _,
-                    sgaseg_len: bytes.len() as u32,
-                }
+                let ptr: *mut [u8] = Box::into_raw(buf_copy);
+                (
+                    ptr::null_mut(),
+                    dmtr_sgaseg_t {
+                        sgaseg_buf: ptr as *mut c_void,
+                        sgaseg_len: bytes.len() as u32,
+                    },
+                )
             },
+            // DPDK-managed buffer.
             DPDKBuf::Managed(mbuf) => {
-                let sgaseg = dmtr_sgaseg_t {
-                    sgaseg_buf: mbuf.data_ptr() as *mut _,
+                let mbuf_ptr: *mut rte_mbuf = mbuf.get_ptr();
+                let sgaseg: dmtr_sgaseg_t = dmtr_sgaseg_t {
+                    sgaseg_buf: mbuf.data_ptr() as *mut c_void,
                     sgaseg_len: mbuf.len() as u32,
                 };
                 mem::forget(mbuf);
-                sgaseg
+                (mbuf_ptr, sgaseg)
             },
         };
+
+        // TODO: Drop the sga_addr field in the scatter-gather array.
         Ok(dmtr_sgarray_t {
-            sga_buf: ptr::null_mut(),
+            sga_buf: mbuf_ptr as *mut c_void,
             sga_numsegs: 1,
             sga_segs: [sgaseg],
             sga_addr: unsafe { mem::zeroed() },
         })
     }
 
-    pub fn alloc_header_mbuf(&self) -> Mbuf {
-        let mbuf_ptr = unsafe { rte_pktmbuf_alloc(self.inner.header_pool) };
-        assert!(!mbuf_ptr.is_null());
-        unsafe {
-            let num_bytes = (*mbuf_ptr).buf_len - (*mbuf_ptr).data_off;
-            (*mbuf_ptr).data_len = num_bytes as u16;
-            (*mbuf_ptr).pkt_len = num_bytes as u32;
-        }
-        Mbuf::new(mbuf_ptr, self.clone())
+    /// Allocates a header mbuf.
+    pub fn alloc_header_mbuf(&self) -> Result<Mbuf, Fail> {
+        let mbuf_ptr: *mut rte_mbuf = self.inner.header_pool.alloc_mbuf(None)?;
+        Ok(Mbuf::new(mbuf_ptr))
     }
 
-    pub fn alloc_body_mbuf(&self) -> Mbuf {
-        let mbuf_ptr = unsafe { rte_pktmbuf_alloc(self.inner.body_pool) };
-        assert!(!mbuf_ptr.is_null());
-        unsafe {
-            let num_bytes = (*mbuf_ptr).buf_len - (*mbuf_ptr).data_off;
-            (*mbuf_ptr).data_len = num_bytes as u16;
-            (*mbuf_ptr).pkt_len = num_bytes as u32;
-        }
-        Mbuf::new(mbuf_ptr, self.clone())
+    /// Allocates a body mbuf.
+    pub fn alloc_body_mbuf(&self) -> Result<Mbuf, Fail> {
+        let mbuf_ptr: *mut rte_mbuf = self.inner.body_pool.alloc_mbuf(None)?;
+        Ok(Mbuf::new(mbuf_ptr))
     }
 
     /// Allocates a scatter-gather array.
@@ -161,20 +145,10 @@ impl MemoryManager {
             && size <= self.inner.config.get_max_body_size()
         {
             // Allocate a DPDK-managed buffer.
-            let mbuf_ptr: *mut rte_mbuf = unsafe { rte_pktmbuf_alloc(self.inner.body_pool) };
-            if mbuf_ptr.is_null() {
-                return Err(Fail::new(libc::ENOMEM, "mbuf allocation failed"));
-            }
-
-            // TODO: Drop the following warning once DPDK memory management is more stable.
-            warn!("allocating mbuf from DPDK pool");
+            let mbuf_ptr: *mut rte_mbuf = self.inner.body_pool.alloc_mbuf(Some(size))?;
 
             // Adjust various fields in the mbuf and create a scatter-gather segment out of it.
             unsafe {
-                let num_bytes: u16 = (*mbuf_ptr).buf_len - (*mbuf_ptr).data_off;
-                debug_assert!((size as u16) < num_bytes);
-                (*mbuf_ptr).data_len = size as u16;
-                (*mbuf_ptr).pkt_len = size as u32;
                 let buf_ptr: *mut u8 = (*mbuf_ptr).buf_addr as *mut u8;
                 let data_ptr: *mut u8 = buf_ptr.offset((*mbuf_ptr).data_off as isize);
                 (
@@ -222,7 +196,7 @@ impl MemoryManager {
         if !sga.sga_buf.is_null() {
             // Release DPDK-managed buffer.
             let mbuf_ptr: *mut rte_mbuf = sga.sga_buf as *mut rte_mbuf;
-            unsafe { rte_pktmbuf_free(mbuf_ptr) };
+            MemoryPool::free_mbuf(mbuf_ptr);
         } else {
             // Release heap-managed buffer.
             let sgaseg: dmtr_sgaseg_t = sga.sga_segs[0];
@@ -253,8 +227,11 @@ impl MemoryManager {
         let buf: DPDKBuf = if !sga.sga_buf.is_null() {
             // Clone DPDK-managed buffer.
             let mbuf_ptr: *mut rte_mbuf = sga.sga_buf as *mut rte_mbuf;
-            let body_clone: *mut rte_mbuf = self.inner.clone_mbuf(mbuf_ptr);
-            let mut mbuf: Mbuf = Mbuf::new(body_clone, self.clone());
+            let body_clone: *mut rte_mbuf = match MemoryPool::clone_mbuf(mbuf_ptr) {
+                Ok(mbuf_ptr) => mbuf_ptr,
+                Err(e) => panic!("failed to clone mbuf: {:?}", e.cause),
+            };
+            let mut mbuf: Mbuf = Mbuf::new(body_clone);
             // Adjust buffer length.
             // TODO: Replace the following method for computing the length of a mbuf once we have a proper Mbuf abstraction.
             let orig_len: usize = unsafe { ((*mbuf_ptr).buf_len - (*mbuf_ptr).data_off).into() };
@@ -273,7 +250,7 @@ impl MemoryManager {
     }
 
     pub fn body_pool(&self) -> *mut rte_mempool {
-        self.inner.body_pool
+        self.inner.body_pool.into_raw()
     }
 }
 
@@ -281,76 +258,52 @@ impl Inner {
     fn new(config: MemoryConfig) -> Result<Self, Error> {
         let header_size = ETHERNET2_HEADER_SIZE + IPV4_HEADER_DEFAULT_SIZE + MAX_TCP_HEADER_SIZE;
         let header_mbuf_size = header_size + config.get_inline_body_size();
-        let priv_size = 0;
-        assert_eq!(
-            priv_size, 0,
-            "Private data isn't supported (it adds another region between `rte_mbuf` and data)"
-        );
-        let header_pool = unsafe {
-            let name = CString::new("header_pool")?;
-            rte_pktmbuf_pool_create(
-                name.as_ptr(),
-                config.get_header_pool_size() as u32,
-                config.get_cache_size() as u32,
-                priv_size,
-                header_mbuf_size as u16,
-                rte_socket_id() as i32,
-            )
-        };
-        if header_pool.is_null() {
-            let reason = unsafe { std::ffi::CStr::from_ptr(rte_strerror(rte_errno())) };
-            anyhow::bail!("Failed to create header pool: {}", reason.to_str().unwrap())
-        }
 
-        let indirect_pool = unsafe {
-            let name = CString::new("indirect_pool")?;
-            rte_pktmbuf_pool_create(
-                name.as_ptr(),
-                config.get_indirect_pool_size() as u32,
-                config.get_cache_size() as u32,
-                priv_size,
-                // These mbufs have no body -- they're just for indirect mbufs to point to
-                // allocations from the body pool.
-                0,
-                rte_socket_id() as i32,
-            )
-        };
-        if indirect_pool.is_null() {
-            anyhow::bail!("Failed to create indirect pool");
-        }
+        // Create memory pool for holding packet headers.
+        let header_pool: MemoryPool = MemoryPool::new(
+            CString::new("header_pool")?,
+            header_mbuf_size,
+            config.get_header_pool_size(),
+            config.get_cache_size(),
+        )?;
 
-        let body_pool = unsafe {
-            let name = CString::new("body_pool")?;
-            rte_pktmbuf_pool_create(
-                name.as_ptr(),
-                config.get_body_pool_size() as u32,
-                config.get_cache_size() as u32,
-                priv_size,
-                config.get_max_body_size() as u16,
-                rte_socket_id() as i32,
-            )
-        };
-        if body_pool.is_null() {
-            anyhow::bail!("Failed to create body pool");
-        }
+        // Create memory pool for holding indirect buffers.
+        let indirect_pool: MemoryPool = MemoryPool::new(
+            CString::new("indirect_pool")?,
+            // These mbufs have no body -- they're just for indirect mbufs to point to
+            // allocations from the body pool.
+            0,
+            config.get_indirect_pool_size(),
+            config.get_cache_size(),
+        )?;
+
+        // Create memory pool for holding packet bodies.
+        let body_pool: MemoryPool = MemoryPool::new(
+            CString::new("body_pool")?,
+            config.get_max_body_size(),
+            config.get_body_pool_size(),
+            config.get_cache_size(),
+        )?;
 
         Ok(Self {
             config,
-            header_pool,
-            indirect_pool,
-            body_pool,
+            header_pool: Rc::new(header_pool),
+            indirect_pool: Rc::new(indirect_pool),
+            body_pool: Rc::new(body_pool),
         })
     }
 
     pub fn alloc_indirect_empty(&self) -> *mut rte_mbuf {
-        let ptr = unsafe { rte_pktmbuf_alloc(self.indirect_pool) };
-        assert!(!ptr.is_null());
-        ptr
+        match self.indirect_pool.alloc_mbuf(None) {
+            Ok(mbuf_ptr) => mbuf_ptr,
+            Err(e) => panic!("failed to allocate mbuf: {:?}", e.cause),
+        }
     }
 
     pub fn clone_mbuf(&self, ptr: *mut rte_mbuf) -> *mut rte_mbuf {
-        let ptr = unsafe { rte_pktmbuf_clone(ptr, self.indirect_pool) };
-        assert!(!ptr.is_null());
-        ptr
+        match MemoryPool::clone_mbuf(ptr) {
+            Ok(mbuf_ptr) => mbuf_ptr,
+            Err(e) => panic!("failed to clone mbuf: {:?}", e.cause),
+        }
     }
 }

--- a/src/catnip/runtime/memory/manager.rs
+++ b/src/catnip/runtime/memory/manager.rs
@@ -47,6 +47,7 @@ pub use super::{
 // Structures
 //==============================================================================
 
+// TODO: Drop this structure.
 #[derive(Debug)]
 pub struct Inner {
     config: MemoryConfig,
@@ -59,6 +60,7 @@ pub struct Inner {
     body_pool: Rc<MemoryPool>,
 }
 
+/// Memory Manager
 #[derive(Clone, Debug)]
 pub struct MemoryManager {
     inner: Rc<Inner>,
@@ -68,7 +70,9 @@ pub struct MemoryManager {
 // Associate Functions
 //==============================================================================
 
+/// Associated Functions for Memory Managers
 impl MemoryManager {
+    /// Instantiates a memory manager.
     pub fn new(max_body_size: usize) -> Result<Self, Error> {
         let memory_config: MemoryConfig =
             MemoryConfig::new(None, None, Some(max_body_size), None, None);
@@ -118,12 +122,14 @@ impl MemoryManager {
     }
 
     /// Allocates a header mbuf.
+    /// TODO: Review the need of this function after we are done with the refactor of the DPDK runtime.
     pub fn alloc_header_mbuf(&self) -> Result<Mbuf, Fail> {
         let mbuf_ptr: *mut rte_mbuf = self.inner.header_pool.alloc_mbuf(None)?;
         Ok(Mbuf::new(mbuf_ptr))
     }
 
     /// Allocates a body mbuf.
+    /// TODO: Review the need of this function after we are done with the refactor of the DPDK runtime.
     pub fn alloc_body_mbuf(&self) -> Result<Mbuf, Fail> {
         let mbuf_ptr: *mut rte_mbuf = self.inner.body_pool.alloc_mbuf(None)?;
         Ok(Mbuf::new(mbuf_ptr))
@@ -241,13 +247,17 @@ impl MemoryManager {
         Ok(buf)
     }
 
+    /// Returns a raw pointer to the underlying body pool.
+    /// TODO: Review the need of this function after we are done with the refactor of the DPDK runtime.
     pub fn body_pool(&self) -> *mut rte_mempool {
         self.inner.body_pool.into_raw()
     }
 }
 
+/// Associated Functions for Memory Managers
 impl Inner {
     fn new(config: MemoryConfig) -> Result<Self, Error> {
+        // TODO: The following computation for header size is bad. It should be fixed to maximum possible size.
         let header_size: usize =
             ETHERNET2_HEADER_SIZE + IPV4_HEADER_DEFAULT_SIZE + MAX_TCP_HEADER_SIZE;
         let header_mbuf_size: usize = header_size + config.get_inline_body_size();

--- a/src/catnip/runtime/memory/mempool.rs
+++ b/src/catnip/runtime/memory/mempool.rs
@@ -1,0 +1,120 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//==============================================================================
+// Imports
+//==============================================================================
+
+use ::dpdk_rs::{
+    rte_mbuf,
+    rte_mempool,
+    rte_pktmbuf_alloc,
+    rte_pktmbuf_clone,
+    rte_pktmbuf_free,
+    rte_pktmbuf_pool_create,
+    rte_socket_id,
+};
+use ::runtime::fail::Fail;
+use ::std::ffi::CString;
+
+//==============================================================================
+// Structures
+//==============================================================================
+
+/// DPDK Memory Pool
+#[derive(Debug)]
+pub struct MemoryPool {
+    /// Underlying memory pool.
+    pool: *mut rte_mempool,
+}
+
+//==============================================================================
+// Associate Functions
+//==============================================================================
+
+/// Associated functions for memory pool.
+impl MemoryPool {
+    /// Creates a new memory pool.
+    pub fn new(
+        name: CString,
+        data_room_size: usize,
+        pool_size: usize,
+        cache_size: usize,
+    ) -> Result<Self, Fail> {
+        let pool: *mut rte_mempool = unsafe {
+            rte_pktmbuf_pool_create(
+                name.as_ptr(),
+                pool_size as u32,
+                cache_size as u32,
+                0,
+                data_room_size as u16,
+                rte_socket_id() as i32,
+            )
+        };
+
+        // Failed to create memory pool.
+        if pool.is_null() {
+            return Err(Fail::new(libc::EAGAIN, "failed to create memory pool"));
+        }
+
+        Ok(Self { pool })
+    }
+
+    /// Gets a raw pointer to the underlying memory pool.
+    pub fn into_raw(&self) -> *mut rte_mempool {
+        self.pool
+    }
+
+    /// Allocates a mbuf in the target memory pool.
+    pub fn alloc_mbuf(&self, size: Option<usize>) -> Result<*mut rte_mbuf, Fail> {
+        // TODO: Drop the following warning once DPDK memory management is more stable.
+        warn!("allocating mbuf from DPDK pool");
+
+        // Allocated mbuf.
+        let mut mbuf_ptr: *mut rte_mbuf = unsafe { rte_pktmbuf_alloc(self.pool) };
+        if mbuf_ptr.is_null() {
+            return Err(Fail::new(libc::ENOMEM, "cannot allocate more mbufs"));
+        }
+
+        // Fill out some fields of the underlying mbuf.
+        unsafe {
+            let mut num_bytes: u16 = (*mbuf_ptr).buf_len - (*mbuf_ptr).data_off;
+
+            if let Some(size) = size {
+                // Allocated buffer is not  big enough.
+                if (size as u16) > num_bytes {
+                    // Rollback allocation.
+                    rte_pktmbuf_free(mbuf_ptr);
+                    return Err(Fail::new(libc::EFAULT, "cannot allocate a mbuf this big"));
+                }
+                num_bytes = size as u16;
+            }
+            (*mbuf_ptr).data_len = num_bytes;
+            (*mbuf_ptr).pkt_len = num_bytes as u32;
+        }
+
+        Ok(mbuf_ptr)
+    }
+
+    /// Releases a mbuf in the target memory pool.
+    pub fn free_mbuf(mbuf_ptr: *mut rte_mbuf) {
+        unsafe {
+            // Do it.
+            rte_pktmbuf_free(mbuf_ptr);
+        }
+    }
+
+    /// Clones a mbuf into a memory pool.
+    pub fn clone_mbuf(mbuf_ptr: *mut rte_mbuf) -> Result<*mut rte_mbuf, Fail> {
+        unsafe {
+            // Do it.
+            let mempool_ptr: *mut rte_mempool = (*mbuf_ptr).pool;
+            let mbuf_ptr_clone: *mut rte_mbuf = rte_pktmbuf_clone(mbuf_ptr, mempool_ptr);
+            if mbuf_ptr_clone.is_null() {
+                return Err(Fail::new(libc::EINVAL, "cannot clone mbuf"));
+            }
+
+            Ok(mbuf_ptr_clone)
+        }
+    }
+}

--- a/src/catnip/runtime/memory/mempool.rs
+++ b/src/catnip/runtime/memory/mempool.rs
@@ -70,7 +70,7 @@ impl MemoryPool {
         // TODO: Drop the following warning once DPDK memory management is more stable.
         warn!("allocating mbuf from DPDK pool");
 
-        // Allocated mbuf.
+        // Allocate mbuf.
         let mut mbuf_ptr: *mut rte_mbuf = unsafe { rte_pktmbuf_alloc(self.pool) };
         if mbuf_ptr.is_null() {
             return Err(Fail::new(libc::ENOMEM, "cannot allocate more mbufs"));
@@ -81,9 +81,9 @@ impl MemoryPool {
             let mut num_bytes: u16 = (*mbuf_ptr).buf_len - (*mbuf_ptr).data_off;
 
             if let Some(size) = size {
-                // Allocated buffer is not  big enough.
+                // Check if allocated buffer is big enough.
                 if (size as u16) > num_bytes {
-                    // Rollback allocation.
+                    // Allocated buffer is not big enough, rollback allocation.
                     rte_pktmbuf_free(mbuf_ptr);
                     return Err(Fail::new(libc::EFAULT, "cannot allocate a mbuf this big"));
                 }
@@ -99,7 +99,6 @@ impl MemoryPool {
     /// Releases a mbuf in the target memory pool.
     pub fn free_mbuf(mbuf_ptr: *mut rte_mbuf) {
         unsafe {
-            // Do it.
             rte_pktmbuf_free(mbuf_ptr);
         }
     }
@@ -107,7 +106,6 @@ impl MemoryPool {
     /// Clones a mbuf into a memory pool.
     pub fn clone_mbuf(mbuf_ptr: *mut rte_mbuf) -> Result<*mut rte_mbuf, Fail> {
         unsafe {
-            // Do it.
             let mempool_ptr: *mut rte_mempool = (*mbuf_ptr).pool;
             let mbuf_ptr_clone: *mut rte_mbuf = rte_pktmbuf_clone(mbuf_ptr, mempool_ptr);
             if mbuf_ptr_clone.is_null() {

--- a/src/catnip/runtime/memory/mod.rs
+++ b/src/catnip/runtime/memory/mod.rs
@@ -13,7 +13,10 @@ mod mempool;
 //==============================================================================
 
 pub use dpdkbuf::DPDKBuf;
-pub use manager::MemoryManager;
+pub use manager::{
+    Mbuf,
+    MemoryManager,
+};
 
 //==============================================================================
 // Imports

--- a/src/catnip/runtime/memory/mod.rs
+++ b/src/catnip/runtime/memory/mod.rs
@@ -6,6 +6,7 @@ pub mod consts;
 mod dpdkbuf;
 mod manager;
 mod mbuf;
+mod mempool;
 
 //==============================================================================
 // Exports

--- a/src/catnip/runtime/network.rs
+++ b/src/catnip/runtime/network.rs
@@ -53,7 +53,10 @@ impl NetworkRuntime for DPDKRuntime {
         // Chain body buffer.
 
         // First, allocate a header mbuf and write the header into it.
-        let mut header_mbuf = self.mm.alloc_header_mbuf();
+        let mut header_mbuf = match self.mm.alloc_header_mbuf() {
+            Ok(mbuf) => mbuf,
+            Err(e) => panic!("failed to allocate header mbuf: {:?}", e.cause),
+        };
         let header_size = buf.header_size();
         assert!(header_size <= header_mbuf.len());
         buf.write_header(unsafe { &mut header_mbuf.slice_mut()[..header_size] });
@@ -72,7 +75,10 @@ impl NetworkRuntime for DPDKRuntime {
                 let body_mbuf = match body {
                     DPDKBuf::Managed(mbuf) => mbuf,
                     DPDKBuf::External(bytes) => {
-                        let mut mbuf = self.mm.alloc_body_mbuf();
+                        let mut mbuf = match self.mm.alloc_body_mbuf() {
+                            Ok(mbuf) => mbuf,
+                            Err(e) => panic!("failed to allocate body mbuf: {:?}", e.cause),
+                        };
                         assert!(mbuf.len() >= bytes.len());
                         unsafe { mbuf.slice_mut()[..bytes.len()].copy_from_slice(&bytes[..]) };
                         mbuf.trim(mbuf.len() - bytes.len());

--- a/src/catnip/runtime/network.rs
+++ b/src/catnip/runtime/network.rs
@@ -6,7 +6,10 @@
 //==============================================================================
 
 use super::DPDKRuntime;
-use crate::catnip::runtime::memory::DPDKBuf;
+use crate::catnip::runtime::memory::{
+    DPDKBuf,
+    Mbuf,
+};
 use ::arrayvec::ArrayVec;
 use ::catnip::protocols::ethernet2::MIN_PAYLOAD_SIZE;
 use ::dpdk_rs::{
@@ -161,7 +164,9 @@ impl NetworkRuntime for DPDKRuntime {
             #[cfg(feature = "profiler")]
             timer!("catnip_libos:receive::for");
             for &packet in &packets[..nb_rx as usize] {
-                out.push(self.mm.make_buffer(packet));
+                let mbuf: Mbuf = Mbuf::new(packet);
+                let dpdkbuf: DPDKBuf = DPDKBuf::Managed(mbuf);
+                out.push(dpdkbuf);
             }
         }
 

--- a/tests/pushpop.rs
+++ b/tests/pushpop.rs
@@ -148,7 +148,7 @@ fn tcp_push_pop() {
             );
 
             i += recvbuf.len();
-            println!("pong {:?}", i);
+            println!("pop {:?}", i);
         }
     } else {
         let sendbuf: Vec<u8> = test.mkbuf(fill_char);

--- a/tests/sga.rs
+++ b/tests/sga.rs
@@ -28,7 +28,7 @@ fn do_test_unit_sga_alloc_free_single(size: usize) {
 
     let sga: dmtr_sgarray_t = match libos.sgaalloc(size) {
         Ok(sga) => sga,
-        Err(e) => panic!("failed to allocated sga: {:?}", e.cause),
+        Err(e) => panic!("failed to allocate sga: {:?}", e.cause),
     };
     match libos.sgafree(sga) {
         Ok(()) => (),
@@ -60,7 +60,7 @@ fn do_test_unit_sga_alloc_free_loop_tight(size: usize) {
     for _ in 0..1_000_000 {
         let sga: dmtr_sgarray_t = match libos.sgaalloc(size) {
             Ok(sga) => sga,
-            Err(e) => panic!("failed to allocated sga: {:?}", e.cause),
+            Err(e) => panic!("failed to allocate sga: {:?}", e.cause),
         };
         match libos.sgafree(sga) {
             Ok(()) => (),
@@ -96,7 +96,7 @@ fn do_test_unit_sga_alloc_free_loop_decoupled(size: usize) {
         for _ in 0..1_000 {
             let sga: dmtr_sgarray_t = match libos.sgaalloc(size) {
                 Ok(sga) => sga,
-                Err(e) => panic!("failed to allocated sga: {:?}", e.cause),
+                Err(e) => panic!("failed to allocate sga: {:?}", e.cause),
             };
             sgas.push(sga);
         }


### PR DESCRIPTION
Description
========

In this PR, I mostly introduce the enhancement that is described in https://github.com/demikernel/demikernel/issues/83. 

Here is a digest of the commits:
- In commit 2a31472a5c8bcd6fb8af00cc75be92f6d69ae14a I drop bad checks that were used in the pointer arithmetic for allocating/releasing `mbufs`.
- In commit dc73ffee6c1d4c56d8780a5e4eff2b56c9d0fbc5 I introduce the `MemoryPool` abstraction.
- In commit c31d48bb67b2039986c1790d0012d9c9d785ecd9 and 729f0915277ae2e27082cf763ad1c419e76f1fd2 I refactor the code to rely on the `MemoryPool` abstraction
- In commit 837ed5049129f8678ef2e8a6005e85c5936a8534 I drop the indirect memory pool, because it is not required to provide the shallow copy of `mbufs` ([`rte_pktmbuf_clone`](https://elixir.bootlin.com/dpdk/latest/source/lib/mbuf/rte_mbuf.c#L512) does the job) and it was causing interdependency between several modules.