### PR TITLE
[pdpix] Generic `wait()`, `wait_any()` and `timedwait()`

### DIFF
--- a/src/rust/catcollar/mod.rs
+++ b/src/rust/catcollar/mod.rs
@@ -370,38 +370,6 @@ impl CatcollarLibOS {
         Ok(pack_result(&self.runtime, r, qd, qt.into()))
     }
 
-    /// Waits for any operation to complete.
-    pub fn wait_any(&mut self, qts: &[QToken]) -> Result<(usize, demi_qresult_t), Fail> {
-        #[cfg(feature = "profiler")]
-        timer!("catcollar::wait_any");
-        trace!("wait_any(): qts={:?}", qts);
-
-        loop {
-            // Poll first, so as to give pending operations a chance to complete.
-            self.runtime.scheduler.poll();
-
-            // Search for any operation that has completed.
-            for (i, &qt) in qts.iter().enumerate() {
-                // Retrieve associated schedule handle.
-                let mut handle: SchedulerHandle = match self.runtime.scheduler.from_raw_handle(qt.into()) {
-                    Some(handle) => handle,
-                    None => return Err(Fail::new(libc::EINVAL, "invalid queue token")),
-                };
-
-                // Found one, so extract the result and return.
-                if handle.has_completed() {
-                    let (qd, r): (QDesc, OperationResult) = self.take_result(handle);
-                    let (i, qd, r): (usize, QDesc, OperationResult) = (i, qd, r);
-                    return Ok((i, pack_result(&self.runtime, r, qd, qts[i].into())));
-                }
-
-                // Return this operation to the scheduling queue by removing the associated key
-                // (which would otherwise cause the operation to be freed).
-                handle.take_key();
-            }
-        }
-    }
-
     /// Allocates a scatter-gather array.
     pub fn sgaalloc(&self, size: usize) -> Result<demi_sgarray_t, Fail> {
         trace!("sgalloc() size={:?}", size);

--- a/src/rust/catnap/mod.rs
+++ b/src/rust/catnap/mod.rs
@@ -73,11 +73,7 @@ use ::std::{
         SocketAddrV4,
     },
     os::unix::prelude::RawFd,
-    time::SystemTime,
 };
-
-#[cfg(feature = "profiler")]
-use crate::timer;
 
 //==============================================================================
 // Structures
@@ -308,38 +304,6 @@ impl CatnapLibOS {
             },
             _ => Err(Fail::new(EBADF, "invalid queue descriptor")),
         }
-    }
-
-    /// Waits for an I/O operation to complete or a timeout to expire.
-    pub fn timedwait(&mut self, qt: QToken, abstime: Option<SystemTime>) -> Result<demi_qresult_t, Fail> {
-        #[cfg(feature = "profiler")]
-        timer!("catnap::timedwait");
-        trace!("timedwait() qt={:?}, timeout={:?}", qt, abstime);
-
-        // Retrieve associated schedule handle.
-        let mut handle: SchedulerHandle = match self.runtime.scheduler.from_raw_handle(qt.into()) {
-            Some(handle) => handle,
-            None => return Err(Fail::new(libc::EINVAL, "invalid queue token")),
-        };
-
-        let (qd, result): (QDesc, OperationResult) = loop {
-            // Poll first, so as to give pending operations a chance to complete.
-            self.runtime.scheduler.poll();
-
-            // The operation has completed, so extract the result and return.
-            if handle.has_completed() {
-                break self.take_result(handle);
-            }
-
-            if abstime.is_none() || SystemTime::now() >= abstime.unwrap() {
-                // Return this operation to the scheduling queue by removing the associated key
-                // (which would otherwise cause the operation to be freed).
-                handle.take_key();
-                return Err(Fail::new(libc::ETIMEDOUT, "timer expired"));
-            }
-        };
-
-        Ok(pack_result(&self.runtime, result, qd, qt.into()))
     }
 
     pub fn poll(&self) {

--- a/src/rust/catnip/mod.rs
+++ b/src/rust/catnip/mod.rs
@@ -46,10 +46,7 @@ use ::std::{
         DerefMut,
     },
     rc::Rc,
-    time::{
-        Instant,
-        SystemTime,
-    },
+    time::Instant,
 };
 
 #[cfg(feature = "profiler")]
