### PR TITLE
[catnap] Set Source Address in `OperationResult` for `pop()`

### DIFF
--- a/src/rust/catnap/futures/mod.rs
+++ b/src/rust/catnap/futures/mod.rs
@@ -132,8 +132,8 @@ impl Operation {
             // Pop operation.
             Operation::Pop(FutureResult {
                 future,
-                done: Some(Ok(buf)),
-            }) => (future.get_qd(), None, None, OperationResult::Pop(None, buf)),
+                done: Some(Ok((addr, buf))),
+            }) => (future.get_qd(), None, None, OperationResult::Pop(addr, buf)),
             Operation::Pop(FutureResult {
                 future,
                 done: Some(Err(e)),


### PR DESCRIPTION
Description
-------------

This PR fixes https://github.com/demikernel/demikernel/issues/147.

Sumary of Changes
----------------------

- Changed `PopFuture::poll()` to use `recvfrom()` and return the source address of the message
- Changed the `Operation::get_result()` to set the address in `OperationResult` accordingly

Additional Information
--------------------------

- The verbose conversion in `recvfrom()` is required because `nix` does not provide a conversion function between `SockaddrStorage` and `SocketAddrV4` (https://docs.rs/nix/latest/nix/sys/socket/union.SockaddrStorage.html). Once we drop the use of `nix` in favor of `libc` we should get rid of this.
- There is a similar issue with Catcollar, but it is harder to fix. See https://github.com/demikernel/demikernel/issues/148 for more details.