### PR TITLE
[runtime] Bad Deref in `DemiBuffer::drop()` Causes Segmentation Fault

### DIFF
--- a/src/rust/runtime/memory/buffer/demibuffer.rs
+++ b/src/rust/runtime/memory/buffer/demibuffer.rs
@@ -724,7 +724,7 @@ impl Drop for DemiBuffer {
         match self.get_tag() {
             Tag::Heap => {
                 // This might be a chain of buffers.  If so, we'll walk the list.
-                let mut next_entry: Option<NonNull<MetaData>> = Some(self.ptr);
+                let mut next_entry: Option<NonNull<MetaData>> = Some(self.get_ptr());
                 while let Some(mut entry) = next_entry {
                     // Safety: This is safe, as `entry` is aligned, dereferenceable, and the MetaData struct it points
                     // to is initialized.
@@ -845,7 +845,7 @@ impl TryFrom<&[u8]> for DemiBuffer {
 
 // Unit tests for `DemiBuffer` type.
 // Note that due to DPDK being a configurable option, all of these unit tests are only for heap-allocated `DemiBuffer`s.
-#[cfg(not(test))]
+#[cfg(test)]
 mod tests {
     use super::DemiBuffer;
     use crate::runtime::fail::Fail;

--- a/src/rust/runtime/memory/buffer/demibuffer.rs
+++ b/src/rust/runtime/memory/buffer/demibuffer.rs
@@ -225,7 +225,7 @@ pub struct DemiBuffer {
     // Pointer to the buffer metadata.
     // Stored as a NonNull so it can efficiently be packed into an Option.
     // This is a "tagged pointer" where the lower bits encode the type of buffer this points to.
-    ptr: NonNull<MetaData>,
+    tagged_ptr: NonNull<MetaData>,
     // Hint to compiler that this struct "owns" a MetaData (for safety determinations).  Doesn't consume space.
     _phantom: PhantomData<MetaData>,
 }
@@ -284,7 +284,7 @@ impl DemiBuffer {
 
         // Return the new DemiBuffer.
         DemiBuffer {
-            ptr: tagged,
+            tagged_ptr: tagged,
             _phantom: PhantomData,
         }
     }
@@ -307,7 +307,7 @@ impl DemiBuffer {
         let tagged: NonNull<MetaData> = temp.with_addr(temp.addr() | Tag::Dpdk);
 
         DemiBuffer {
-            ptr: tagged,
+            tagged_ptr: tagged,
             _phantom: PhantomData,
         }
     }
@@ -457,15 +457,16 @@ impl DemiBuffer {
     // Gets the tag containing the type of DemiBuffer.
     #[inline]
     fn get_tag(&self) -> Tag {
-        Tag::from(usize::from(self.ptr.addr()) & Tag::MASK)
+        Tag::from(usize::from(self.tagged_ptr.addr()) & Tag::MASK)
     }
 
     // Gets the untagged pointer to the underlying type.
     #[inline]
     fn get_ptr<U>(&self) -> NonNull<U> {
         // Safety: The call to NonZeroUsize::new_unchecked is safe, as its argument is guaranteed to be non-zero.
-        let address: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(usize::from(self.ptr.addr()) & !Tag::MASK) };
-        self.ptr.with_addr(address).cast::<U>()
+        let address: NonZeroUsize =
+            unsafe { NonZeroUsize::new_unchecked(usize::from(self.tagged_ptr.addr()) & !Tag::MASK) };
+        self.tagged_ptr.with_addr(address).cast::<U>()
     }
 
     // Gets the DemiBuffer as a mutable MetaData reference.
@@ -647,7 +648,7 @@ impl Clone for DemiBuffer {
 
                 // Return the new DemiBuffer.
                 DemiBuffer {
-                    ptr: tagged,
+                    tagged_ptr: tagged,
                     _phantom: PhantomData,
                 }
             },
@@ -837,7 +838,7 @@ impl TryFrom<&[u8]> for DemiBuffer {
 
         // Return the new DemiBuffer.
         Ok(DemiBuffer {
-            ptr: tagged,
+            tagged_ptr: tagged,
             _phantom: PhantomData,
         })
     }


### PR DESCRIPTION
This PR fixes [Issue#310](https://github.com/demikernel/demikernel/issues/310).

The drop code was referencing `DemiBuffer`'s `ptr` field directly, rather than calling the internal `get_ptr()` method to get the `MetaData` pointer.

One take-away from this experience, is that we can't trust individual unit tests to (indirectly) test `drop` methods.  The DemiBuffer unit tests ran fine when run individually, or even together.  It appears to be non-deterministic as to whether Cargo's test harness keeps the test environment around long enough for destructors to run.