### PR TITLE
[pdpix] Drop Deprecated System Calls

### DIFF
--- a/src/rust/catnap/mod.rs
+++ b/src/rust/catnap/mod.rs
@@ -356,7 +356,22 @@ impl CatnapLibOS {
         timer!("catnap::wait");
         trace!("wait() qt={:?}", qt);
 
-        let (qd, result): (QDesc, OperationResult) = self.wait2(qt)?;
+        // Retrieve associated schedule handle.
+        let handle: SchedulerHandle = match self.runtime.scheduler.from_raw_handle(qt.into()) {
+            Some(handle) => handle,
+            None => return Err(Fail::new(libc::EINVAL, "invalid queue token")),
+        };
+
+        let (qd, result): (QDesc, OperationResult) = loop {
+            // Poll first, so as to give pending operations a chance to complete.
+            self.runtime.scheduler.poll();
+
+            // The operation has completed, so extract the result and return.
+            if handle.has_completed() {
+                break self.take_result(handle);
+            }
+        };
+
         Ok(pack_result(&self.runtime, result, qd, qt.into()))
     }
 
@@ -390,29 +405,6 @@ impl CatnapLibOS {
         };
 
         Ok(pack_result(&self.runtime, result, qd, qt.into()))
-    }
-
-    /// Waits for an operation to complete.
-    pub fn wait2(&mut self, qt: QToken) -> Result<(QDesc, OperationResult), Fail> {
-        #[cfg(feature = "profiler")]
-        timer!("catnap::wait2");
-        trace!("wait2() qt={:?}", qt);
-
-        // Retrieve associated schedule handle.
-        let handle: SchedulerHandle = match self.runtime.scheduler.from_raw_handle(qt.into()) {
-            Some(handle) => handle,
-            None => return Err(Fail::new(libc::EINVAL, "invalid queue token")),
-        };
-
-        loop {
-            // Poll first, so as to give pending operations a chance to complete.
-            self.runtime.scheduler.poll();
-
-            // The operation has completed, so extract the result and return.
-            if handle.has_completed() {
-                return Ok(self.take_result(handle));
-            }
-        }
     }
 
     /// Waits for any operation to complete.