@@ -151,16 +148,6 @@ impl CatnipLibOS {
             },
             Err(e) => Err(e),
         }
-    }
-
-    /// Waits for an I/O operation to complete or a timeout to expire.
-    pub fn timedwait(&mut self, qt: QToken, abstime: Option<SystemTime>) -> Result<demi_qresult_t, Fail> {
-        #[cfg(feature = "profiler")]
-        timer!("catnip::timedwait");
-        trace!("timedwait() qt={:?}, timeout={:?}", qt, abstime);
-
-        let (qd, result): (QDesc, OperationResult) = self.timedwait2(qt, abstime)?;
-        Ok(pack_result(self.rt.clone(), result, qd, qt.into()))
     }
 
     pub fn schedule(&mut self, qt: QToken) -> Result<SchedulerHandle, Fail> {

--- a/src/rust/catnip/mod.rs
+++ b/src/rust/catnip/mod.rs
@@ -175,38 +175,6 @@ impl CatnipLibOS {
         Ok(pack_result(self.rt.clone(), r, qd, qt.into()))
     }
 
-    /// Waits for any operation to complete.
-    pub fn wait_any(&mut self, qts: &[QToken]) -> Result<(usize, demi_qresult_t), Fail> {
-        #[cfg(feature = "profiler")]
-        timer!("catnip::wait_any");
-        trace!("wait_any(): qts={:?}", qts);
-
-        loop {
-            // Poll first, so as to give pending operations a chance to complete.
-            self.poll_bg_work();
-
-            // Search for any operation that has completed.
-            for (i, &qt) in qts.iter().enumerate() {
-                // Retrieve associated schedule handle.
-                // TODO: move this out of the loop.
-                let mut handle: SchedulerHandle = match self.scheduler.from_raw_handle(qt.into()) {
-                    Some(handle) => handle,
-                    None => return Err(Fail::new(libc::EINVAL, "invalid queue token")),
-                };
-
-                // Found one, so extract the result and return.
-                if handle.has_completed() {
-                    let (qd, r): (QDesc, OperationResult) = self.take_operation(handle);
-                    return Ok((i, pack_result(self.rt.clone(), r, qd, qts[i].into())));
-                }
-
-                // Return this operation to the scheduling queue by removing the associated key
-                // (which would otherwise cause the operation to be freed).
-                handle.take_key();
-            }
-        }
-    }
-
     /// Allocates a scatter-gather array.
     pub fn sgaalloc(&self, size: usize) -> Result<demi_sgarray_t, Fail> {
         self.rt.alloc_sgarray(size)

--- a/src/rust/catpowder/mod.rs
+++ b/src/rust/catpowder/mod.rs
@@ -46,10 +46,7 @@ use ::std::{
         DerefMut,
     },
     rc::Rc,
-    time::{
-        Instant,
-        SystemTime,
-    },
+    time::Instant,
 };
 
 #[cfg(feature = "profiler")]
@@ -146,16 +143,6 @@ impl CatpowderLibOS {
             },
             Err(e) => Err(e),
         }
