### PR TITLE
[catcollar] Set Source Address in `OperationResult` for `pop()`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,8 @@ yaml-rust = "0.4.5"
 log = "0.4.17"
 nix = "0.24.2"
 
-inetstack = { git = "https://github.com/demikernel/inetstack", rev = "0754923ca899dd24e9d0f20b6ff2a0aa8bf2c382" }
-runtime = { git = "https://github.com/demikernel/runtime", rev = "2ce0ed6d29a3aa831eefe6dc10ef2f843df275c1" }
+inetstack = { git = "https://github.com/demikernel/inetstack", rev = "8c1e680fe97310e690e8f57e07ed7b3faf22f774" }
+runtime = { git = "https://github.com/demikernel/runtime", rev = "83e5442ff0c9404d9aae66ec50f479edd9e86e6a" }
 
 [[test]]
 name = "sga"

--- a/src/rust/catcollar/futures/mod.rs
+++ b/src/rust/catcollar/futures/mod.rs
@@ -132,8 +132,8 @@ impl Operation {
             // Pop operation.
             Operation::Pop(FutureResult {
                 future,
-                done: Some(Ok(buf)),
-            }) => (future.get_qd(), None, None, OperationResult::Pop(None, buf)),
+                done: Some(Ok((addr, buf))),
+            }) => (future.get_qd(), None, None, OperationResult::Pop(addr, buf)),
             Operation::Pop(FutureResult {
                 future,
                 done: Some(Err(e)),

--- a/src/rust/catcollar/futures/push.rs
+++ b/src/rust/catcollar/futures/push.rs
@@ -66,18 +66,18 @@ impl Future for PushFuture {
         let self_: &mut PushFuture = self.get_mut();
         match self_.rt.peek(self_.request_id) {
             // Operation completed.
-            Ok(Some(size)) if size >= 0 => {
+            Ok((_, Some(size))) if size >= 0 => {
                 trace!("data pushed ({:?} bytes)", size);
                 Poll::Ready(Ok(()))
             },
             // Operation in progress, re-schedule future.
-            Ok(None) => {
+            Ok((None, None)) => {
                 trace!("push in progress");
                 ctx.waker().wake_by_ref();
                 Poll::Pending
             },
             // Underlying asynchronous operation failed.
-            Ok(Some(size)) if size < 0 => {
+            Ok((None, Some(size))) if size < 0 => {
                 let errno: i32 = -size;
                 warn!("push failed ({:?})", errno);
                 Poll::Ready(Err(Fail::new(errno, "I/O error")))

--- a/src/rust/catcollar/futures/pushto.rs
+++ b/src/rust/catcollar/futures/pushto.rs
@@ -66,18 +66,18 @@ impl Future for PushtoFuture {
         let self_: &mut PushtoFuture = self.get_mut();
         match self_.rt.peek(self_.request_id) {
             // Operation completed.
-            Ok(Some(size)) if size >= 0 => {
+            Ok((_, Some(size))) if size >= 0 => {
                 trace!("data pushed ({:?} bytes)", size);
                 Poll::Ready(Ok(()))
             },
             // Operation in progress, re-schedule future.
-            Ok(None) => {
+            Ok((None, None)) => {
                 trace!("push in progress");
                 ctx.waker().wake_by_ref();
                 Poll::Pending
             },
             // Underlying asynchronous operation failed.
-            Ok(Some(size)) if size < 0 => {
+            Ok((None, Some(size))) if size < 0 => {
                 let errno: i32 = -size;
                 warn!("push failed ({:?})", errno);
                 Poll::Ready(Err(Fail::new(errno, "I/O error")))


### PR DESCRIPTION
Description
-------------

This PR fixes https://github.com/demikernel/demikernel/issues/148.

Summary of Changes
-------------------------

- Changed `IoUring` to rely on `io_uring_prep_recvmsg()` and thus be able to get the socket address of the source.
- Changed lookip logic in `IoUring` to use the `msghdr` rather than the buffer address
- Changed futures accordinly