### PR TITLE
[winport] Add Windows makefiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,9 @@ target/
 bin/
 *.a
 *.elf
+*.exe
 *.o
+*.obj
 *.so
 *.stderr
 *.stdout

--- a/examples/c/linux.mk
+++ b/examples/c/linux.mk
@@ -5,10 +5,6 @@
 # Toolchain Configuration
 #=======================================================================================================================
 
-# Rust
-export CARGO ?= $(HOME)/.cargo/bin/cargo
-export CARGO_FLAGS += --profile $(BUILD)
-
 # C
 export CC := gcc
 export CFLAGS := -Werror -Wall -Wextra -O3 -I $(INCDIR) -std=c99

--- a/examples/c/windows.mk
+++ b/examples/c/windows.mk
@@ -1,3 +1,53 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+# C/C++ compiler
+CC = cl
+
+LIBS = $(LIBS) "WS2_32.lib"
+
+# Compiles several object files into a binary.
+COMPILE_CMD = $(CC) $@.obj $(LIBS) /Fe: $(BINDIR)/examples/c/$@.exe
+
+# Builds everything.
+all: udp-push-pop udp-ping-pong tcp-push-pop tcp-ping-pong
+
+make-dirs:
+	IF NOT EXIST $(BINDIR)\examples\c mkdir $(BINDIR)\examples\c
+
+# Builds UDP push pop test.
+udp-push-pop: make-dirs udp-push-pop.obj
+	$(COMPILE_CMD)
+
+# Builds UDP ping pong test.
+udp-ping-pong: make-dirs udp-ping-pong.obj
+	$(COMPILE_CMD)
+
+# Builds TCP push pop test.
+tcp-push-pop: make-dirs tcp-push-pop.obj
+	$(COMPILE_CMD)
+
+# Builds TCP ping pong test.
+tcp-ping-pong: make-dirs tcp-ping-pong.obj
+	$(COMPILE_CMD)
+
+# Cleans up all build artifacts.
+clean:
+	del /S /Q *.obj
+	IF EXIST $(BINDIR)\examples\c\udp-push-pop.exe del /Q $(BINDIR)\examples\c\udp-push-pop.exe
+	IF EXIST $(BINDIR)\examples\c\udp-ping-pong.exe del /Q $(BINDIR)\examples\c\udp-ping-pong.exe
+	IF EXIST $(BINDIR)\examples\c\tcp-push-pop.exe del /Q $(BINDIR)\examples\c\tcp-push-pop.exe
+	IF EXIST $(BINDIR)\examples\c\tcp-ping-pong.exe del /Q $(BINDIR)\examples\c\tcp-ping-pong.exe
+
+# Builds a C source file.
+udp-push-pop.obj:
+	$(CC) /I $(INCDIR) /I examples\c\ examples\c\udp-push-pop.c /c
+
+udp-ping-pong.obj:
+	$(CC) /I $(INCDIR) /I examples\c\ examples\c\udp-ping-pong.c /c
+
+tcp-push-pop.obj:
+	$(CC) /I $(INCDIR) /I examples\c\ examples\c\tcp-push-pop.c /c
+
+tcp-ping-pong.obj:
+	$(CC) /I $(INCDIR) /I examples\c\ examples\c\tcp-ping-pong.c /c

--- a/linux.mk
+++ b/linux.mk
@@ -101,8 +101,8 @@ all-tests: all-tests-rust all-tests-c
 
 # Builds all Rust tests.
 all-tests-rust: all-libs
-	@echo "$(CARGO) build  --tests $(CARGO_FEATURES) $(CARGO_FLAGS)"
-	$(CARGO) build  --tests $(CARGO_FEATURES) $(CARGO_FLAGS)
+	@echo "$(CARGO) build --tests $(CARGO_FEATURES) $(CARGO_FLAGS)"
+	$(CARGO) build --tests $(CARGO_FEATURES) $(CARGO_FLAGS)
 
 # Builds all C tests.
 all-tests-c: all-libs

--- a/tests/c/windows.mk
+++ b/tests/c/windows.mk
@@ -1,3 +1,19 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+CC = cl
+
+all: syscalls
+
+syscalls: make-dirs syscalls.obj
+	$(CC) syscalls.obj $(LIBS) /Fe: $(BINDIR)\syscalls.exe
+
+clean:
+	IF EXIST syscalls.obj del /Q syscalls.obj
+	IF EXIST $(BINDIR)\syscalls.exe del /S /Q $(BINDIR)\syscalls.exe
+
+syscalls.obj:
+	$(CC) /I $(INCDIR) tests\c\syscalls.c /c
+
+make-dirs:
+	IF NOT EXIST $(BINDIR) mkdir $(BINDIR)

