### PR TITLE
[network] Move to std network types

### DIFF
--- a/src/rust/catcollar/mod.rs
+++ b/src/rust/catcollar/mod.rs
@@ -54,7 +54,6 @@ use ::runtime::{
         DataBuffer,
         MemoryRuntime,
     },
-    network::types::Ipv4Addr,
     queue::IoQueueTable,
     scheduler::SchedulerHandle,
     types::{
@@ -72,7 +71,10 @@ use ::std::{
     any::Any,
     collections::HashMap,
     mem,
-    net::SocketAddrV4,
+    net::{
+        Ipv4Addr,
+        SocketAddrV4,
+    },
     os::unix::prelude::RawFd,
 };
 

--- a/src/rust/catnap/mod.rs
+++ b/src/rust/catnap/mod.rs
@@ -55,7 +55,6 @@ use ::runtime::{
         DataBuffer,
         MemoryRuntime,
     },
-    network::types::Ipv4Addr,
     queue::IoQueueTable,
     scheduler::SchedulerHandle,
     types::{
@@ -73,7 +72,10 @@ use ::std::{
     any::Any,
     collections::HashMap,
     mem,
-    net::SocketAddrV4,
+    net::{
+        Ipv4Addr,
+        SocketAddrV4,
+    },
     os::unix::prelude::RawFd,
 };
 

--- a/src/rust/demikernel/config.rs
+++ b/src/rust/demikernel/config.rs
@@ -43,9 +43,8 @@ impl Config {
 
     /// Reads the local IPv4 address parameter from the underlying configuration file.
     #[cfg(any(feature = "catnip-libos", feature = "catpowder-libos"))]
-    pub fn local_ipv4_addr(&self) -> std::net::Ipv4Addr {
+    pub fn local_ipv4_addr(&self) -> Ipv4Addr {
         // FIXME: this function should return a result.
-        use ::std::net::Ipv4Addr;
 
         // FIXME: Change the follow key from "catnip" to "demikernel".
         let local_ipv4_addr: Ipv4Addr = self.0["catnip"]["my_ipv4_addr"]

--- a/src/rust/demikernel/config.rs
+++ b/src/rust/demikernel/config.rs
@@ -43,8 +43,9 @@ impl Config {
 
     /// Reads the local IPv4 address parameter from the underlying configuration file.
     #[cfg(any(feature = "catnip-libos", feature = "catpowder-libos"))]
-    pub fn local_ipv4_addr(&self) -> Ipv4Addr {
+    pub fn local_ipv4_addr(&self) -> ::std::net::Ipv4Addr {
         // FIXME: this function should return a result.
+        use ::std::net::Ipv4Addr;
 
         // FIXME: Change the follow key from "catnip" to "demikernel".
         let local_ipv4_addr: Ipv4Addr = self.0["catnip"]["my_ipv4_addr"]

--- a/src/rust/lib.rs
+++ b/src/rust/lib.rs
@@ -53,7 +53,6 @@ pub use libos_export::*;
 pub use self::demikernel::libos::LibOS;
 pub use ::runtime::{
     network::types::{
-        Ipv4Addr,
         MacAddress,
         Port16,
     },
@@ -66,5 +65,6 @@ pub use ::runtime::{
     QToken,
     QType,
 };
+pub use ::std::net::Ipv4Addr;
 
 pub mod demikernel;


### PR DESCRIPTION
Partially addresses this issue: https://github.com/demikernel/inetstack/issues/124

This is a part of a multi-part series of PRs. This series aims to move from custom types that support network-related data structures to standard library types in Rust. Multiple other PRs will follow targetting similar changes to other libraries (e.g. inetstack, runtime).