### PR TITLE
[pdpix] Missing Endianness Conversion for Port Number

### DIFF
--- a/src/rust/demikernel/bindings.rs
+++ b/src/rust/demikernel/bindings.rs
@@ -514,6 +514,7 @@ pub extern "C" fn demi_getsockopt(
 
 /// Converts a [sockaddr] into a [SocketAddrV4].
 fn sockaddr_to_socketaddrv4(saddr: *const sockaddr) -> Result<SocketAddrV4, Fail> {
+    // TODO: Change the logic bellow and rename this function once we support V6 addresses as well.
     let sin: libc::sockaddr_in = unsafe { *mem::transmute::<*const sockaddr, *const libc::sockaddr_in>(saddr) };
     if sin.sin_family != libc::AF_INET as u16 {
         return Err(Fail::new(libc::ENOTSUP, "communication domain  not supported"));
@@ -525,6 +526,8 @@ fn sockaddr_to_socketaddrv4(saddr: *const sockaddr) -> Result<SocketAddrV4, Fail
 
 #[test]
 fn test_sockaddr_to_socketaddrv4() {
+    // TODO: assign something meaningful to sa_family and check it once we support V6 addresses as well.
+
     // SocketAddrV4: 127.0.0.1:80
     let saddr: libc::sockaddr = {
         sockaddr {

--- a/src/rust/demikernel/bindings.rs
+++ b/src/rust/demikernel/bindings.rs
@@ -512,10 +512,31 @@ pub extern "C" fn demi_getsockopt(
 // Standalone Functions
 //==============================================================================
 
-/// Converts a [sockaddr] into a [Ipv4Endpoint].
+/// Converts a [sockaddr] into a [SocketAddrV4].
 fn sockaddr_to_ipv4endpoint(saddr: *const sockaddr) -> Result<SocketAddrV4, Fail> {
     // TODO: Review why we need byte ordering conversion here.
     let sin: libc::sockaddr_in = unsafe { *mem::transmute::<*const sockaddr, *const libc::sockaddr_in>(saddr) };
+    if sin.sin_family != libc::AF_INET as u16 {
+        return Err(Fail::new(libc::ENOTSUP, "communication domain  not supported"));
+    };
     let addr: Ipv4Addr = { Ipv4Addr::from(u32::from_be_bytes(sin.sin_addr.s_addr.to_le_bytes())) };
     Ok(SocketAddrV4::new(addr, sin.sin_port))
+}
+
+#[test]
+fn test_sockaddr_to_ipv4endpoint() {
+    // SocketAddrV4: 127.0.0.1:80
+    let saddr: libc::sockaddr = {
+        sockaddr {
+            sa_family: libc::AF_INET as u16,
+            sa_data: [0, 80, 127, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0],
+        }
+    };
+    match sockaddr_to_ipv4endpoint(&saddr) {
+        Ok(addr) => {
+            assert_eq!(addr.port(), 80);
+            assert_eq!(addr.ip(), &Ipv4Addr::new(127, 0, 0, 1));
+        },
+        _ => panic!("failed to convert"),
+    }
 }

--- a/src/rust/demikernel/bindings.rs
+++ b/src/rust/demikernel/bindings.rs
@@ -514,12 +514,11 @@ pub extern "C" fn demi_getsockopt(
 
 /// Converts a [sockaddr] into a [SocketAddrV4].
 fn sockaddr_to_ipv4endpoint(saddr: *const sockaddr) -> Result<SocketAddrV4, Fail> {
-    // TODO: Review why we need byte ordering conversion here.
     let sin: libc::sockaddr_in = unsafe { *mem::transmute::<*const sockaddr, *const libc::sockaddr_in>(saddr) };
     if sin.sin_family != libc::AF_INET as u16 {
         return Err(Fail::new(libc::ENOTSUP, "communication domain  not supported"));
     };
-    let addr: Ipv4Addr = { Ipv4Addr::from(u32::from_be_bytes(sin.sin_addr.s_addr.to_le_bytes())) };
+    let addr: Ipv4Addr = Ipv4Addr::from(u32::from_be(sin.sin_addr.s_addr));
     Ok(SocketAddrV4::new(addr, sin.sin_port))
 }
 

--- a/src/rust/demikernel/bindings.rs
+++ b/src/rust/demikernel/bindings.rs
@@ -519,7 +519,8 @@ fn sockaddr_to_ipv4endpoint(saddr: *const sockaddr) -> Result<SocketAddrV4, Fail
         return Err(Fail::new(libc::ENOTSUP, "communication domain  not supported"));
     };
     let addr: Ipv4Addr = Ipv4Addr::from(u32::from_be(sin.sin_addr.s_addr));
-    Ok(SocketAddrV4::new(addr, sin.sin_port))
+    let port: u16 = u16::from_be(sin.sin_port);
+    Ok(SocketAddrV4::new(addr, port))
 }
 
 #[test]

--- a/src/rust/demikernel/bindings.rs
+++ b/src/rust/demikernel/bindings.rs
@@ -116,7 +116,7 @@ pub extern "C" fn demi_bind(qd: c_int, saddr: *const sockaddr, size: socklen_t) 
     }
 
     // Get socket address.
-    let endpoint: SocketAddrV4 = match sockaddr_to_ipv4endpoint(saddr) {
+    let endpoint: SocketAddrV4 = match sockaddr_to_socketaddrv4(saddr) {
         Ok(endpoint) => endpoint,
         Err(e) => {
             warn!("bind() failed: {:?}", e);
@@ -204,7 +204,7 @@ pub extern "C" fn demi_connect(
     }
 
     // Get socket address.
-    let endpoint: SocketAddrV4 = match sockaddr_to_ipv4endpoint(saddr) {
+    let endpoint: SocketAddrV4 = match sockaddr_to_socketaddrv4(saddr) {
         Ok(endpoint) => endpoint,
         Err(e) => {
             warn!("connect() failed: {:?}", e);
@@ -275,7 +275,7 @@ pub extern "C" fn demi_pushto(
     let sga: &demi_sgarray_t = unsafe { &*sga };
 
     // Get socket address.
-    let endpoint: SocketAddrV4 = match sockaddr_to_ipv4endpoint(saddr) {
+    let endpoint: SocketAddrV4 = match sockaddr_to_socketaddrv4(saddr) {
         Ok(endpoint) => endpoint,
         Err(e) => {
             warn!("pushto() failed: {:?}", e);
@@ -513,7 +513,7 @@ pub extern "C" fn demi_getsockopt(
 //==============================================================================
 
 /// Converts a [sockaddr] into a [SocketAddrV4].
-fn sockaddr_to_ipv4endpoint(saddr: *const sockaddr) -> Result<SocketAddrV4, Fail> {
+fn sockaddr_to_socketaddrv4(saddr: *const sockaddr) -> Result<SocketAddrV4, Fail> {
     let sin: libc::sockaddr_in = unsafe { *mem::transmute::<*const sockaddr, *const libc::sockaddr_in>(saddr) };
     if sin.sin_family != libc::AF_INET as u16 {
         return Err(Fail::new(libc::ENOTSUP, "communication domain  not supported"));
@@ -524,7 +524,7 @@ fn sockaddr_to_ipv4endpoint(saddr: *const sockaddr) -> Result<SocketAddrV4, Fail
 }
 
 #[test]
-fn test_sockaddr_to_ipv4endpoint() {
+fn test_sockaddr_to_socketaddrv4() {
     // SocketAddrV4: 127.0.0.1:80
     let saddr: libc::sockaddr = {
         sockaddr {
@@ -532,7 +532,7 @@ fn test_sockaddr_to_ipv4endpoint() {
             sa_data: [0, 80, 127, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0],
         }
     };
-    match sockaddr_to_ipv4endpoint(&saddr) {
+    match sockaddr_to_socketaddrv4(&saddr) {
         Ok(addr) => {
             assert_eq!(addr.port(), 80);
             assert_eq!(addr.ip(), &Ipv4Addr::new(127, 0, 0, 1));


### PR DESCRIPTION
Description
-------------

This PR fixes https://github.com/demikernel/demikernel/issues/144.

Summary of Changes
-------------------------

- Renamed `sockaddr_to_ipv4endpoint()` to `test_sockaddr_to_socketaddrv4()`
- Dropped useless byte ordering conversion for socket address in `test_sockaddr_to_socketaddrv4`.
- Introduced a test unit for bug https://github.com/demikernel/demikernel/issues/144.
- Fixed missing edianness conversion for port number in `test_sockaddr_to_socketaddrv4()`
- Added check for `AF_INET` in `test_sockaddr_to_socketaddrv4()`