### PR TITLE
[pdpix] `timedwait_any()` System Call

### DIFF
--- a/include/demi/wait.h
+++ b/include/demi/wait.h
@@ -45,6 +45,20 @@ extern "C"
      */
     extern int demi_wait_any(demi_qresult_t *qr_out, int *ready_offset, const demi_qtoken_t qts[], int num_qts);
 
+    /**
+     * @brief Waits for the first asynchronous I/O operation in a list to complete or a timeout to expire.
+     *
+     * @param qr_out       Store location for the result of the completed I/O operation.
+     * @param ready_offset Store location for the offset in the list of I/O queue tokens of the completed I/O operation.
+     * @param qts          List of I/O queue tokens to wait for completion.
+     * @param num_qts      Length of the list of I/O queue tokens to wait for completion.
+     * @param abstime      Absolute timeout in seconds and nanoseconds since Epoch.
+     *
+     * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
+     */
+    extern int demi_timedwait_any(demi_qresult_t *qr_out, int *ready_offset, const demi_qtoken_t qts[], int num_qts,
+                                  const struct timespec *abstime);
+
 #ifdef __cplusplus
 }
 #endif

--- a/man/demi_wait.md
+++ b/man/demi_wait.md
@@ -8,6 +8,8 @@
 
 `demi_wait_any` - Waits for the first asynchronous I/O operation in a list to complete.
 
+`demi_timedwait_any` - Waits for an asynchronous I/O operation to complete or a timeout to expire.
+
 ## Synopsis
 
 ```c
@@ -17,6 +19,8 @@
 int demi_wait(demi_qresult_t *qr_out, demi_qtoken_t qt);
 int demi_timedwait(demi_qresult_t *qr_out, demi_qtoken_t qt, const struct timespec *abstime);
 int demi_wait_any(demi_qresult_t *qr_out, int *ready_offset, demi_qtoken_t qts[], int num_qts);
+int demi_timedwait_any(demi_qresult_t *qr_out, int *ready_offset, const demi_qtoken_t qts[], int num_qts,
+                                  const struct timespec *abstime);
 ```
 
 ## Description
@@ -34,10 +38,17 @@ the calling thread to block (spin) until the timeout `abstime` expires.
 specified by the list of queue tokens `qts` and it has a length of `num_qts`. This system call may cause the calling
 thread to block (spin) indefinitely.
 
+`demi_timedwait_any()` waits for the first asynchronous I/O operation in a set to complete or for the expiration of a
+timeout, whichever happens first. The set of I/O operations is specified by the list of queue tokens `qts` and it has a
+length of `num_qts`.  The `abstime` parameter specifies an absolute timeout in seconds and nanoseconds since the
+Epoch. If the I/O operation has already completed when `demi_timedwait()` is called, then this system call never fails
+with a timeout error, regardless of the value of `abstime`. This system call may cause the calling thread to block
+(spin) until the timeout `abstime` expires.
+
 When `demi_wait()` and `demi_timedwait()` successfully completes, the structure pointed to by `qr_out` is filled in with
-the result value of the I/O operation that has completed. The `demi_wait_any()` system call behaves similarly, but it
-additionally sets `ready_offset` to indicate the index of that I/O operation in the list of queue tokens `qts` that has
-completed.
+the result value of the I/O operation that has completed. The `demi_wait_any()` and `demi_timedwait_any` system calls
+behave similarly, but they additionally set `ready_offset` to indicate the index of that I/O operation in the list of
+queue tokens `qts` that has completed.
 
 The `demi_qresult_t` is defined as follows:
 

--- a/man/demi_wait.md
+++ b/man/demi_wait.md
@@ -15,6 +15,7 @@
 #include <demi/types.h> /* For demi_qresult_t and demi_qtoken_t. */
 
 int demi_wait(demi_qresult_t *qr_out, demi_qtoken_t qt);
+int demi_timedwait(demi_qresult_t *qr_out, demi_qtoken_t qt, const struct timespec *abstime);
 int demi_wait_any(demi_qresult_t *qr_out, int *ready_offset, demi_qtoken_t qts[], int num_qts);
 ```
 

--- a/tests/c/syscalls.c
+++ b/tests/c/syscalls.c
@@ -188,6 +188,20 @@ static bool inval_wait_any(void)
     return (demi_wait_any(qr, ready_offset, qts, num_qts) != 0);
 }
 
+/**
+ * @brief Issues an invalid system call to demi_timedwait_any().
+ */
+static bool inval_timedwait_any(void)
+{
+    struct timespec *abstime = NULL;
+    demi_qresult_t *qr = NULL;
+    int *ready_offset = NULL;
+    demi_qtoken_t *qts = NULL;
+    int num_qts = -1;
+
+    return (demi_timedwait_any(qr, ready_offset, qts, num_qts, abstime) != 0);
+}
+
 /*===================================================================================================================*
  * main()                                                                                                            *
  *===================================================================================================================*/
@@ -221,7 +235,8 @@ static struct test tests_sga[] = {{inval_sgaalloc, "invalid demi_sgaalloc()"},
  */
 static struct test tests_wait[] = {{inval_timedwait, "invalid demi_timedwait()"},
                                    {inval_wait, "invalid demi_wait()"},
-                                   {inval_wait_any, "invalid demi_wait_any()"}};
+                                   {inval_wait_any, "invalid demi_wait_any()"},
+                                   {inval_timedwait_any, "invalid demi_timedwait_any()"}};
 
 /**
  * @brief Drives the application.


### PR DESCRIPTION
Description
-------------

This PR is a partial fix for https://github.com/demikernel/demikernel/issues/61.

Summary of Changes
------------------------

- Introduced `timedwait_any()`.
- Added bindings for `timedwait_any()`
- Added invalid test for `timedwait_any()`.
- Updated manual pages accordingly.