### PR TITLE
[catnap][catcollar] `demi_socket()` Fails with `EADDRINUSE`

### DIFF
--- a/src/rust/catcollar/futures/accept.rs
+++ b/src/rust/catcollar/futures/accept.rs
@@ -5,13 +5,12 @@
 // Imports
 //==============================================================================
 
-use crate::runtime::{
-    fail::Fail,
-    QDesc,
-};
-use ::libc::{
-    c_void,
-    socklen_t,
+use crate::{
+    pal::linux,
+    runtime::{
+        fail::Fail,
+        QDesc,
+    },
 };
 use ::nix::{
     errno::Errno,
@@ -19,7 +18,6 @@ use ::nix::{
 };
 use ::std::{
     future::Future,
-    mem::size_of_val,
     os::unix::prelude::RawFd,
     pin::Pin,
     task::{
@@ -82,13 +80,16 @@ impl Future for AcceptFuture {
             Ok(new_fd) => {
                 trace!("connection accepted ({:?})", new_fd);
 
-                // Set async options in socket.
+                // Set socket options.
                 unsafe {
-                    if set_tcp_nodelay(new_fd) != 0 {
+                    if linux::set_tcp_nodelay(new_fd) != 0 {
                         warn!("cannot set TCP_NONDELAY option");
                     }
-                    if set_nonblock(new_fd) != 0 {
+                    if linux::set_nonblock(new_fd) != 0 {
                         warn!("cannot set NONBLOCK option");
+                    }
+                    if linux::set_so_reuseport(new_fd) != 0 {
+                        warn!("cannot set SO_REUSEPORT option");
                     }
                 }
 
@@ -106,36 +107,4 @@ impl Future for AcceptFuture {
             },
         }
     }
-}
-
-//==============================================================================
-// Standalone Functions
-//==============================================================================
-
-/// Sets TCP_NODELAY option in a socket.
-unsafe fn set_tcp_nodelay(fd: RawFd) -> i32 {
-    let value: u32 = 1;
-    let value_ptr: *const u32 = &value as *const u32;
-    let option_len: socklen_t = size_of_val(&value) as socklen_t;
-    libc::setsockopt(
-        fd,
-        libc::IPPROTO_TCP,
-        libc::TCP_NODELAY,
-        value_ptr as *const c_void,
-        option_len,
-    )
-}
-
-/// Sets NONBLOCK option in a socket.
-unsafe fn set_nonblock(fd: RawFd) -> i32 {
-    // Get file flags.
-    let mut flags: i32 = libc::fcntl(fd, libc::F_GETFL);
-    if flags == -1 {
-        warn!("failed to get flags for new socket");
-        return -1;
-    }
-
-    // Set file flags.
-    flags |= libc::O_NONBLOCK;
-    libc::fcntl(fd, libc::F_SETFL, flags, 1)
 }

--- a/src/rust/catcollar/mod.rs
+++ b/src/rust/catcollar/mod.rs
@@ -141,6 +141,10 @@ impl CatcollarLibOS {
         // Create socket.
         match socket::socket(domain, ty, flags, protocol) {
             Ok(fd) => {
+                // Try to set SO_REUSEPORT option. If we fail, keep going because this is non-critical.
+                if socket::setsockopt(fd, socket::sockopt::ReusePort, &true).is_err() {
+                    warn!("cannot set SO_REUSEPORT option");
+                }
                 let qtype: QType = QType::TcpSocket;
                 let qd: QDesc = self.qtable.alloc(qtype.into());
                 assert_eq!(self.sockets.insert(qd, fd).is_none(), true);

--- a/src/rust/catnap/mod.rs
+++ b/src/rust/catnap/mod.rs
@@ -140,6 +140,10 @@ impl CatnapLibOS {
         // Create socket.
         match socket::socket(domain, ty, flags, protocol) {
             Ok(fd) => {
+                // Try to set SO_REUSEPORT option. If we fail, keep going because this is non-critical.
+                if socket::setsockopt(fd, socket::sockopt::ReusePort, &true).is_err() {
+                    warn!("cannot set SO_REUSEPORT option");
+                }
                 let qtype: QType = QType::TcpSocket;
                 let qd: QDesc = self.qtable.alloc(qtype.into());
                 assert_eq!(self.sockets.insert(qd, fd).is_none(), true);

--- a/src/rust/lib.rs
+++ b/src/rust/lib.rs
@@ -12,6 +12,7 @@
 #![feature(allocator_api)]
 
 mod collections;
+mod pal;
 
 #[cfg(feature = "profiler")]
 pub mod perftools;

--- a/src/rust/pal/linux.rs
+++ b/src/rust/pal/linux.rs
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//======================================================================================================================
+// Imports
+//======================================================================================================================
+
+use ::std::{
+    mem,
+    os::unix::prelude::RawFd,
+};
+
+//======================================================================================================================
+// Standalone Functions
+//======================================================================================================================
+
+/// Sets TCP_NODELAY option in a socket.
+pub unsafe fn set_tcp_nodelay(fd: RawFd) -> i32 {
+    let value: u32 = 1;
+    let value_ptr: *const u32 = &value as *const u32;
+    let option_len: libc::socklen_t = mem::size_of_val(&value) as libc::socklen_t;
+    libc::setsockopt(
+        fd,
+        libc::IPPROTO_TCP,
+        libc::TCP_NODELAY,
+        value_ptr as *const libc::c_void,
+        option_len,
+    )
+}
+
+/// Sets SO_REUSEPORT option in a socket.
+pub unsafe fn set_so_reuseport(fd: RawFd) -> i32 {
+    let value: u32 = 1;
+    let value_ptr: *const u32 = &value as *const u32;
+    let option_len: libc::socklen_t = mem::size_of_val(&value) as libc::socklen_t;
+    libc::setsockopt(
+        fd,
+        libc::IPPROTO_TCP,
+        libc::SO_REUSEPORT,
+        value_ptr as *const libc::c_void,
+        option_len,
+    )
+}
+
+/// Sets NONBLOCK option in a socket.
+pub unsafe fn set_nonblock(fd: RawFd) -> i32 {
+    // Get file flags.
+    let mut flags: i32 = libc::fcntl(fd, libc::F_GETFL);
+    if flags == -1 {
+        warn!("failed to get flags for new socket");
+        return -1;
+    }
+
+    // Set file flags.
+    flags |= libc::O_NONBLOCK;
+    libc::fcntl(fd, libc::F_SETFL, flags, 1)
+}

--- a/src/rust/pal/mod.rs
+++ b/src/rust/pal/mod.rs
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+pub mod linux;


### PR DESCRIPTION
Description
-------------

This PR fixes https://github.com/demikernel/demikernel/issues/281 and https://github.com/demikernel/demikernel/issues/282.

Summary of Changes
------------------------

- Introduced a PAL (Platform Abstraction Play) module for placing platform-specific code.
- Fixed Catnap to set `SO_REUSEPORT` when creating sockets.
- Fixed Catcollar to set `SO_REUSEPORT` when creating sockets.