### PR TITLE
[pdpix] Wrong Conversions Between `DataBuffer` and `demi_sgarray_t`

### DIFF
--- a/src/rust/catcollar/runtime/memory.rs
+++ b/src/rust/catcollar/runtime/memory.rs
@@ -21,7 +21,6 @@ use crate::runtime::{
 use ::libc::c_void;
 use ::std::{
     mem,
-    ptr,
     slice,
 };
 
@@ -35,18 +34,21 @@ impl MemoryRuntime for IoUringRuntime {
     fn into_sgarray(&self, buf: Buffer) -> Result<demi_sgarray_t, Fail> {
         let len: usize = buf.len();
         #[allow(unreachable_patterns)]
-        let sgaseg: demi_sgaseg_t = match buf {
+        let (dbuf_ptr, sgaseg): (*const u8, demi_sgaseg_t) = match buf {
             Buffer::Heap(dbuf) => {
-                let dbuf_ptr: *const [u8] = DataBuffer::into_raw(Clone::clone(&dbuf))?;
-                demi_sgaseg_t {
-                    sgaseg_buf: dbuf_ptr as *mut c_void,
-                    sgaseg_len: len as u32,
-                }
+                let (dbuf_ptr, data_ptr): (*const u8, *const u8) = DataBuffer::into_raw_parts(Clone::clone(&dbuf))?;
+                (
+                    dbuf_ptr,
+                    demi_sgaseg_t {
+                        sgaseg_buf: data_ptr as *mut c_void,
+                        sgaseg_len: len as u32,
+                    },
+                )
             },
             _ => return Err(Fail::new(libc::EINVAL, "invalid buffer type")),
         };
         Ok(demi_sgarray_t {
-            sga_buf: ptr::null_mut(),
+            sga_buf: dbuf_ptr as *mut c_void,
             sga_numsegs: 1,
             sga_segs: [sgaseg],
             sga_addr: unsafe { mem::zeroed() },
@@ -57,13 +59,13 @@ impl MemoryRuntime for IoUringRuntime {
     fn alloc_sgarray(&self, size: usize) -> Result<demi_sgarray_t, Fail> {
         // Allocate a heap-managed buffer.
         let dbuf: DataBuffer = DataBuffer::new(size)?;
-        let dbuf_ptr: *const [u8] = DataBuffer::into_raw(dbuf)?;
+        let (dbuf_ptr, data_ptr): (*const u8, *const u8) = DataBuffer::into_raw_parts(dbuf)?;
         let sgaseg: demi_sgaseg_t = demi_sgaseg_t {
-            sgaseg_buf: dbuf_ptr as *mut c_void,
+            sgaseg_buf: data_ptr as *mut c_void,
             sgaseg_len: size as u32,
         };
         Ok(demi_sgarray_t {
-            sga_buf: ptr::null_mut(),
+            sga_buf: dbuf_ptr as *mut c_void,
             sga_numsegs: 1,
             sga_segs: [sgaseg],
             sga_addr: unsafe { mem::zeroed() },
@@ -79,11 +81,8 @@ impl MemoryRuntime for IoUringRuntime {
         }
 
         // Release heap-managed buffer.
-        let sgaseg: demi_sgaseg_t = sga.sga_segs[0];
-        let (data_ptr, length): (*mut u8, usize) = (sgaseg.sgaseg_buf as *mut u8, sgaseg.sgaseg_len as usize);
-
-        // Convert back raw slice to a heap buffer and drop allocation.
-        DataBuffer::from_raw_parts(data_ptr, length)?;
+        let (dbuf_ptr, length): (*mut u8, usize) = (sga.sga_buf as *mut u8, sga.sga_segs[0].sgaseg_len as usize);
+        DataBuffer::from_raw_parts(dbuf_ptr, length)?;
 
         Ok(())
     }
@@ -97,10 +96,13 @@ impl MemoryRuntime for IoUringRuntime {
         }
 
         let sgaseg: demi_sgaseg_t = sga.sga_segs[0];
-        let (ptr, len): (*mut c_void, usize) = (sgaseg.sgaseg_buf, sgaseg.sgaseg_len as usize);
+        let (dbuf_ptr, len): (*mut c_void, usize) = (sga.sga_buf, sgaseg.sgaseg_len as usize);
 
-        Ok(Buffer::Heap(DataBuffer::from_slice(unsafe {
-            slice::from_raw_parts(ptr as *const u8, len)
-        })))
+        // Clone heap-managed buffer.
+        let seg_slice: &[u8] = unsafe { slice::from_raw_parts(dbuf_ptr as *const u8, len) };
+        let mut dbuf: DataBuffer = DataBuffer::from_slice(seg_slice);
+        let nbytes: usize = unsafe { sgaseg.sgaseg_buf.sub_ptr(sga.sga_buf) };
+        dbuf.adjust(nbytes);
+        Ok(Buffer::Heap(dbuf))
     }
 }

--- a/src/rust/catnap/runtime.rs
+++ b/src/rust/catnap/runtime.rs
@@ -24,7 +24,6 @@ use crate::{
 use ::libc::c_void;
 use ::std::{
     mem,
-    ptr,
     slice,
 };
 
@@ -62,18 +61,21 @@ impl MemoryRuntime for PosixRuntime {
     fn into_sgarray(&self, buf: Buffer) -> Result<demi_sgarray_t, Fail> {
         let len: usize = buf.len();
         #[allow(unreachable_patterns)]
-        let sgaseg: demi_sgaseg_t = match buf {
+        let (dbuf_ptr, sgaseg): (*const u8, demi_sgaseg_t) = match buf {
             Buffer::Heap(dbuf) => {
-                let dbuf_ptr: *const [u8] = DataBuffer::into_raw(Clone::clone(&dbuf))?;
-                demi_sgaseg_t {
-                    sgaseg_buf: dbuf_ptr as *mut c_void,
-                    sgaseg_len: len as u32,
-                }
+                let (dbuf_ptr, data_ptr): (*const u8, *const u8) = DataBuffer::into_raw_parts(Clone::clone(&dbuf))?;
+                (
+                    dbuf_ptr,
+                    demi_sgaseg_t {
+                        sgaseg_buf: data_ptr as *mut c_void,
+                        sgaseg_len: len as u32,
+                    },
+                )
             },
             _ => return Err(Fail::new(libc::EINVAL, "invalid buffer type")),
         };
         Ok(demi_sgarray_t {
-            sga_buf: ptr::null_mut(),
+            sga_buf: dbuf_ptr as *mut c_void,
             sga_numsegs: 1,
             sga_segs: [sgaseg],
             sga_addr: unsafe { mem::zeroed() },
@@ -84,13 +86,13 @@ impl MemoryRuntime for PosixRuntime {
     fn alloc_sgarray(&self, size: usize) -> Result<demi_sgarray_t, Fail> {
         // Allocate a heap-managed buffer.
         let dbuf: DataBuffer = DataBuffer::new(size)?;
-        let dbuf_ptr: *const [u8] = DataBuffer::into_raw(dbuf)?;
+        let (dbuf_ptr, data_ptr): (*const u8, *const u8) = DataBuffer::into_raw_parts(dbuf)?;
         let sgaseg: demi_sgaseg_t = demi_sgaseg_t {
-            sgaseg_buf: dbuf_ptr as *mut c_void,
+            sgaseg_buf: data_ptr as *mut c_void,
             sgaseg_len: size as u32,
         };
         Ok(demi_sgarray_t {
-            sga_buf: ptr::null_mut(),
+            sga_buf: dbuf_ptr as *mut c_void,
             sga_numsegs: 1,
             sga_segs: [sgaseg],
             sga_addr: unsafe { mem::zeroed() },
@@ -106,11 +108,8 @@ impl MemoryRuntime for PosixRuntime {
         }
 
         // Release heap-managed buffer.
-        let sgaseg: demi_sgaseg_t = sga.sga_segs[0];
-        let (data_ptr, length): (*mut u8, usize) = (sgaseg.sgaseg_buf as *mut u8, sgaseg.sgaseg_len as usize);
-
-        // Convert back raw slice to a heap buffer and drop allocation.
-        DataBuffer::from_raw_parts(data_ptr, length)?;
+        let (dbuf_ptr, length): (*mut u8, usize) = (sga.sga_buf as *mut u8, sga.sga_segs[0].sgaseg_len as usize);
+        DataBuffer::from_raw_parts(dbuf_ptr, length)?;
 
         Ok(())
     }
@@ -124,11 +123,14 @@ impl MemoryRuntime for PosixRuntime {
         }
 
         let sgaseg: demi_sgaseg_t = sga.sga_segs[0];
-        let (ptr, len): (*mut c_void, usize) = (sgaseg.sgaseg_buf, sgaseg.sgaseg_len as usize);
+        let (dbuf_ptr, len): (*mut c_void, usize) = (sga.sga_buf, sgaseg.sgaseg_len as usize);
 
-        Ok(Buffer::Heap(DataBuffer::from_slice(unsafe {
-            slice::from_raw_parts(ptr as *const u8, len)
-        })))
+        // Clone heap-managed buffer.
+        let seg_slice: &[u8] = unsafe { slice::from_raw_parts(dbuf_ptr as *const u8, len) };
+        let mut dbuf: DataBuffer = DataBuffer::from_slice(seg_slice);
+        let nbytes: usize = unsafe { sgaseg.sgaseg_buf.sub_ptr(sga.sga_buf) };
+        dbuf.adjust(nbytes);
+        Ok(Buffer::Heap(dbuf))
     }
 }
 

--- a/src/rust/lib.rs
+++ b/src/rust/lib.rs
@@ -12,6 +12,8 @@
 #![feature(test)]
 #![feature(type_alias_impl_trait)]
 #![feature(allocator_api)]
+#![feature(slice_ptr_get)]
+#![feature(ptr_sub_ptr)]
 
 mod collections;
 mod pal;

--- a/src/rust/runtime/memory/buffer/databuffer.rs
+++ b/src/rust/runtime/memory/buffer/databuffer.rs
@@ -94,11 +94,13 @@ impl DataBuffer {
         })
     }
 
-    /// Consumes the data buffer returning a raw pointer to the underlying data.
-    pub fn into_raw(dbuf: DataBuffer) -> Result<*const [u8], Fail> {
+    /// Consumes the data buffer returning a raw pointer to the underlying buffer and data.
+    pub fn into_raw_parts(dbuf: DataBuffer) -> Result<(*const u8, *const u8), Fail> {
         if let Some(data) = dbuf.data {
-            let data_ptr: *const [u8] = Arc::<[u8]>::into_raw(data);
-            return Ok(data_ptr);
+            let offset: usize = dbuf.offset;
+            let dbuf_ptr: *const u8 = Arc::<[u8]>::into_raw(data).as_ptr();
+            let data_ptr: *const u8 = unsafe { dbuf_ptr.add(offset) };
+            return Ok((dbuf_ptr, data_ptr));
         }
 
         Err(Fail::new(libc::EINVAL, "zero-length buffer"))


### PR DESCRIPTION
Description
-------------

This PR fixes https://github.com/demikernel/demikernel/issues/301.

Summary of Changes
------------------------

- Renamed the `DataBuffer::into_raw()` to `DataBuffer::into_raw_parts()`.
- Changed `DataBuffer::into_raw_parts()` to return a pair of pointers (one for the start of the buffer and one for the start of the data)
- Changed scatter-gather management in LibOSes accordingly.