### PR TITLE
[catnip] `Buffer::clone()` for `DPDKBuf`

### DIFF
--- a/src/catnip/runtime/memory/dpdkbuf.rs
+++ b/src/catnip/runtime/memory/dpdkbuf.rs
@@ -21,7 +21,7 @@ use std::{
 //==============================================================================
 
 /// DPDK Buffer
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub enum DPDKBuf {
     External(DataBuffer),
     Managed(Mbuf),
@@ -66,7 +66,14 @@ impl Buffer for DPDKBuf {
     }
 
     fn clone(&self) -> Box<dyn Buffer> {
-        todo!()
+        match self {
+            DPDKBuf::External(buf) => Buffer::clone(buf),
+            DPDKBuf::Managed(mbuf) => {
+                let mbuf = Clone::clone(mbuf);
+                let dpdkbuf = DPDKBuf::Managed(mbuf);
+                Box::new(dpdkbuf)
+            },
+        }
     }
 
     fn as_any(&self) -> &dyn Any {


### PR DESCRIPTION
Description
-------------

This commit fixes https://github.com/demikernel/demikernel/issues/130.

**This PR is a hotfix to the `unstable` branch**

Summary of Changes
-------------------------

- Droped derived `Clone` trait.
- Added implementation for `Buffer::clone()`.