--- a/src/rust/catnap/mod.rs
+++ b/src/rust/catnap/mod.rs
@@ -413,16 +413,6 @@ impl CatnapLibOS {
         timer!("catnap::wait_any");
         trace!("wait_any(): qts={:?}", qts);
 
-        let (i, qd, r): (usize, QDesc, OperationResult) = self.wait_any2(qts)?;
-        Ok((i, pack_result(&self.runtime, r, qd, qts[i].into())))
-    }
-
-    /// Waits for any operation to complete.
-    pub fn wait_any2(&mut self, qts: &[QToken]) -> Result<(usize, QDesc, OperationResult), Fail> {
-        #[cfg(feature = "profiler")]
-        timer!("catnap::wait_any2");
-        trace!("wait_any2() {:?}", qts);
-
         loop {
             // Poll first, so as to give pending operations a chance to complete.
             self.runtime.scheduler.poll();
@@ -438,7 +428,7 @@ impl CatnapLibOS {
                 // Found one, so extract the result and return.
                 if handle.has_completed() {
                     let (qd, r): (QDesc, OperationResult) = self.take_result(handle);
-                    return Ok((i, qd, r));
+                    return Ok((i, pack_result(&self.runtime, r, qd, qts[i].into())));
                 }
 
                 // Return this operation to the scheduling queue by removing the associated key

--- a/src/rust/catnip/mod.rs
+++ b/src/rust/catnip/mod.rs
@@ -159,7 +159,23 @@ impl CatnipLibOS {
         timer!("catnip::wait");
         trace!("wait(): qt={:?}", qt);
 
-        let (qd, result): (QDesc, OperationResult) = self.wait2(qt)?;
+        // Retrieve associated schedule handle.
+        let handle: SchedulerHandle = match self.scheduler.from_raw_handle(qt.into()) {
+            Some(handle) => handle,
+            None => return Err(Fail::new(libc::EINVAL, "invalid queue token")),
+        };
+
+        let (qd, result): (QDesc, OperationResult) = loop {
+            // Poll first, so as to give pending operations a chance to complete.
+            self.poll_bg_work();
+
+            // The operation has completed, so extract the result and return.
+            if handle.has_completed() {
+                trace!("wait2() qt={:?} completed!", qt);
+                break self.take_operation(handle);
+            }
+        };
+
         Ok(pack_result(self.rt.clone(), result, qd, qt.into()))
     }
 

--- a/src/rust/catnip/mod.rs
+++ b/src/rust/catnip/mod.rs
@@ -195,8 +195,30 @@ impl CatnipLibOS {
         timer!("catnip::wait_any");
         trace!("wait_any(): qts={:?}", qts);
 
-        let (i, qd, r): (usize, QDesc, OperationResult) = self.wait_any2(qts)?;
-        Ok((i, pack_result(self.rt.clone(), r, qd, qts[i].into())))
+        loop {
+            // Poll first, so as to give pending operations a chance to complete.
+            self.poll_bg_work();
+
+            // Search for any operation that has completed.
+            for (i, &qt) in qts.iter().enumerate() {
+                // Retrieve associated schedule handle.
+                // TODO: move this out of the loop.
+                let mut handle: SchedulerHandle = match self.scheduler.from_raw_handle(qt.into()) {
+                    Some(handle) => handle,
+                    None => return Err(Fail::new(libc::EINVAL, "invalid queue token")),
+                };
+
+                // Found one, so extract the result and return.
+                if handle.has_completed() {
+                    let (qd, r): (QDesc, OperationResult) = self.take_operation(handle);
+                    return Ok((i, pack_result(self.rt.clone(), r, qd, qts[i].into())));
+                }
+
+                // Return this operation to the scheduling queue by removing the associated key
+                // (which would otherwise cause the operation to be freed).
+                handle.take_key();
+            }
+        }
     }
 
     /// Allocates a scatter-gather array.

--- a/src/rust/catpowder/mod.rs
+++ b/src/rust/catpowder/mod.rs
@@ -154,7 +154,23 @@ impl CatpowderLibOS {
         timer!("catpowder::wait");
         trace!("wait(): qt={:?}", qt);
 
-        let (qd, result): (QDesc, OperationResult) = self.wait2(qt)?;
+        // Retrieve associated schedule handle.
+        let handle: SchedulerHandle = match self.scheduler.from_raw_handle(qt.into()) {
+            Some(handle) => handle,
+            None => return Err(Fail::new(libc::EINVAL, "invalid queue token")),
+        };
+
+        let (qd, result): (QDesc, OperationResult) = loop {
+            // Poll first, so as to give pending operations a chance to complete.
+            self.poll_bg_work();
+
+            // The operation has completed, so extract the result and return.
+            if handle.has_completed() {
+                trace!("wait2() qt={:?} completed!", qt);
+                break self.take_operation(handle);
+            }
+        };
+
         Ok(pack_result(self.rt.clone(), result, qd, qt.into()))
     }
 

--- a/src/rust/demikernel/libos/mod.rs
+++ b/src/rust/demikernel/libos/mod.rs
@@ -100,14 +100,6 @@ impl LibOS {
         }
     }
 
-    /// Waits on a pending operation in an I/O queue.
-    #[deprecated]
-    pub fn wait2(&mut self, qt: QToken) -> Result<(QDesc, OperationResult), Fail> {
-        match self {
-            LibOS::NetworkLibOS(libos) => libos.wait2(qt),
-        }
-    }
-
     /// Creates a socket.
     pub fn socket(
         &mut self,

--- a/src/rust/demikernel/libos/mod.rs
+++ b/src/rust/demikernel/libos/mod.rs
@@ -92,14 +92,6 @@ impl LibOS {
         Ok(libos)
     }
 
-    /// Waits on a pending operation in an I/O queue.
-    #[deprecated]
-    pub fn wait_any2(&mut self, qts: &[QToken]) -> Result<(usize, QDesc, OperationResult), Fail> {
-        match self {
-            LibOS::NetworkLibOS(libos) => libos.wait_any2(qts),
-        }
-    }
-
     /// Creates a socket.
     pub fn socket(
         &mut self,

--- a/src/rust/demikernel/libos/mod.rs
+++ b/src/rust/demikernel/libos/mod.rs
@@ -10,10 +10,7 @@ pub mod network;
 
 use self::{
     name::LibOSName,
-    network::{
-        NetworkLibOS,
-        OperationResult,
-    },
+    network::NetworkLibOS,
 };
 use crate::{
     demikernel::config::Config,

--- a/src/rust/demikernel/libos/mod.rs
+++ b/src/rust/demikernel/libos/mod.rs
@@ -153,14 +153,6 @@ impl LibOS {
         }
     }
 
-    /// Pushes raw data to a UDP socket.
-    #[deprecated]
-    pub fn pushto2(&mut self, qd: QDesc, data: &[u8], remote: SocketAddrV4) -> Result<QToken, Fail> {
-        match self {
-            LibOS::NetworkLibOS(libos) => libos.pushto2(qd, data, remote),
-        }
-    }
-
     /// Pops data from a socket.
     pub fn pop(&mut self, qd: QDesc) -> Result<QToken, Fail> {
         match self {

--- a/src/rust/demikernel/libos/mod.rs
+++ b/src/rust/demikernel/libos/mod.rs
@@ -146,14 +146,6 @@ impl LibOS {
         }
     }
 
-    /// Pushes raw data to a TCP socket.
-    #[deprecated]
-    pub fn push2(&mut self, qd: QDesc, data: &[u8]) -> Result<QToken, Fail> {
-        match self {
-            LibOS::NetworkLibOS(libos) => libos.push2(qd, data),
-        }
-    }
-
     /// Pushes a scatter-gather array to a UDP socket.
     pub fn pushto(&mut self, qd: QDesc, sga: &demi_sgarray_t, to: SocketAddrV4) -> Result<QToken, Fail> {
         match self {

--- a/src/rust/demikernel/libos/network.rs
+++ b/src/rust/demikernel/libos/network.rs
@@ -173,21 +173,6 @@ impl NetworkLibOS {
         }
     }
 
-    /// Pushes raw data to a UDP socket.
-    #[deprecated]
-    pub fn pushto2(&mut self, sockqd: QDesc, data: &[u8], remote: SocketAddrV4) -> Result<QToken, Fail> {
-        match self {
-            #[cfg(feature = "catpowder-libos")]
-            NetworkLibOS::Catpowder(libos) => libos.pushto2(sockqd, data, remote),
-            #[cfg(feature = "catnap-libos")]
-            NetworkLibOS::Catnap(libos) => libos.pushto2(sockqd, data, remote),
-            #[cfg(feature = "catcollar-libos")]
-            NetworkLibOS::Catcollar(libos) => libos.pushto2(sockqd, data, remote),
-            #[cfg(feature = "catnip-libos")]
-            NetworkLibOS::Catnip(libos) => libos.pushto2(sockqd, data, remote),
-        }
-    }
-
     /// Pops data from a socket.
     pub fn pop(&mut self, sockqd: QDesc) -> Result<QToken, Fail> {
         match self {

--- a/src/rust/demikernel/libos/network.rs
+++ b/src/rust/demikernel/libos/network.rs
@@ -56,21 +56,6 @@ pub enum NetworkLibOS {
 
 /// Associated functions for network LibOSes.
 impl NetworkLibOS {
-    /// Waits on a pending operation in an I/O queue.
-    #[deprecated]
-    pub fn wait_any2(&mut self, qts: &[QToken]) -> Result<(usize, QDesc, OperationResult), Fail> {
-        match self {
-            #[cfg(feature = "catpowder-libos")]
-            NetworkLibOS::Catpowder(libos) => libos.wait_any2(qts),
-            #[cfg(feature = "catnap-libos")]
-            NetworkLibOS::Catnap(libos) => libos.wait_any2(qts),
-            #[cfg(feature = "catcollar-libos")]
-            NetworkLibOS::Catcollar(libos) => libos.wait_any2(qts),
-            #[cfg(feature = "catnip-libos")]
-            NetworkLibOS::Catnip(libos) => libos.wait_any2(qts),
-        }
-    }
-
     /// Creates a socket.
     pub fn socket(
         &mut self,

--- a/src/rust/demikernel/libos/network.rs
+++ b/src/rust/demikernel/libos/network.rs
@@ -71,21 +71,6 @@ impl NetworkLibOS {
         }
     }
 
-    /// Waits on a pending operation in an I/O queue.
-    #[deprecated]
-    pub fn wait2(&mut self, qt: QToken) -> Result<(QDesc, OperationResult), Fail> {
-        match self {
-            #[cfg(feature = "catpowder-libos")]
-            NetworkLibOS::Catpowder(libos) => libos.wait2(qt),
-            #[cfg(feature = "catnap-libos")]
-            NetworkLibOS::Catnap(libos) => libos.wait2(qt),
-            #[cfg(feature = "catcollar-libos")]
-            NetworkLibOS::Catcollar(libos) => libos.wait2(qt),
-            #[cfg(feature = "catnip-libos")]
-            NetworkLibOS::Catnip(libos) => libos.wait2(qt),
-        }
-    }
-
     /// Creates a socket.
     pub fn socket(
         &mut self,

--- a/src/rust/demikernel/libos/network.rs
+++ b/src/rust/demikernel/libos/network.rs
@@ -159,21 +159,6 @@ impl NetworkLibOS {
         }
     }
 
-    /// Pushes raw data to a TCP socket.
-    #[deprecated]
-    pub fn push2(&mut self, sockqd: QDesc, data: &[u8]) -> Result<QToken, Fail> {
-        match self {
-            #[cfg(feature = "catpowder-libos")]
-            NetworkLibOS::Catpowder(libos) => libos.push2(sockqd, data),
-            #[cfg(feature = "catnap-libos")]
-            NetworkLibOS::Catnap(libos) => libos.push2(sockqd, data),
-            #[cfg(feature = "catcollar-libos")]
-            NetworkLibOS::Catcollar(libos) => libos.push2(sockqd, data),
-            #[cfg(feature = "catnip-libos")]
-            NetworkLibOS::Catnip(libos) => libos.push2(sockqd, data),
-        }
-    }
-
     /// Pushes a scatter-gather array to a UDP socket.
     pub fn pushto(&mut self, sockqd: QDesc, sga: &demi_sgarray_t, to: SocketAddrV4) -> Result<QToken, Fail> {
         match self {

--- a/src/rust/inetstack/mod.rs
+++ b/src/rust/inetstack/mod.rs
@@ -468,6 +468,7 @@ impl InetStack {
     }
 
     /// Waits for an operation to complete.
+    #[deprecated]
     pub fn wait2(&mut self, qt: QToken) -> Result<(QDesc, OperationResult), Fail> {
         #[cfg(feature = "profiler")]
         timer!("inetstack::wait2");
@@ -522,6 +523,7 @@ impl InetStack {
     }
 
     /// Waits for any operation to complete.
+    #[deprecated]
     pub fn wait_any2(&mut self, qts: &[QToken]) -> Result<(usize, QDesc, OperationResult), Fail> {
         #[cfg(feature = "profiler")]
         timer!("inetstack::wait_any2");


### PR DESCRIPTION
Description
-------------

This PR fixes https://github.com/demikernel/demikernel/issues/295

Summary of Changes
------------------------

- Dropped `wait2()` from all LibOSes
- Dropped `wait_any2()` from all LibOSes
- Dropped `push2()` from all LibOSes
- Dropped `pushto2()` from all LibOSes