### PR TITLE
[catnip] Bug Fix: Don't Trim on SGA Clone

### DIFF
--- a/src/rust/catnip/runtime/memory/manager.rs
+++ b/src/rust/catnip/runtime/memory/manager.rs
@@ -219,13 +219,7 @@ impl MemoryManager {
                 Ok(mbuf_ptr) => mbuf_ptr,
                 Err(e) => panic!("failed to clone mbuf: {:?}", e.cause),
             };
-            let mut mbuf: DPDKBuffer = DPDKBuffer::new(body_clone);
-            // Adjust buffer length.
-            // TODO: Replace the following method for computing the length of a mbuf once we have a proper DPDKBuffer abstraction.
-            let orig_len: usize = unsafe { ((*mbuf_ptr).buf_len - (*mbuf_ptr).data_off).into() };
-            let trim: usize = orig_len - len;
-            mbuf.trim(trim);
-            Buffer::DPDK(mbuf)
+            Buffer::DPDK(DPDKBuffer::new(body_clone))
         } else {
             // Clone heap-managed buffer.
             let seg_slice: &[u8] = unsafe { slice::from_raw_parts(ptr as *const u8, len) };

--- a/src/rust/runtime/memory/buffer/dpdkbuffer.rs
+++ b/src/rust/runtime/memory/buffer/dpdkbuffer.rs
@@ -43,7 +43,7 @@ pub struct DPDKBuffer {
 impl DPDKBuffer {
     /// Removes `len` bytes at the beginning of the target [Mbuf].
     pub fn adjust(&mut self, nbytes: usize) {
-        assert!(nbytes <= self.len());
+        assert!(nbytes <= self.len(), "nbytes={:?} self.len()={:?}", nbytes, self.len());
         if unsafe { rte_pktmbuf_adj(self.ptr, nbytes as u16) } == ptr::null_mut() {
             panic!("rte_pktmbuf_adj failed");
         }
@@ -51,6 +51,7 @@ impl DPDKBuffer {
 
     /// Removes `len` bytes at the end of the target [Mbuf].
     pub fn trim(&mut self, nbytes: usize) {
+        assert!(nbytes <= self.len(), "nbytes={:?} self.len()={:?}", nbytes, self.len());
         assert!(nbytes <= self.len());
         if unsafe { rte_pktmbuf_trim(self.ptr, nbytes as u16) } != 0 {
             panic!("rte_pktmbuf_trim failed");


### PR DESCRIPTION
Description
-------------

This PR fixes https://github.com/demikernel/demikernel/issues/299.

Summary of Changes
------------------------

- Changed `DPDKBuffer::adjust()` to dump arguments that cause a panic
- Changed `DPDKBuffer::trim()` to dump arguments that cause a panic.
- Removed call to `DPDKBuffer:trim()` when cloning scatter-gather arrays.