### PR TITLE
[contrib] Upgrade `nix` to `v0.24.0` Catnap and Catcollar

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ libc = "0.2.126"
 rand = { version = "0.8.5", features = ["small_rng"] }
 yaml-rust = "0.4.5"
 log = "0.4.17"
-nix = "0.23.1"
+nix = "0.24.0"
 socket2 = { version = "0.4.4", features = ["all"] }
 cfg-if = "1.0.0"
 

--- a/src/catcollar/futures/connect.rs
+++ b/src/catcollar/futures/connect.rs
@@ -9,7 +9,7 @@ use ::nix::{
     errno::Errno,
     sys::{
         socket,
-        socket::SockAddr,
+        socket::SockaddrStorage,
     },
 };
 use ::runtime::{
@@ -37,7 +37,7 @@ pub struct ConnectFuture {
     // Underlying file descriptor.
     fd: RawFd,
     /// Destination address.
-    addr: SockAddr,
+    addr: SockaddrStorage,
 }
 
 //==============================================================================
@@ -47,7 +47,7 @@ pub struct ConnectFuture {
 /// Associate Functions for Connect Operation Descriptors
 impl ConnectFuture {
     /// Creates a descriptor for a connect operation.
-    pub fn new(qd: QDesc, fd: RawFd, addr: SockAddr) -> Self {
+    pub fn new(qd: QDesc, fd: RawFd, addr: SockaddrStorage) -> Self {
         Self { qd, fd, addr }
     }
 

--- a/src/catcollar/runtime/mod.rs
+++ b/src/catcollar/runtime/mod.rs
@@ -12,7 +12,7 @@ mod utils;
 
 use super::iouring::IoUring;
 use crate::demikernel::dbuf::DataBuffer;
-use ::nix::sys::socket::SockAddr;
+use ::nix::sys::socket::SockaddrStorage;
 use ::runtime::{
     fail::Fail,
     timer::{
@@ -124,7 +124,7 @@ impl IoUringRuntime {
     }
 
     /// Pushes a buffer to the target I/O user ring.
-    pub fn pushto(&self, sockfd: i32, addr: SockAddr, buf: DataBuffer) -> Result<RequestId, Fail> {
+    pub fn pushto(&self, sockfd: i32, addr: SockaddrStorage, buf: DataBuffer) -> Result<RequestId, Fail> {
         let request_id: RequestId = self.io_uring.borrow_mut().pushto(sockfd, addr, buf)?.into();
         Ok(request_id)
     }

--- a/src/catnap/futures/connect.rs
+++ b/src/catnap/futures/connect.rs
@@ -9,7 +9,7 @@ use ::nix::{
     errno::Errno,
     sys::{
         socket,
-        socket::SockAddr,
+        socket::SockaddrStorage,
     },
 };
 use ::runtime::{
@@ -37,7 +37,7 @@ pub struct ConnectFuture {
     // Underlying file descriptor.
     fd: RawFd,
     /// Destination address.
-    addr: SockAddr,
+    addr: SockaddrStorage,
 }
 
 //==============================================================================
@@ -47,7 +47,7 @@ pub struct ConnectFuture {
 /// Associate Functions for Connect Operation Descriptors
 impl ConnectFuture {
     /// Creates a descriptor for a connect operation.
-    pub fn new(qd: QDesc, fd: RawFd, addr: SockAddr) -> Self {
+    pub fn new(qd: QDesc, fd: RawFd, addr: SockaddrStorage) -> Self {
         Self { qd, fd, addr }
     }
 

--- a/src/catnap/futures/pushto.rs
+++ b/src/catnap/futures/pushto.rs
@@ -11,7 +11,7 @@ use ::nix::{
     sys::socket::{
         self,
         MsgFlags,
-        SockAddr,
+        SockaddrStorage,
     },
 };
 use ::runtime::{
@@ -37,7 +37,7 @@ pub struct PushtoFuture {
     /// Associated queue descriptor.
     qd: QDesc,
     /// Destination address.
-    addr: SockAddr,
+    addr: SockaddrStorage,
     // Underlying file descriptor.
     fd: RawFd,
     /// Buffer to send.
@@ -51,7 +51,7 @@ pub struct PushtoFuture {
 /// Associate Functions for Pushto Operation Descriptors
 impl PushtoFuture {
     /// Creates a descriptor for a pushto operation.
-    pub fn new(qd: QDesc, fd: RawFd, addr: SockAddr, buf: DataBuffer) -> Self {
+    pub fn new(qd: QDesc, fd: RawFd, addr: SockaddrStorage, buf: DataBuffer) -> Self {
         Self { qd, addr, fd, buf }
     }
 


### PR DESCRIPTION
Description
-------------

This PR fixes https://github.com/demikernel/demikernel/issues/122.

Digest of Changes
---------------------
- Bumped `nix` crate to `v0.24.0`
- Dropped deprecated `Sockaddr` in Catnap
- Dropped deprecated `Sockaddr` in Catcollar