--- a/tests/windows.mk
+++ b/tests/windows.mk
@@ -1,3 +1,11 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+all:
+	set BINDIR = $(BINDIR)
+	set INCDIR = $(INCDIR)
+	$(MAKE) /C /F tests/c/windows.mk all
+
+clean:
+	set BINDIR = $(BINDIR)
+	$(MAKE) /C /F tests/c/windows.mk clean

--- a/windows.mk
+++ b/windows.mk
@@ -1,3 +1,238 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+#=======================================================================================================================
+# Default Paths
+#=======================================================================================================================
+
+!ifndef PREFIX
+PREFIX = $(USERPROFILE)
+!endif
+
+!ifndef INSTALL_PREFIX
+INSTALL_PREFIX = $(USERPROFILE)
+!endif
+
+!ifndef LD_LIBRARY_PATH
+LD_LIBRARY_PATH = $(USERPROFILE)/lib
+!endif
+
+#=======================================================================================================================
+# Build Configuration
+#=======================================================================================================================
+
+BUILD = release
+!if "$(DEBUG)" == "yes"
+BUILD = dev
+!endif
+
+#=======================================================================================================================
+# Project Directories
+#=======================================================================================================================
+
+!ifndef BINDIR
+BINDIR = $(MAKEDIR)\bin
+!endif
+
+!ifndef INCDIR
+INCDIR = $(MAKEDIR)\include
+!endif
+
+SRCDIR = $(MAKEDIR)\src
+
+BUILD_DIR = $(MAKEDIR)\target\release
+!if "$(BUILD)" == "dev"
+BUILD_DIR = $(MAKEDIR)\target\debug
+!endif
+
+#=======================================================================================================================
+# Toolchain Configuration
+#=======================================================================================================================
+
+# Rust
+!ifndef CARGO
+CARGO = $(USERPROFILE)\.cargo\bin\cargo.exe
+!endif
+CARGO_FLAGS = $(CARGO_FLAGS) --profile $(BUILD)
+
+#=======================================================================================================================
+# Libraries
+#=======================================================================================================================
+
+DEMIKERNEL_LIB = $(BUILD_DIR)/demikernel.dll.lib
+LIBS = $(DEMIKERNEL_LIB)
+
+#=======================================================================================================================
+# Build Parameters
+#=======================================================================================================================
+
+!ifndef LIBOS
+LIBOS = catnapw
+!endif
+CARGO_FEATURES = $(CARGO_FEATURES) --features=$(LIBOS)-libos
+
+# Switch for DPDK
+!if "$(LIBOS)" == "catnip"
+!ifndef DRIVER
+DRIVER = mlx5	# defaults to mlx5, set the DRIVER env var if you want to change this
+!endif
+CARGO_FEATURES = $(CARGO_FEATURES) --features=$(DRIVER)
+!endif
+
+# Switch for profiler.
+!if "$(PROFILER)" == "yes"
+CARGO_FEATURES = $(CARGO_FEATURES) --features=profiler
+!endif
+
+CARGO_FEATURES = $(CARGO_FEATURES) $(FEATURES)
+
+#=======================================================================================================================
+
+all: all-libs all-tests all-examples
+
+# Builds documentation.
+doc:
+	$(CARGO) doc $(FLAGS) --no-deps
+
+# Copies demikernel artifacts to a INSTALL_PREFIX directory.
+install:
+	mkdir $(INSTALL_PREFIX)/include $(INSTALL_PREFIX)/lib
+	xcopy /S /E /Y /I $(INCDIR) $(INSTALL_PREFIX)/include/
+	xcopy /S /E /Y /I $(DEMIKERNEL_LIB) $(INSTALL_PREFIX)/lib/
+
+#=======================================================================================================================
+# Libs
+#=======================================================================================================================
+
+# Builds all libraries.
+all-libs:
+	@echo "LD_LIBRARY_PATH: $(LD_LIBRARY_PATH)"
+	@echo "$(CARGO) build --libs $(CARGO_FEATURES) $(CARGO_FLAGS)"
+	$(CARGO) build --lib $(CARGO_FEATURES) $(CARGO_FLAGS)
+
+#=======================================================================================================================
+# Tests
+#=======================================================================================================================
+
+# Builds all tests.
+all-tests: all-tests-rust all-tests-c
+
+# Builds all Rust tests.
+all-tests-rust: all-libs
+	@echo "$(CARGO) build --tests $(CARGO_FEATURES) $(CARGO_FLAGS)"
+	$(CARGO) build --tests $(CARGO_FEATURES) $(CARGO_FLAGS)
+
+# Builds all C tests.
+all-tests-c: all-libs
+	set BINDIR=$(BINDIR)
+	set INCDIR=$(INCDIR)
+	set LIBS=$(LIBS)
+	$(MAKE) /C /F tests/windows.mk all
+
+# Cleans up all build artifactos for tests.
+clean-tests: clean-tests-c
+
+# Cleans up all C build artifacts for tests.
+clean-tests-c:
+	set BINDIR=$(BINDIR)
+	$(MAKE) /C /F tests/windows.mk clean
+
+#=======================================================================================================================
+# Examples
+#=======================================================================================================================
+
+# Builds all examples.
+all-examples: all-examples-c all-examples-rust
+
+# Builds all C examples.
+all-examples-c: all-libs
+	set BINDIR=$(BINDIR)
+	set INCDIR=$(INCDIR)
+	set LIBS=$(LIBS)
+	$(MAKE) /C /F examples/c/windows.mk all
+
+# Builds all Rust examples.
+all-examples-rust: all-libs
+	set BINDIR=$(BINDIR)
+	set BUILD_DIR=$(BUILD_DIR)
+	set CARGO_FEATURES=$(CARGO_FEATURES)
+	set CARGO_FLAGS=$(CARGO_FLAGS)
+	set CARGO=$(CARGO)
+	set INCDIR=$(INCDIR)
+	$(MAKE) /C /F examples/rust/windows.mk all
+
+# Cleans all examples.
+clean-examples: clean-examples-c clean-examples-rust
+
+# Cleans all C examples.
+clean-examples-c:
+	set BINDIR=$(BINDIR)
+	$(MAKE) /C /F examples/c/windows.mk clean
+
+# Cleans all Rust examples.
+clean-examples-rust:
+	set BINDIR=$(BINDIR)
+	$(MAKE) /C /F examples/rust/windows.mk clean
+
+#=======================================================================================================================
+# Check
+#=======================================================================================================================
+
+# Check code style formatting.
+check-fmt: check-fmt-c check-fmt-rust
+
+# Check code style formatting for Rust.
+check-fmt-rust:
+	$(CARGO) fmt --all -- --check
+
+#=======================================================================================================================
+# Clean
+#=======================================================================================================================
+
+# Cleans up all build artifacts.
+clean: clean-examples clean-tests
+	del /S /Q target
+	del /Q Cargo.lock
+	$(CARGO) clean
+
+#=======================================================================================================================
+# Tests section
+#=======================================================================================================================
+
+!ifndef CONFIG_PATH
+CONFIG_PATH = $(USERPROFILE)/config.yaml
+!endif
+
+!ifndef MTU
+MTU = 1500
+!endif
+
+!ifndef MSS
+MSS = 1500
+!endif
+
+!ifndef PEER
+PEER = server
+!endif
+
+!ifndef TEST
+TEST = udp_push_pop
+!endif
+
+# Runs system tests.
+test-system: test-system-rust
+
+# Rust system tests.
+test-system-rust:
+	$(BINDIR)/examples/rust/$(TEST).exe $(ARGS)
+
+# Runs unit tests.
+test-unit: test-unit-rust
+
+# C unit tests.
+test-unit-c: $(BINDIR)/syscalls.exe
+	$(BINDIR)/syscalls.exe
+
+# Rust unit tests.
+test-unit-rust:
+	$(CARGO) test --lib $(CARGO_FLAGS) $(CARGO_FEATURES) -- --nocapture $(UNIT_TEST)


### PR DESCRIPTION
Partially addresses issue https://github.com/demikernel/demikernel/issues/274.

This PR adds the Makefiles for Windows build. Subsequent PRs will add the CatnapW LibOS for Windows and test/example builds for Windows.

**_Note that the build will NOT work on Windows just with this change. This is a part of a series of PRs to follow._**