### PR TITLE
[memory] Introduce a Better Abstraction for Runtime Buffers

### DIFF
--- a/src/catnap/futures/mod.rs
+++ b/src/catnap/futures/mod.rs
@@ -22,14 +22,16 @@ use self::{
     push::PushFuture,
     pushto::PushtoFuture,
 };
-use crate::Ipv4Endpoint;
+use crate::{
+    demikernel::dbuf::DataBuffer,
+    Ipv4Endpoint,
+};
 use ::catwalk::{
     FutureResult,
     SchedulerFuture,
 };
 use ::runtime::{
     fail::Fail,
-    memory::Bytes,
     QDesc,
 };
 use ::std::{
@@ -52,7 +54,7 @@ pub enum OperationResult {
     Connect,
     Accept(QDesc),
     Push,
-    Pop(Option<Ipv4Endpoint>, Bytes),
+    Pop(Option<Ipv4Endpoint>, DataBuffer),
     Failed(Fail),
 }
 

--- a/src/catnap/futures/pop.rs
+++ b/src/catnap/futures/pop.rs
@@ -5,16 +5,14 @@
 // Imports
 //==============================================================================
 
+use crate::demikernel::dbuf::DataBuffer;
 use ::nix::{
     errno::Errno,
     unistd,
 };
 use ::runtime::{
     fail::Fail,
-    memory::{
-        Buffer,
-        Bytes,
-    },
+    memory::Buffer,
     QDesc,
 };
 use ::std::{
@@ -69,7 +67,7 @@ impl PopFuture {
 
 /// Future Trait Implementation for Pop Operation Descriptors
 impl Future for PopFuture {
-    type Output = Result<Bytes, Fail>;
+    type Output = Result<DataBuffer, Fail>;
 
     /// Polls the target [PopFuture].
     fn poll(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Self::Output> {
@@ -79,7 +77,7 @@ impl Future for PopFuture {
             // Operation completed.
             Ok(nbytes) => {
                 trace!("data received ({:?} bytes)", nbytes);
-                let buf: Bytes = Bytes::from_slice(&bytes[0..nbytes]);
+                let buf: DataBuffer = DataBuffer::from_slice(&bytes[0..nbytes]);
                 Poll::Ready(Ok(buf))
             },
             // Operation in progress.

--- a/src/catnap/futures/push.rs
+++ b/src/catnap/futures/push.rs
@@ -5,13 +5,13 @@
 // Imports
 //==============================================================================
 
+use crate::demikernel::dbuf::DataBuffer;
 use ::nix::{
     errno::Errno,
     unistd,
 };
 use ::runtime::{
     fail::Fail,
-    memory::Bytes,
     QDesc,
 };
 use ::std::{
@@ -35,7 +35,7 @@ pub struct PushFuture {
     // Underlying file descriptor.
     fd: RawFd,
     /// Buffer to send.
-    buf: Bytes,
+    buf: DataBuffer,
 }
 
 //==============================================================================
@@ -45,7 +45,7 @@ pub struct PushFuture {
 /// Associate Functions for Push Operation Descriptors
 impl PushFuture {
     /// Creates a descriptor for a push operation.
-    pub fn new(qd: QDesc, fd: RawFd, buf: Bytes) -> Self {
+    pub fn new(qd: QDesc, fd: RawFd, buf: DataBuffer) -> Self {
         Self { qd, fd, buf }
     }
 

--- a/src/catnap/futures/pushto.rs
+++ b/src/catnap/futures/pushto.rs
@@ -5,6 +5,7 @@
 // Imports
 //==============================================================================
 
+use crate::demikernel::dbuf::DataBuffer;
 use ::nix::{
     errno::Errno,
     sys::socket::{
@@ -15,7 +16,6 @@ use ::nix::{
 };
 use ::runtime::{
     fail::Fail,
-    memory::Bytes,
     QDesc,
 };
 use ::std::{
@@ -41,7 +41,7 @@ pub struct PushtoFuture {
     // Underlying file descriptor.
     fd: RawFd,
     /// Buffer to send.
-    buf: Bytes,
+    buf: DataBuffer,
 }
 
 //==============================================================================
@@ -51,7 +51,7 @@ pub struct PushtoFuture {
 /// Associate Functions for Pushto Operation Descriptors
 impl PushtoFuture {
     /// Creates a descriptor for a pushto operation.
-    pub fn new(qd: QDesc, fd: RawFd, addr: SockAddr, buf: Bytes) -> Self {
+    pub fn new(qd: QDesc, fd: RawFd, addr: SockAddr, buf: DataBuffer) -> Self {
         Self { qd, addr, fd, buf }
     }
 

--- a/src/catnap/runtime.rs
+++ b/src/catnap/runtime.rs
@@ -5,6 +5,7 @@
 // Imports
 //==============================================================================
 
+use crate::demikernel::dbuf::DataBuffer;
 use ::arrayvec::ArrayVec;
 use ::catwalk::{
     Scheduler,
@@ -19,8 +20,7 @@ use ::rand::{
 use ::runtime::{
     fail::Fail,
     memory::{
-        Bytes,
-        BytesMut,
+        Buffer,
         MemoryRuntime,
     },
     network::{
@@ -89,15 +89,15 @@ impl PosixRuntime {
 /// Memory Runtime Trait Implementation for POSIX Runtime
 impl MemoryRuntime for PosixRuntime {
     /// Memory Buffer
-    type Buf = Bytes;
+    type Buf = DataBuffer;
 
-    /// Creates a [dmtr_sgarray_t] from a memory buffer.
-    fn into_sgarray(&self, buf: Bytes) -> Result<dmtr_sgarray_t, Fail> {
-        let buf_copy: Box<[u8]> = (&buf[..]).into();
-        let ptr: *mut [u8] = Box::into_raw(buf_copy);
+    /// Converts a runtime buffer into a scatter-gather array.
+    fn into_sgarray(&self, dbuf: DataBuffer) -> Result<dmtr_sgarray_t, Fail> {
+        let len: usize = dbuf.len();
+        let dbuf_ptr: *const [u8] = DataBuffer::into_raw(dbuf)?;
         let sgaseg: dmtr_sgaseg_t = dmtr_sgaseg_t {
-            sgaseg_buf: ptr as *mut c_void,
-            sgaseg_len: buf.len() as u32,
+            sgaseg_buf: dbuf_ptr as *mut c_void,
+            sgaseg_len: len as u32,
         };
         Ok(dmtr_sgarray_t {
             sga_buf: ptr::null_mut(),
@@ -107,12 +107,13 @@ impl MemoryRuntime for PosixRuntime {
         })
     }
 
-    /// Allocates a [dmtr_sgarray_t].
+    /// Allocates a scatter-gather array.
     fn alloc_sgarray(&self, size: usize) -> Result<dmtr_sgarray_t, Fail> {
-        let allocation: Box<[u8]> = unsafe { Box::new_uninit_slice(size).assume_init() };
-        let ptr: *mut [u8] = Box::into_raw(allocation);
-        let sgaseg = dmtr_sgaseg_t {
-            sgaseg_buf: ptr as *mut _,
+        // Allocate a heap-managed buffer.
+        let dbuf: DataBuffer = DataBuffer::new(size)?;
+        let dbuf_ptr: *const [u8] = DataBuffer::into_raw(dbuf)?;
+        let sgaseg: dmtr_sgaseg_t = dmtr_sgaseg_t {
+            sgaseg_buf: dbuf_ptr as *mut c_void,
             sgaseg_len: size as u32,
         };
         Ok(dmtr_sgarray_t {
@@ -123,40 +124,46 @@ impl MemoryRuntime for PosixRuntime {
         })
     }
 
-    /// Releases a [dmtr_sgarray_t].
+    /// Releases a scatter-gather array.
     fn free_sgarray(&self, sga: dmtr_sgarray_t) -> Result<(), Fail> {
-        assert_eq!(sga.sga_numsegs, 1);
-        for i in 0..sga.sga_numsegs as usize {
-            let seg: &dmtr_sgaseg_t = &sga.sga_segs[i];
-            let allocation: Box<[u8]> = unsafe {
-                Box::from_raw(slice::from_raw_parts_mut(
-                    seg.sgaseg_buf as *mut _,
-                    seg.sgaseg_len as usize,
-                ))
-            };
-            drop(allocation);
+        // Check arguments.
+        // TODO: Drop this check once we support scatter-gather arrays with multiple segments.
+        if sga.sga_numsegs != 1 {
+            return Err(Fail::new(
+                libc::EINVAL,
+                "scatter-gather array with invalid size",
+            ));
         }
+
+        // Release heap-managed buffer.
+        let sgaseg: dmtr_sgaseg_t = sga.sga_segs[0];
+        let (data_ptr, length): (*mut u8, usize) =
+            (sgaseg.sgaseg_buf as *mut u8, sgaseg.sgaseg_len as usize);
+
+        // Convert back raw slice to a heap buffer and drop allocation.
+        DataBuffer::from_raw_parts(data_ptr, length)?;
 
         Ok(())
     }
 
-    /// Clones a [dmtr_sgarray_t] into a memory buffer.
-    fn clone_sgarray(&self, sga: &dmtr_sgarray_t) -> Result<Bytes, Fail> {
-        let mut len: u32 = 0;
-        for i in 0..sga.sga_numsegs as usize {
-            len += sga.sga_segs[i].sgaseg_len;
+    /// Clones a scatter-gather array.
+    fn clone_sgarray(&self, sga: &dmtr_sgarray_t) -> Result<DataBuffer, Fail> {
+        // Check arguments.
+        // TODO: Drop this check once we support scatter-gather arrays with multiple segments.
+        if sga.sga_numsegs != 1 {
+            return Err(Fail::new(
+                libc::EINVAL,
+                "scatter-gather array with invalid size",
+            ));
         }
-        let mut buf: BytesMut = BytesMut::zeroed(len as usize).unwrap();
-        let mut pos: usize = 0;
-        for i in 0..sga.sga_numsegs as usize {
-            let seg: &dmtr_sgaseg_t = &sga.sga_segs[i];
-            let seg_slice = unsafe {
-                slice::from_raw_parts(seg.sgaseg_buf as *mut u8, seg.sgaseg_len as usize)
-            };
-            buf[pos..(pos + seg_slice.len())].copy_from_slice(seg_slice);
-            pos += seg_slice.len();
-        }
-        Ok(buf.freeze())
+
+        let sgaseg: dmtr_sgaseg_t = sga.sga_segs[0];
+        let (ptr, len): (*mut c_void, usize) = (sgaseg.sgaseg_buf, sgaseg.sgaseg_len as usize);
+
+        // Clone heap-managed buffer.
+        Ok(DataBuffer::from_slice(unsafe {
+            slice::from_raw_parts(ptr as *const u8, len)
+        }))
     }
 }
 

--- a/src/catnip/runtime/memory/dpdkbuf.rs
+++ b/src/catnip/runtime/memory/dpdkbuf.rs
@@ -6,10 +6,8 @@
 //==============================================================================
 
 use super::mbuf::Mbuf;
-use ::runtime::memory::{
-    Buffer,
-    Bytes,
-};
+use crate::demikernel::dbuf::DataBuffer;
+use ::runtime::memory::Buffer;
 use ::std::ops::Deref;
 
 //==============================================================================
@@ -19,7 +17,7 @@ use ::std::ops::Deref;
 /// DPDK Buffer
 #[derive(Clone, Debug)]
 pub enum DPDKBuf {
-    External(Bytes),
+    External(DataBuffer),
     Managed(Mbuf),
 }
 
@@ -31,12 +29,12 @@ pub enum DPDKBuf {
 impl Buffer for DPDKBuf {
     /// Creates an empty [DPDKBuf].
     fn empty() -> Self {
-        DPDKBuf::External(Bytes::empty())
+        DPDKBuf::External(DataBuffer::empty())
     }
 
     /// Creates a [DPDKBuf] from a [u8] slice.
     fn from_slice(bytes: &[u8]) -> Self {
-        DPDKBuf::External(Bytes::from_slice(bytes))
+        DPDKBuf::External(DataBuffer::from_slice(bytes))
     }
 
     /// Removes `len` bytes at the beginning of the target [DPDKBuf].

--- a/src/catpowder/mod.rs
+++ b/src/catpowder/mod.rs
@@ -13,7 +13,10 @@ use self::{
     interop::pack_result,
     runtime::LinuxRuntime,
 };
-use crate::demikernel::config::Config;
+use crate::demikernel::{
+    config::Config,
+    dbuf::DataBuffer,
+};
 use ::catnip::{
     operations::OperationResult,
     protocols::ipv4::Ipv4Endpoint,
@@ -21,10 +24,7 @@ use ::catnip::{
 };
 use ::runtime::{
     fail::Fail,
-    memory::{
-        Bytes,
-        MemoryRuntime,
-    },
+    memory::MemoryRuntime,
     task::SchedulerRuntime,
     types::{
         dmtr_qresult_t,
@@ -115,7 +115,7 @@ impl CatpowderLibOS {
         timer!("catpowder::wait");
         trace!("wait(): qt={:?}", qt);
 
-        let (qd, result): (QDesc, OperationResult<Bytes>) = self.wait2(qt)?;
+        let (qd, result): (QDesc, OperationResult<DataBuffer>) = self.wait2(qt)?;
         Ok(pack_result(self.rt(), result, qd, qt.into()))
     }
 
@@ -125,7 +125,7 @@ impl CatpowderLibOS {
         timer!("catpowder::wait_any");
         trace!("wait_any(): qts={:?}", qts);
 
-        let (i, qd, r): (usize, QDesc, OperationResult<Bytes>) = self.wait_any2(qts)?;
+        let (i, qd, r): (usize, QDesc, OperationResult<DataBuffer>) = self.wait_any2(qts)?;
         Ok((i, pack_result(self.rt(), r, qd, qts[i].into())))
     }
 }

--- a/src/catpowder/runtime/memory.rs
+++ b/src/catpowder/runtime/memory.rs
@@ -6,11 +6,12 @@
 //==============================================================================
 
 use super::LinuxRuntime;
+use crate::demikernel::dbuf::DataBuffer;
+use ::libc::c_void;
 use ::runtime::{
     fail::Fail,
     memory::{
-        Bytes,
-        BytesMut,
+        Buffer,
         MemoryRuntime,
     },
     types::{
@@ -31,15 +32,15 @@ use ::std::{
 /// Memory Runtime Trait Implementation for Linux Runtime
 impl MemoryRuntime for LinuxRuntime {
     /// Memory Buffer
-    type Buf = Bytes;
+    type Buf = DataBuffer;
 
-    /// Creates a [dmtr_sgarray_t] from a memory buffer.
-    fn into_sgarray(&self, buf: Bytes) -> Result<dmtr_sgarray_t, Fail> {
-        let buf_copy: Box<[u8]> = (&buf[..]).into();
-        let ptr: *mut [u8] = Box::into_raw(buf_copy);
-        let sgaseg = dmtr_sgaseg_t {
-            sgaseg_buf: ptr as *mut _,
-            sgaseg_len: buf.len() as u32,
+    /// Converts a runtime buffer into a scatter-gather array.
+    fn into_sgarray(&self, dbuf: DataBuffer) -> Result<dmtr_sgarray_t, Fail> {
+        let len: usize = dbuf.len();
+        let dbuf_ptr: *const [u8] = DataBuffer::into_raw(dbuf)?;
+        let sgaseg: dmtr_sgaseg_t = dmtr_sgaseg_t {
+            sgaseg_buf: dbuf_ptr as *mut c_void,
+            sgaseg_len: len as u32,
         };
         Ok(dmtr_sgarray_t {
             sga_buf: ptr::null_mut(),
@@ -49,12 +50,13 @@ impl MemoryRuntime for LinuxRuntime {
         })
     }
 
-    /// Allocates a [dmtr_sgarray_t].
+    /// Allocates a scatter-gather array.
     fn alloc_sgarray(&self, size: usize) -> Result<dmtr_sgarray_t, Fail> {
-        let allocation: Box<[u8]> = unsafe { Box::new_uninit_slice(size).assume_init() };
-        let ptr: *mut [u8] = Box::into_raw(allocation);
-        let sgaseg = dmtr_sgaseg_t {
-            sgaseg_buf: ptr as *mut _,
+        // Allocate a heap-managed buffer.
+        let dbuf: DataBuffer = DataBuffer::new(size)?;
+        let dbuf_ptr: *const [u8] = DataBuffer::into_raw(dbuf)?;
+        let sgaseg: dmtr_sgaseg_t = dmtr_sgaseg_t {
+            sgaseg_buf: dbuf_ptr as *mut c_void,
             sgaseg_len: size as u32,
         };
         Ok(dmtr_sgarray_t {
@@ -65,39 +67,44 @@ impl MemoryRuntime for LinuxRuntime {
         })
     }
 
-    /// Releases a [dmtr_sgarray_t].
+    /// Releases a scatter-gather array.
     fn free_sgarray(&self, sga: dmtr_sgarray_t) -> Result<(), Fail> {
-        assert_eq!(sga.sga_numsegs, 1);
-        for i in 0..sga.sga_numsegs as usize {
-            let seg: &dmtr_sgaseg_t = &sga.sga_segs[i];
-            let allocation: Box<[u8]> = unsafe {
-                Box::from_raw(slice::from_raw_parts_mut(
-                    seg.sgaseg_buf as *mut _,
-                    seg.sgaseg_len as usize,
-                ))
-            };
-            drop(allocation);
+        // Check arguments.
+        // TODO: Drop this check once we support scatter-gather arrays with multiple segments.
+        if sga.sga_numsegs != 1 {
+            return Err(Fail::new(
+                libc::EINVAL,
+                "scatter-gather array with invalid size",
+            ));
         }
+
+        // Release heap-managed buffer.
+        let sgaseg: dmtr_sgaseg_t = sga.sga_segs[0];
+        let (data_ptr, length): (*mut u8, usize) =
+            (sgaseg.sgaseg_buf as *mut u8, sgaseg.sgaseg_len as usize);
+
+        // Convert back raw slice to a heap buffer and drop allocation.
+        DataBuffer::from_raw_parts(data_ptr, length)?;
 
         Ok(())
     }
 
-    /// Clones a [dmtr_sgarray_t] into a memory buffer.
-    fn clone_sgarray(&self, sga: &dmtr_sgarray_t) -> Result<Bytes, Fail> {
-        let mut len: u32 = 0;
-        for i in 0..sga.sga_numsegs as usize {
-            len += sga.sga_segs[i].sgaseg_len;
+    /// Clones a scatter-gather array.
+    fn clone_sgarray(&self, sga: &dmtr_sgarray_t) -> Result<DataBuffer, Fail> {
+        // Check arguments.
+        // TODO: Drop this check once we support scatter-gather arrays with multiple segments.
+        if sga.sga_numsegs != 1 {
+            return Err(Fail::new(
+                libc::EINVAL,
+                "scatter-gather array with invalid size",
+            ));
         }
-        let mut buf: BytesMut = BytesMut::zeroed(len as usize).unwrap();
-        let mut pos: usize = 0;
-        for i in 0..sga.sga_numsegs as usize {
-            let seg: &dmtr_sgaseg_t = &sga.sga_segs[i];
-            let seg_slice = unsafe {
-                slice::from_raw_parts(seg.sgaseg_buf as *mut u8, seg.sgaseg_len as usize)
-            };
-            buf[pos..(pos + seg_slice.len())].copy_from_slice(seg_slice);
-            pos += seg_slice.len();
-        }
-        Ok(buf.freeze())
+
+        let sgaseg: dmtr_sgaseg_t = sga.sga_segs[0];
+        let (ptr, len): (*mut c_void, usize) = (sgaseg.sgaseg_buf, sgaseg.sgaseg_len as usize);
+
+        // Clone heap-managed buffer.
+        let seg_slice: &[u8] = unsafe { slice::from_raw_parts(ptr as *const u8, len) };
+        Ok(DataBuffer::from_slice(seg_slice))
     }
 }

--- a/src/demikernel/dbuf.rs
+++ b/src/demikernel/dbuf.rs
@@ -1,0 +1,192 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//==============================================================================
+// Imports
+//==============================================================================
+
+use ::runtime::{
+    fail::Fail,
+    memory::Buffer,
+};
+use ::std::{
+    fmt,
+    fmt::Debug,
+    ops::{
+        Deref,
+        DerefMut,
+    },
+    slice,
+    sync::Arc,
+};
+
+//==============================================================================
+// Structures
+//==============================================================================
+
+/// Data Buffer.
+#[derive(Clone)]
+pub struct DataBuffer {
+    /// Underlying data.
+    data: Option<Arc<[u8]>>,
+
+    /// Data offset.
+    offset: usize,
+
+    /// Data length
+    len: usize,
+}
+
+//==============================================================================
+// Associated Functions
+//==============================================================================
+
+/// Associated Functions for Data Buffers
+impl DataBuffer {
+    // Creates a data buffer with a given capacity.
+    pub fn new(capacity: usize) -> Result<Self, Fail> {
+        // Check if argument is valid.
+        if capacity == 0 {
+            return Err(Fail::new(libc::EINVAL, "zero-capacity buffer"));
+        }
+
+        // Create buffer.
+        Ok(Self {
+            data: unsafe { Some(Arc::new_zeroed_slice(capacity).assume_init()) },
+            offset: 0,
+            len: capacity,
+        })
+    }
+
+    /// Creates a data buffer from a raw pointer and a length.
+    pub fn from_raw_parts(data: *mut u8, len: usize) -> Result<Self, Fail> {
+        // Check if arguments are valid.
+        if len == 0 {
+            return Err(Fail::new(libc::EINVAL, "zero-length buffer"));
+        }
+        if data.is_null() {
+            return Err(Fail::new(libc::EINVAL, "null data pointer"));
+        }
+
+        // Perform conversions.
+        let data: Arc<[u8]> = unsafe {
+            let data_ptr: &mut [u8] = slice::from_raw_parts_mut(data, len);
+            Arc::from_raw(data_ptr)
+        };
+
+        Ok(Self {
+            data: Some(data),
+            offset: 0,
+            len,
+        })
+    }
+
+    /// Consumes the data buffer returning a raw pointer to the underlying data.
+    pub fn into_raw(dbuf: DataBuffer) -> Result<*const [u8], Fail> {
+        if let Some(data) = dbuf.data {
+            let data_ptr: *const [u8] = Arc::<[u8]>::into_raw(data);
+            return Ok(data_ptr);
+        }
+
+        Err(Fail::new(libc::EINVAL, "zero-length buffer"))
+    }
+}
+
+//==============================================================================
+// Standard-Library Trait Implementations
+//==============================================================================
+
+/// Partial Equality Trait Implementation for Data Buffers
+impl PartialEq for DataBuffer {
+    fn eq(&self, rhs: &Self) -> bool {
+        self[..] == rhs[..]
+    }
+}
+
+/// Equality Trait Implementation for Data Buffers
+impl Eq for DataBuffer {}
+
+/// Conversion Trait Implementation for Data Buffers
+impl From<&[u8]> for DataBuffer {
+    fn from(src: &[u8]) -> Self {
+        let buf: Arc<[u8]> = src.into();
+        Self {
+            data: Some(buf),
+            offset: 0,
+            len: src.len(),
+        }
+    }
+}
+
+/// Debug Trait Implementation for Data Buffers
+impl Debug for DataBuffer {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "DataBuffer({:?})", &self[..])
+    }
+}
+
+/// De-Reference Trait Implementation for Data Buffers
+impl Deref for DataBuffer {
+    type Target = [u8];
+
+    fn deref(&self) -> &[u8] {
+        match self.data {
+            None => &[],
+            Some(ref buf) => &buf[self.offset..(self.offset + self.len)],
+        }
+    }
+}
+
+/// Mutable De-Reference Trait Implementation for Data Buffers
+impl DerefMut for DataBuffer {
+    fn deref_mut(&mut self) -> &mut [u8] {
+        match self.data {
+            None => &mut [],
+            Some(ref mut data) => {
+                let slice: &mut [u8] = Arc::get_mut(data).expect("cannot write to a shared buffer");
+                &mut slice[self.offset..(self.offset + self.len)]
+            },
+        }
+    }
+}
+
+//==============================================================================
+// Buffer Trait Implementation
+//==============================================================================
+
+/// Buffer Trait Implementation for Data Buffers
+impl Buffer for DataBuffer {
+    /// Creates an empty buffer.
+    fn empty() -> Self {
+        Self {
+            data: None,
+            offset: 0,
+            len: 0,
+        }
+    }
+
+    /// Creates a data buffer from a slice.
+    fn from_slice(src: &[u8]) -> Self {
+        src.into()
+    }
+
+    /// Removes bytes from the front of the target data buffer.
+    fn adjust(&mut self, nbytes: usize) {
+        if nbytes > self.len {
+            panic!("adjusting past end of buffer: {} vs {}", nbytes, self.len);
+        }
+        self.offset += nbytes;
+        self.len -= nbytes;
+    }
+
+    /// Removes bytes from the end of the target data buffer.
+    fn trim(&mut self, nbytes: usize) {
+        if nbytes > self.len {
+            panic!(
+                "trimming past beginning of buffer: {} vs {}",
+                nbytes, self.len
+            );
+        }
+        self.len -= nbytes;
+    }
+}

--- a/src/demikernel/libos.rs
+++ b/src/demikernel/libos.rs
@@ -8,7 +8,7 @@ cfg_if::cfg_if! {
         use crate::catnip::runtime::DPDKRuntime as Runtime;
         use ::catnip::operations::OperationResult as OperationResult;
     } else if  #[cfg(feature = "catpowder-libos")] {
-        use ::runtime::memory::Bytes;
+        use super::dbuf::DataBuffer;
         use crate::catpowder::CatpowderLibOS as NetworkLibOS;
         use crate::catpowder::runtime::LinuxRuntime as Runtime;
         use ::catnip::operations::OperationResult;
@@ -60,7 +60,7 @@ impl LibOS {
             }
         } else if  #[cfg(feature = "catpowder-libos")] {
             /// Waits on a pending operation in an I/O queue.
-            pub fn wait2(&mut self, qt: QToken) -> Result<(QDesc, OperationResult<Bytes>), Fail> {
+            pub fn wait2(&mut self, qt: QToken) -> Result<(QDesc, OperationResult<DataBuffer>), Fail> {
                 match self {
                     LibOS::NetworkLibOS(libos) => libos.wait2(qt),
                 }
@@ -85,7 +85,7 @@ impl LibOS {
             }
         } else if  #[cfg(feature = "catpowder-libos")] {
             /// Waits on a pending operation in an I/O queue.
-            pub fn wait_any2(&mut self, qts: &[QToken]) -> Result<(usize, QDesc, OperationResult<Bytes>), Fail> {
+            pub fn wait_any2(&mut self, qts: &[QToken]) -> Result<(usize, QDesc, OperationResult<DataBuffer>), Fail> {
                 match self {
                     LibOS::NetworkLibOS(libos) => libos.wait_any2(qts),
                 }

--- a/src/demikernel/mod.rs
+++ b/src/demikernel/mod.rs
@@ -3,4 +3,5 @@
 
 pub mod bindings;
 pub mod config;
+pub mod dbuf;
 pub mod libos;

--- a/tests/common/catnap.rs
+++ b/tests/common/catnap.rs
@@ -2,14 +2,12 @@
 // Licensed under the MIT license.
 
 use super::config::TestConfig;
-use demikernel::{
+use ::demikernel::{
+    demikernel::dbuf::DataBuffer,
     Ipv4Endpoint,
     LibOS,
 };
-use runtime::memory::{
-    Buffer,
-    Bytes,
-};
+use ::runtime::memory::Buffer;
 
 //==============================================================================
 // Test
@@ -56,8 +54,8 @@ impl Test {
         data
     }
 
-    pub fn bufcmp(x: &[u8], b: Bytes) -> bool {
-        let a: Bytes = Bytes::from_slice(x);
+    pub fn bufcmp(x: &[u8], b: DataBuffer) -> bool {
+        let a: DataBuffer = DataBuffer::from_slice(x);
         if a.len() != b.len() {
             return false;
         }

--- a/tests/common/catpowder.rs
+++ b/tests/common/catpowder.rs
@@ -3,13 +3,11 @@
 
 use super::config::TestConfig;
 use ::demikernel::{
+    demikernel::dbuf::DataBuffer,
     Ipv4Endpoint,
     LibOS,
 };
-use ::runtime::memory::{
-    Buffer,
-    Bytes,
-};
+use ::runtime::memory::Buffer;
 
 //==============================================================================
 // Test
@@ -53,8 +51,8 @@ impl Test {
         data
     }
 
-    pub fn bufcmp(x: &[u8], b: Bytes) -> bool {
-        let a: Bytes = Bytes::from_slice(x);
+    pub fn bufcmp(x: &[u8], b: DataBuffer) -> bool {
+        let a: DataBuffer = DataBuffer::from_slice(x);
         if a.len() != b.len() {
             return false;
         }

--- a/tests/pushpop.rs
+++ b/tests/pushpop.rs
@@ -95,7 +95,6 @@ fn tcp_push_pop() {
     let nbytes: usize = 64 * 1024;
     let local_addr: Ipv4Endpoint = test.local_addr();
     let remote_addr: Ipv4Endpoint = test.remote_addr();
-    let expectbuf: Vec<u8> = test.mkbuf(fill_char);
 
     // Setup peer.
     let sockqd: QDesc = match test.libos.socket(libc::AF_INET, libc::SOCK_STREAM, 0) {
@@ -140,12 +139,6 @@ fn tcp_push_pop() {
                 Err(e) => panic!("operation failed: {:?}", e.cause),
                 _ => unreachable!(),
             };
-
-            // Sanity check received data.
-            assert!(
-                Test::bufcmp(&expectbuf, recvbuf.clone()),
-                "server expectbuf != recvbuf"
-            );
 
             i += recvbuf.len();
             println!("pop {:?}", i);


### PR DESCRIPTION
Description
========

In this PR I fix issue https://github.com/demikernel/demikernel/issues/86.

Here is a digest of the commits:
- In commit aab28885ea2fad42ded151b3bef0a461c3ee7695 I introduce the new `HeapBuffer` abstraction.
- In commits ee0efe081b96594e29036ced6b4ccb0457964d7e, 1b024fbaf5f8a441eacd327f22bdb1b2329170ab,  I patch our LibOSes to rely on this new abstraction.

Also, note that:
- In commit 1c027eb81b24315f83a56ff27713cc2a33f130d8 I fix a bug in our TCP push pop test. It was expecting a packet of a given content and size. This check was not good because this unit tests performns a one-directrion transmission.