### PR TITLE
[pdpix] `timedwait()` System Call

### DIFF
--- a/include/demi/wait.h
+++ b/include/demi/wait.h
@@ -5,6 +5,7 @@
 #define DEMI_WAIT_H_IS_INCLUDED
 
 #include <demi/types.h>
+#include <time.h>
 
 #ifdef __cplusplus
 extern "C"
@@ -20,6 +21,17 @@ extern "C"
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
     extern int demi_wait(demi_qresult_t *qr_out, demi_qtoken_t qt);
+
+    /**
+     * @brief Waits for an asynchronous I/O operation to complete or a timeout to expire.
+     *
+     * @param qr_out  Store location for the result of the completed I/O operation.
+     * @param qt      I/O queue token of the target operation to wait for completion.
+     * @param abstime Absolute timeout in seconds and nanoseconds since Epoch.
+     *
+     * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
+     */
+    extern int demi_timedwait(demi_qresult_t *qr_out, demi_qtoken_t qt, const struct timespec *abstime);
 
     /**
      * @brief Waits for the first asynchronous I/O operation in a list to complete.

--- a/man/demi_wait.md
+++ b/man/demi_wait.md
@@ -4,6 +4,8 @@
 
 `demi_wait` - Waits for an asynchronous I/O operation to complete.
 
+`demi_timedwait` - Waits for an asynchronous I/O operation to complete or a timeout to expire.
+
 `demi_wait_any` - Waits for the first asynchronous I/O operation in a list to complete.
 
 ## Synopsis
@@ -18,15 +20,23 @@ int demi_wait_any(demi_qresult_t *qr_out, int *ready_offset, demi_qtoken_t qts[]
 
 ## Description
 
-`demi_wait()` waits for an I/O operation to complete, and`demi_wait_any()` waits for the first I/O operation in a list to
-complete.
+`demi_wait()` waits for the completion of the asynchronous I/O operation associated with the queue token `qt`. This
+system call may cause the calling thread to block (spin) indefinitely.
 
-- The `qt` parameter in `demi_wait()` is the queue token wait for completion.
-- The `qts` parameter in `demi_wait_any()` is the list of queue tokens to wait for completion.
-- The `num_qts` parameter in `demi_wait_any()` specifies the length of `qts` list.
-- The `ready_offset` parameter points to the location where `demi_wait_any()` shall store the offset within `qts` of the
-operation that has completed.
-- The `qr_out` points to the location where the result of the completed operation shall be stored.
+`demi_timedwait()` waits for the completion of the asynchronous I/O operation associated with the queue token `qt` or
+for the expiration of a timeout, whichever happens first. The `abstime` parameter specifies an absolute timeout in
+seconds and nanoseconds since the Epoch.  If the I/O operation has already completed when `demi_timedwait()` is called,
+then this system call never fails with a timeout error, regardless of the value of `abstime`. This system call may cause
+the calling thread to block (spin) until the timeout `abstime` expires.
+
+`demi_wait_any()` waits for the first asynchronous I/O operation in a set to complete. The set of I/O operations is
+specified by the list of queue tokens `qts` and it has a length of `num_qts`. This system call may cause the calling
+thread to block (spin) indefinitely.
+
+When `demi_wait()` and `demi_timedwait()` successfully completes, the structure pointed to by `qr_out` is filled in with
+the result value of the I/O operation that has completed. The `demi_wait_any()` system call behaves similarly, but it
+additionally sets `ready_offset` to indicate the index of that I/O operation in the list of queue tokens `qts` that has
+completed.
 
 The `demi_qresult_t` is defined as follows:
 
@@ -102,6 +112,8 @@ On error, one of the following positive error codes is returned:
 - `EINVAL` - The `qt` argument refers to an invalid queue token.
 - `EINVAL` - The `num_qts` argument has an invalid size.
 - `EINVAL` - The `qts` argument contains an invalid queue token.
+- `EINVAL` - The `abtime` argument does not point to a valid structure.
+- `ETIMEDOUT` - The system call timed out before an I/O operation was completed.
 
 ## Conforming To
 

--- a/src/rust/catcollar/mod.rs
+++ b/src/rust/catcollar/mod.rs
@@ -71,6 +71,7 @@ use ::std::{
         SocketAddrV4,
     },
     os::unix::prelude::RawFd,
+    time::SystemTime,
 };
 
 #[cfg(feature = "profiler")]
@@ -354,6 +355,38 @@ impl CatcollarLibOS {
         trace!("wait() qt={:?}", qt);
 
         let (qd, result): (QDesc, OperationResult) = self.wait2(qt)?;
+        Ok(pack_result(&self.runtime, result, qd, qt.into()))
+    }
+
+    /// Waits for an I/O operation to complete or a timeout to expire.
+    pub fn timedwait(&mut self, qt: QToken, abstime: Option<SystemTime>) -> Result<demi_qresult_t, Fail> {
+        #[cfg(feature = "profiler")]
+        timer!("catcollar::timedwait");
+        trace!("timedwait() qt={:?}, timeout={:?}", qt, abstime);
+
+        // Retrieve associated schedule handle.
+        let mut handle: SchedulerHandle = match self.runtime.scheduler.from_raw_handle(qt.into()) {
+            Some(handle) => handle,
+            None => return Err(Fail::new(libc::EINVAL, "invalid queue token")),
+        };
+
+        let (qd, result): (QDesc, OperationResult) = loop {
+            // Poll first, so as to give pending operations a chance to complete.
+            self.runtime.scheduler.poll();
+
+            // The operation has completed, so extract the result and return.
+            if handle.has_completed() {
+                break self.take_result(handle);
+            }
+
+            if abstime.is_none() || SystemTime::now() >= abstime.unwrap() {
+                // Return this operation to the scheduling queue by removing the associated key
+                // (which would otherwise cause the operation to be freed).
+                handle.take_key();
+                return Err(Fail::new(libc::ETIMEDOUT, "timer expired"));
+            }
+        };
+
         Ok(pack_result(&self.runtime, result, qd, qt.into()))
     }
 

--- a/src/rust/catnap/mod.rs
+++ b/src/rust/catnap/mod.rs
@@ -77,6 +77,7 @@ use ::std::{
         SocketAddrV4,
     },
     os::unix::prelude::RawFd,
+    time::SystemTime,
 };
 
 #[cfg(feature = "profiler")]
@@ -347,6 +348,38 @@ impl CatnapLibOS {
         trace!("wait() qt={:?}", qt);
 
         let (qd, result): (QDesc, OperationResult) = self.wait2(qt)?;
+        Ok(pack_result(&self.runtime, result, qd, qt.into()))
+    }
+
+    /// Waits for an I/O operation to complete or a timeout to expire.
+    pub fn timedwait(&mut self, qt: QToken, abstime: Option<SystemTime>) -> Result<demi_qresult_t, Fail> {
+        #[cfg(feature = "profiler")]
+        timer!("catnap::timedwait");
+        trace!("timedwait() qt={:?}, timeout={:?}", qt, abstime);
+
+        // Retrieve associated schedule handle.
+        let mut handle: SchedulerHandle = match self.runtime.scheduler.from_raw_handle(qt.into()) {
+            Some(handle) => handle,
+            None => return Err(Fail::new(libc::EINVAL, "invalid queue token")),
+        };
+
+        let (qd, result): (QDesc, OperationResult) = loop {
+            // Poll first, so as to give pending operations a chance to complete.
+            self.runtime.scheduler.poll();
+
+            // The operation has completed, so extract the result and return.
+            if handle.has_completed() {
+                break self.take_result(handle);
+            }
+
+            if abstime.is_none() || SystemTime::now() >= abstime.unwrap() {
+                // Return this operation to the scheduling queue by removing the associated key
+                // (which would otherwise cause the operation to be freed).
+                handle.take_key();
+                return Err(Fail::new(libc::ETIMEDOUT, "timer expired"));
+            }
+        };
+
         Ok(pack_result(&self.runtime, result, qd, qt.into()))
     }
 

--- a/src/rust/catnip/mod.rs
+++ b/src/rust/catnip/mod.rs
@@ -46,7 +46,10 @@ use ::std::{
         DerefMut,
     },
     rc::Rc,
-    time::Instant,
+    time::{
+        Instant,
+        SystemTime,
+    },
 };
 
 #[cfg(feature = "profiler")]
@@ -157,6 +160,16 @@ impl CatnipLibOS {
         trace!("wait(): qt={:?}", qt);
 
         let (qd, result): (QDesc, OperationResult) = self.wait2(qt)?;
+        Ok(pack_result(self.rt.clone(), result, qd, qt.into()))
+    }
+
+    /// Waits for an I/O operation to complete or a timeout to expire.
+    pub fn timedwait(&mut self, qt: QToken, abstime: Option<SystemTime>) -> Result<demi_qresult_t, Fail> {
+        #[cfg(feature = "profiler")]
+        timer!("catnip::timedwait");
+        trace!("timedwait() qt={:?}, timeout={:?}", qt, abstime);
+
+        let (qd, result): (QDesc, OperationResult) = self.timedwait2(qt, abstime)?;
         Ok(pack_result(self.rt.clone(), result, qd, qt.into()))
     }
 

--- a/src/rust/catpowder/mod.rs
+++ b/src/rust/catpowder/mod.rs
@@ -46,7 +46,10 @@ use ::std::{
         DerefMut,
     },
     rc::Rc,
-    time::Instant,
+    time::{
+        Instant,
+        SystemTime,
+    },
 };
 
 #[cfg(feature = "profiler")]
@@ -152,6 +155,16 @@ impl CatpowderLibOS {
         trace!("wait(): qt={:?}", qt);
 
         let (qd, result): (QDesc, OperationResult) = self.wait2(qt)?;
+        Ok(pack_result(self.rt.clone(), result, qd, qt.into()))
+    }
+
+    /// Waits for an I/O operation to complete or a timeout to expire.
+    pub fn timedwait(&mut self, qt: QToken, abstime: Option<SystemTime>) -> Result<demi_qresult_t, Fail> {
+        #[cfg(feature = "profiler")]
+        timer!("catpowder::timedwait");
+        trace!("timedwait() qt={:?}, timeout={:?}", qt, abstime);
+
+        let (qd, result): (QDesc, OperationResult) = self.timedwait2(qt, abstime)?;
         Ok(pack_result(self.rt.clone(), result, qd, qt.into()))
     }
 

--- a/src/rust/demikernel/libos/mod.rs
+++ b/src/rust/demikernel/libos/mod.rs
@@ -28,9 +28,10 @@ use crate::{
         QToken,
     },
 };
-use std::{
+use ::std::{
     env,
     net::SocketAddrV4,
+    time::SystemTime,
 };
 
 #[cfg(feature = "catcollar-libos")]
@@ -191,6 +192,13 @@ impl LibOS {
     pub fn wait(&mut self, qt: QToken) -> Result<demi_qresult_t, Fail> {
         match self {
             LibOS::NetworkLibOS(libos) => libos.wait(qt),
+        }
+    }
+
+    /// Waits for an I/O operation to complete or a timeout to expire.
+    pub fn timedwait(&mut self, qt: QToken, abstime: Option<SystemTime>) -> Result<demi_qresult_t, Fail> {
+        match self {
+            LibOS::NetworkLibOS(libos) => libos.timedwait(qt, abstime),
         }
     }
 

--- a/src/rust/demikernel/libos/network.rs
+++ b/src/rust/demikernel/libos/network.rs
@@ -14,7 +14,10 @@ use crate::runtime::{
     QDesc,
     QToken,
 };
-use ::std::net::SocketAddrV4;
+use ::std::{
+    net::SocketAddrV4,
+    time::SystemTime,
+};
 
 #[cfg(feature = "catcollar-libos")]
 use crate::catcollar::CatcollarLibOS;
@@ -251,6 +254,21 @@ impl NetworkLibOS {
             NetworkLibOS::Catcollar(libos) => libos.wait(qt),
             #[cfg(feature = "catnip-libos")]
             NetworkLibOS::Catnip(libos) => libos.wait(qt),
+        }
+    }
+
+    /// Waits for an I/O operation to complete or a timeout to expire.
+    #[allow(unreachable_patterns)]
+    pub fn timedwait(&mut self, qt: QToken, abstime: Option<SystemTime>) -> Result<demi_qresult_t, Fail> {
+        match self {
+            #[cfg(feature = "catpowder-libos")]
+            NetworkLibOS::Catpowder(libos) => libos.timedwait(qt, abstime),
+            #[cfg(feature = "catnap-libos")]
+            NetworkLibOS::Catnap(libos) => libos.timedwait(qt, abstime),
+            #[cfg(feature = "catcollar-libos")]
+            NetworkLibOS::Catcollar(libos) => libos.timedwait(qt, abstime),
+            #[cfg(feature = "catnip-libos")]
+            NetworkLibOS::Catnip(libos) => libos.timedwait(qt, abstime),
         }
     }
 

--- a/tests/c/Makefile
+++ b/tests/c/Makefile
@@ -10,4 +10,3 @@
 include linux.mk
 #                     \
 !endif
-

--- a/tests/c/linux.mk
+++ b/tests/c/linux.mk
@@ -12,6 +12,7 @@ export CARGO_FLAGS += --profile $(BUILD)
 # C
 export CC := gcc
 export CFLAGS := -Werror -Wall -Wextra -O3 -I $(INCDIR) -std=c99
+export CFLAGS += -D_POSIX_C_SOURCE=199309L
 
 #=======================================================================================================================
 # Build Artifacts

--- a/tests/c/syscalls.c
+++ b/tests/c/syscalls.c
@@ -153,6 +153,18 @@ static bool inval_sgafree(void)
  *===================================================================================================================*/
 
 /**
+ * @brief Issues an invalid system call to demi_timedwait().
+ */
+static bool inval_timedwait(void)
+{
+    struct timespec abstime;
+    demi_qresult_t *qr = NULL;
+    demi_qtoken_t qt = -1;
+
+    return (demi_timedwait(qr, qt, &abstime) != 0);
+}
+
+/**
  * @brief Issues an invalid system call to demi_wait().
  */
 static bool inval_wait(void)
@@ -207,7 +219,9 @@ static struct test tests_sga[] = {{inval_sgaalloc, "invalid demi_sgaalloc()"},
 /**
  * @brief Tests for system calls in demi/wait.h
  */
-static struct test tests_wait[] = {{inval_wait, "invalid demi_wait()"}, {inval_wait_any, "invalid demi_wait_any()"}};
+static struct test tests_wait[] = {{inval_timedwait, "invalid demi_timedwait()"},
+                                   {inval_wait, "invalid demi_wait()"},
+                                   {inval_wait_any, "invalid demi_wait_any()"}};
 
 /**
  * @brief Drives the application.


### PR DESCRIPTION
Description
-------------

This PR partially fixes https://github.com/demikernel/demikernel/issues/61.

Summary of Changes
------------------------

- Added `timedwait()` system call to PDPIX
- Added implementation of `timedwait()` for Catnap, Catnip, Catpowder and Catcollar LibOses
- Added manual pages for `timedwait()`
- Added invalided system call unit test for `timedwait()`