### PR TITLE
[test] Drop Workflow Dispatch

### DIFF
--- a/.github/workflows/catnap-build.yml
+++ b/.github/workflows/catnap-build.yml
@@ -17,15 +17,6 @@ on:
       - dev
       - unstable
       - master
-  workflow_dispatch:
-    branches:
-      - bugfix-*
-      - enhancement-*
-      - feature-*
-      - workaround-*
-      - dev
-      - unstable
-      - master
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/catnap-tcp-pingpong.yml
+++ b/.github/workflows/catnap-tcp-pingpong.yml
@@ -17,15 +17,6 @@ on:
       - dev
       - unstable
       - master
-  workflow_dispatch:
-    branches:
-      - bugfix-*
-      - enhancement-*
-      - feature-*
-      - workaround-*
-      - dev
-      - unstable
-      - master
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/catnap-tcp-pushpop.yml
+++ b/.github/workflows/catnap-tcp-pushpop.yml
@@ -17,15 +17,6 @@ on:
       - dev
       - unstable
       - master
-  workflow_dispatch:
-    branches:
-      - bugfix-*
-      - enhancement-*
-      - feature-*
-      - workaround-*
-      - dev
-      - unstable
-      - master
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/catnap-udp-pingpong.yml
+++ b/.github/workflows/catnap-udp-pingpong.yml
@@ -17,15 +17,6 @@ on:
       - dev
       - unstable
       - master
-  workflow_dispatch:
-    branches:
-      - bugfix-*
-      - enhancement-*
-      - feature-*
-      - workaround-*
-      - dev
-      - unstable
-      - master
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/catnap-udp-pushpop.yml
+++ b/.github/workflows/catnap-udp-pushpop.yml
@@ -17,15 +17,6 @@ on:
       - dev
       - unstable
       - master
-  workflow_dispatch:
-    branches:
-      - bugfix-*
-      - enhancement-*
-      - feature-*
-      - workaround-*
-      - dev
-      - unstable
-      - master
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/catnap-unit-tests.yml
+++ b/.github/workflows/catnap-unit-tests.yml
@@ -17,15 +17,6 @@ on:
       - dev
       - unstable
       - master
-  workflow_dispatch:
-    branches:
-      - bugfix-*
-      - enhancement-*
-      - feature-*
-      - workaround-*
-      - dev
-      - unstable
-      - master
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/catnip-build.yml
+++ b/.github/workflows/catnip-build.yml
@@ -17,15 +17,6 @@ on:
       - dev
       - unstable
       - master
-  workflow_dispatch:
-    branches:
-      - bugfix-*
-      - enhancement-*
-      - feature-*
-      - workaround-*
-      - dev
-      - unstable
-      - master
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/catnip-tcp-pingpong.yml
+++ b/.github/workflows/catnip-tcp-pingpong.yml
@@ -17,15 +17,6 @@ on:
       - dev
       - unstable
       - master
-  workflow_dispatch:
-    branches:
-      - bugfix-*
-      - enhancement-*
-      - feature-*
-      - workaround-*
-      - dev
-      - unstable
-      - master
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/catnip-tcp-pushpop.yml
+++ b/.github/workflows/catnip-tcp-pushpop.yml
@@ -17,15 +17,6 @@ on:
       - dev
       - unstable
       - master
-  workflow_dispatch:
-    branches:
-      - bugfix-*
-      - enhancement-*
-      - feature-*
-      - workaround-*
-      - dev
-      - unstable
-      - master
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/catnip-udp-pingpong.yml
+++ b/.github/workflows/catnip-udp-pingpong.yml
@@ -17,15 +17,6 @@ on:
       - dev
       - unstable
       - master
-  workflow_dispatch:
-    branches:
-      - bugfix-*
-      - enhancement-*
-      - feature-*
-      - workaround-*
-      - dev
-      - unstable
-      - master
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/catnip-udp-pushpop.yml
+++ b/.github/workflows/catnip-udp-pushpop.yml
@@ -17,15 +17,6 @@ on:
       - dev
       - unstable
       - master
-  workflow_dispatch:
-    branches:
-      - bugfix-*
-      - enhancement-*
-      - feature-*
-      - workaround-*
-      - dev
-      - unstable
-      - master
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/catnip-unit-test.yml
+++ b/.github/workflows/catnip-unit-test.yml
@@ -17,15 +17,6 @@ on:
       - dev
       - unstable
       - master
-  workflow_dispatch:
-    branches:
-      - bugfix-*
-      - enhancement-*
-      - feature-*
-      - workaround-*
-      - dev
-      - unstable
-      - master
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/catpowder-build.yml
+++ b/.github/workflows/catpowder-build.yml
@@ -17,15 +17,6 @@ on:
       - dev
       - unstable
       - master
-  workflow_dispatch:
-    branches:
-      - bugfix-*
-      - enhancement-*
-      - feature-*
-      - workaround-*
-      - dev
-      - unstable
-      - master
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/catpowder-tcp-pingpong.yml
+++ b/.github/workflows/catpowder-tcp-pingpong.yml
@@ -17,15 +17,6 @@ on:
       - dev
       - unstable
       - master
-  workflow_dispatch:
-    branches:
-      - bugfix-*
-      - enhancement-*
-      - feature-*
-      - workaround-*
-      - dev
-      - unstable
-      - master
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/catpowder-tcp-pushpop.yml
+++ b/.github/workflows/catpowder-tcp-pushpop.yml
@@ -17,15 +17,6 @@ on:
       - dev
       - unstable
       - master
-  workflow_dispatch:
-    branches:
-      - bugfix-*
-      - enhancement-*
-      - feature-*
-      - workaround-*
-      - dev
-      - unstable
-      - master
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/catpowder-udp-pingpong.yml
+++ b/.github/workflows/catpowder-udp-pingpong.yml
@@ -17,15 +17,6 @@ on:
       - dev
       - unstable
       - master
-  workflow_dispatch:
-    branches:
-      - bugfix-*
-      - enhancement-*
-      - feature-*
-      - workaround-*
-      - dev
-      - unstable
-      - master
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/catpowder-udp-pushpop.yml
+++ b/.github/workflows/catpowder-udp-pushpop.yml
@@ -17,15 +17,6 @@ on:
       - dev
       - unstable
       - master
-  workflow_dispatch:
-    branches:
-      - bugfix-*
-      - enhancement-*
-      - feature-*
-      - workaround-*
-      - dev
-      - unstable
-      - master
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/catpowder-unit-test.yml
+++ b/.github/workflows/catpowder-unit-test.yml
@@ -17,15 +17,6 @@ on:
       - dev
       - unstable
       - master
-  workflow_dispatch:
-    branches:
-      - bugfix-*
-      - enhancement-*
-      - feature-*
-      - workaround-*
-      - dev
-      - unstable
-      - master
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Description
========

In this PR I drop workflow dispatch in GitHub actions, because branch filtering is no longer supported on this dispatching option.