-    }
-
-    /// Waits for an I/O operation to complete or a timeout to expire.
-    pub fn timedwait(&mut self, qt: QToken, abstime: Option<SystemTime>) -> Result<demi_qresult_t, Fail> {
-        #[cfg(feature = "profiler")]
-        timer!("catpowder::timedwait");
-        trace!("timedwait() qt={:?}, timeout={:?}", qt, abstime);
-
-        let (qd, result): (QDesc, OperationResult) = self.timedwait2(qt, abstime)?;
-        Ok(pack_result(self.rt.clone(), result, qd, qt.into()))
     }
 
     pub fn schedule(&mut self, qt: QToken) -> Result<SchedulerHandle, Fail> {

--- a/src/rust/catpowder/mod.rs
+++ b/src/rust/catpowder/mod.rs
@@ -170,38 +170,6 @@ impl CatpowderLibOS {
         Ok(pack_result(self.rt.clone(), r, qd, qt.into()))
     }
 
-    /// Waits for any operation to complete.
-    pub fn wait_any(&mut self, qts: &[QToken]) -> Result<(usize, demi_qresult_t), Fail> {
-        #[cfg(feature = "profiler")]
-        timer!("catpowder::wait_any");
-        trace!("wait_any(): qts={:?}", qts);
-
-        loop {
-            // Poll first, so as to give pending operations a chance to complete.
-            self.poll_bg_work();
-
-            // Search for any operation that has completed.
-            for (i, &qt) in qts.iter().enumerate() {
-                // Retrieve associated schedule handle.
-                // TODO: move this out of the loop.
-                let mut handle: SchedulerHandle = match self.scheduler.from_raw_handle(qt.into()) {
-                    Some(handle) => handle,
-                    None => return Err(Fail::new(libc::EINVAL, "invalid queue token")),
-                };
-
-                // Found one, so extract the result and return.
-                if handle.has_completed() {
-                    let (qd, r): (QDesc, OperationResult) = self.take_operation(handle);
-                    return Ok((i, pack_result(self.rt.clone(), r, qd, qts[i].into())));
-                }
-
-                // Return this operation to the scheduling queue by removing the associated key
-                // (which would otherwise cause the operation to be freed).
-                handle.take_key();
-            }
-        }
-    }
-
     /// Allocates a scatter-gather array.
     pub fn sgaalloc(&self, size: usize) -> Result<demi_sgarray_t, Fail> {
         self.rt.alloc_sgarray(size)

--- a/src/rust/demikernel/libos/network.rs
+++ b/src/rust/demikernel/libos/network.rs
@@ -219,20 +219,6 @@ impl NetworkLibOS {
     }
 
     /// Waits for any operation in an I/O queue.
-    pub fn wait_any(&mut self, qts: &[QToken]) -> Result<(usize, demi_qresult_t), Fail> {
-        match self {
-            #[cfg(feature = "catpowder-libos")]
-            NetworkLibOS::Catpowder(libos) => libos.wait_any(qts),
-            #[cfg(feature = "catnap-libos")]
-            NetworkLibOS::Catnap(libos) => libos.wait_any(qts),
-            #[cfg(feature = "catcollar-libos")]
-            NetworkLibOS::Catcollar(libos) => libos.wait_any(qts),
-            #[cfg(feature = "catnip-libos")]
-            NetworkLibOS::Catnip(libos) => libos.wait_any(qts),
-        }
-    }
-
-    /// Waits for any operation in an I/O queue.
     pub fn schedule(&mut self, qt: QToken) -> Result<SchedulerHandle, Fail> {
         match self {
             #[cfg(feature = "catpowder-libos")]

--- a/src/rust/demikernel/libos/network.rs
+++ b/src/rust/demikernel/libos/network.rs
@@ -17,10 +17,7 @@ use crate::{
     },
     scheduler::SchedulerHandle,
 };
-use ::std::{
-    net::SocketAddrV4,
-    time::SystemTime,
-};
+use ::std::net::SocketAddrV4;
 
 #[cfg(feature = "catcollar-libos")]
 use crate::catcollar::CatcollarLibOS;
@@ -187,20 +184,6 @@ impl NetworkLibOS {
             NetworkLibOS::Catcollar(libos) => libos.pop(sockqd),
             #[cfg(feature = "catnip-libos")]
             NetworkLibOS::Catnip(libos) => libos.pop(sockqd),
-        }
-    }
-
-    /// Waits for an I/O operation to complete or a timeout to expire.
-    pub fn timedwait(&mut self, qt: QToken, abstime: Option<SystemTime>) -> Result<demi_qresult_t, Fail> {
-        match self {
-            #[cfg(feature = "catpowder-libos")]
-            NetworkLibOS::Catpowder(libos) => libos.timedwait(qt, abstime),
-            #[cfg(feature = "catnap-libos")]
-            NetworkLibOS::Catnap(libos) => libos.timedwait(qt, abstime),
-            #[cfg(feature = "catcollar-libos")]
-            NetworkLibOS::Catcollar(libos) => libos.timedwait(qt, abstime),
-            #[cfg(feature = "catnip-libos")]
-            NetworkLibOS::Catnip(libos) => libos.timedwait(qt, abstime),
         }
     }
 

--- a/src/rust/demikernel/libos/network.rs
+++ b/src/rust/demikernel/libos/network.rs
@@ -259,24 +259,6 @@ impl NetworkLibOS {
         }
     }
 
-    /// Waits for an operation to complete.
-    pub fn wait(&mut self, qt: QToken) -> Result<demi_qresult_t, Fail> {
-        trace!("wait(): qt={:?}", qt);
-
-        // Retrieve associated schedule handle.
-        let handle: SchedulerHandle = self.schedule(qt)?;
-
-        loop {
-            // Poll first, so as to give pending operations a chance to complete.
-            self.poll();
-
-            // The operation has completed, so extract the result and return.
-            if handle.has_completed() {
-                return Ok(self.pack_result(handle, qt)?);
-            }
-        }
-    }
-
     /// Allocates a scatter-gather array.
     pub fn sgaalloc(&self, size: usize) -> Result<demi_sgarray_t, Fail> {
         match self {

--- a/src/rust/inetstack/mod.rs
+++ b/src/rust/inetstack/mod.rs
@@ -66,10 +66,7 @@ use ::std::{
         SocketAddrV4,
     },
     rc::Rc,
-    time::{
-        Instant,
-        SystemTime,
-    },
+    time::Instant,
 };
 
 #[cfg(feature = "profiler")]
@@ -493,36 +490,6 @@ impl InetStack {
             if handle.has_completed() {
                 trace!("wait2() qt={:?} completed!", qt);
                 return Ok(self.take_operation(handle));
-            }
-        }
-    }
-
-    /// Waits for an I/O operation to complete or a timeout to expire.
-    pub fn timedwait2(&mut self, qt: QToken, abstime: Option<SystemTime>) -> Result<(QDesc, OperationResult), Fail> {
-        #[cfg(feature = "profiler")]
-        timer!("inetstack::timedwait");
-        trace!("timedwait() qt={:?}, timeout={:?}", qt, abstime);
-
-        // Retrieve associated schedule handle.
-        let mut handle: SchedulerHandle = match self.scheduler.from_raw_handle(qt.into()) {
-            Some(handle) => handle,
-            None => return Err(Fail::new(libc::EINVAL, "invalid queue token")),
-        };
-
-        loop {
-            // Poll first, so as to give pending operations a chance to complete.
-            self.poll_bg_work();
-
-            // The operation has completed, so extract the result and return.
-            if handle.has_completed() {
-                return Ok(self.take_operation(handle));
-            }
-
-            if abstime.is_none() || SystemTime::now() >= abstime.unwrap() {
-                // Return this operation to the scheduling queue by removing the associated key
-                // (which would otherwise cause the operation to be freed).
-                handle.take_key();
-                return Err(Fail::new(libc::ETIMEDOUT, "timer expired"));
             }
         }
     }


### PR DESCRIPTION
Description
-------------

This PR fixes https://github.com/demikernel/demikernel/issues/306.

Summary of Changes
------------------------

- Moved definition of `wait()` to PDPIX layer
- Moved definition of `wait_any()` to PDPIX layer
- Moved definition of `timedwait()` to PDIX layer
- Dropped definition of `wait_any()` from Catnap, Catnip, Catpowder and Catcollar
- Dropped definition of `timedwait()` from Catnap, Catnip, Catpowder and Catcollar