### PR TITLE
[demikernel] Integrate `DemiBuffer` into the System as `Buffer`/`DataBuffer` Replacement

### DIFF
--- a/src/rust/catcollar/futures/pop.rs
+++ b/src/rust/catcollar/futures/pop.rs
@@ -12,7 +12,7 @@ use crate::{
     },
     runtime::{
         fail::Fail,
-        memory::Buffer,
+        memory::DemiBuffer,
         QDesc,
     },
 };
@@ -37,7 +37,7 @@ pub struct PopFuture {
     /// Associated queue descriptor.
     qd: QDesc,
     /// Associated receive buffer.
-    buf: Buffer,
+    buf: DemiBuffer,
     /// Associated request.
     request_id: RequestId,
 }
@@ -49,7 +49,7 @@ pub struct PopFuture {
 /// Associate Functions for Pop Operation Descriptors
 impl PopFuture {
     /// Creates a descriptor for a pop operation.
-    pub fn new(rt: IoUringRuntime, request_id: RequestId, qd: QDesc, buf: Buffer) -> Self {
+    pub fn new(rt: IoUringRuntime, request_id: RequestId, qd: QDesc, buf: DemiBuffer) -> Self {
         Self {
             rt,
             qd,
@@ -70,7 +70,7 @@ impl PopFuture {
 
 /// Future Trait Implementation for Pop Operation Descriptors
 impl Future for PopFuture {
-    type Output = Result<(Option<SocketAddrV4>, Buffer), Fail>;
+    type Output = Result<(Option<SocketAddrV4>, DemiBuffer), Fail>;
 
     /// Polls the underlying pop operation.
     fn poll(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Self::Output> {
@@ -80,7 +80,7 @@ impl Future for PopFuture {
             Ok((addr, Some(size))) if size >= 0 => {
                 trace!("data received ({:?} bytes)", size);
                 let trim_size: usize = self_.buf.len() - (size as usize);
-                let mut buf: Buffer = self_.buf.clone();
+                let mut buf: DemiBuffer = self_.buf.clone();
                 buf.trim(trim_size);
                 Poll::Ready(Ok((addr, buf)))
             },

--- a/src/rust/catcollar/iouring.rs
+++ b/src/rust/catcollar/iouring.rs
@@ -8,7 +8,7 @@
 use crate::runtime::{
     fail::Fail,
     liburing,
-    memory::Buffer,
+    memory::DemiBuffer,
 };
 use ::libc::socklen_t;
 use ::nix::{
@@ -72,7 +72,7 @@ impl IoUring {
     }
 
     /// Pushes a buffer to the target IO user ring.
-    pub fn push(&mut self, sockfd: RawFd, buf: Buffer) -> Result<*const liburing::msghdr, Fail> {
+    pub fn push(&mut self, sockfd: RawFd, buf: DemiBuffer) -> Result<*const liburing::msghdr, Fail> {
         let len: usize = buf.len();
         let data: &[u8] = &buf[..];
         let data_ptr: *const u8 = data.as_ptr();
@@ -119,7 +119,7 @@ impl IoUring {
         &mut self,
         sockfd: RawFd,
         addr: SockaddrStorage,
-        buf: Buffer,
+        buf: DemiBuffer,
     ) -> Result<*const liburing::msghdr, Fail> {
         let len: usize = buf.len();
         let data: &[u8] = &buf[..];
@@ -169,7 +169,7 @@ impl IoUring {
     }
 
     /// Pops a buffer from the target IO user ring.
-    pub fn pop(&mut self, sockfd: RawFd, buf: Buffer) -> Result<*const liburing::msghdr, Fail> {
+    pub fn pop(&mut self, sockfd: RawFd, buf: DemiBuffer) -> Result<*const liburing::msghdr, Fail> {
         let len: usize = buf.len();
         let data: &[u8] = &buf[..];
         let data_ptr: *const u8 = data.as_ptr();

--- a/src/rust/catcollar/mod.rs
+++ b/src/rust/catcollar/mod.rs
@@ -32,8 +32,7 @@ use crate::{
     runtime::{
         fail::Fail,
         memory::{
-            Buffer,
-            DataBuffer,
+            DemiBuffer,
             MemoryRuntime,
         },
         queue::IoQueueTable,
@@ -78,7 +77,7 @@ use ::std::{
 //======================================================================================================================
 
 // Size of receive buffers.
-const CATCOLLAR_RECVBUF_SIZE: usize = 9000;
+const CATCOLLAR_RECVBUF_SIZE: u16 = 9000;
 
 //======================================================================================================================
 // Structures
@@ -241,7 +240,7 @@ impl CatcollarLibOS {
     pub fn push(&mut self, qd: QDesc, sga: &demi_sgarray_t) -> Result<QToken, Fail> {
         trace!("push() qd={:?}", qd);
 
-        let buf: Buffer = self.runtime.clone_sgarray(sga)?;
+        let buf: DemiBuffer = self.runtime.clone_sgarray(sga)?;
 
         if buf.len() == 0 {
             return Err(Fail::new(libc::EINVAL, "zero-length buffer"));
@@ -300,7 +299,7 @@ impl CatcollarLibOS {
     pub fn pop(&mut self, qd: QDesc) -> Result<QToken, Fail> {
         trace!("pop() qd={:?}", qd);
 
-        let buf: Buffer = Buffer::Heap(DataBuffer::new(CATCOLLAR_RECVBUF_SIZE)?);
+        let buf: DemiBuffer = DemiBuffer::new(CATCOLLAR_RECVBUF_SIZE);
 
         // Issue pop operation.
         match self.sockets.get(&qd) {

--- a/src/rust/catcollar/runtime/memory.rs
+++ b/src/rust/catcollar/runtime/memory.rs
@@ -9,8 +9,7 @@ use super::IoUringRuntime;
 use crate::runtime::{
     fail::Fail,
     memory::{
-        Buffer,
-        DataBuffer,
+        DemiBuffer,
         MemoryRuntime,
     },
     types::{
@@ -21,53 +20,60 @@ use crate::runtime::{
 use ::libc::c_void;
 use ::std::{
     mem,
-    slice,
+    ptr::{
+        self,
+        NonNull,
+    },
 };
 
 //==============================================================================
 // Trait Implementations
 //==============================================================================
 
-/// Memory Runtime Trait Implementation for I/O User Ring Runtime
+/// Memory Runtime Trait Implementation for IoUring Runtime
 impl MemoryRuntime for IoUringRuntime {
-    /// Creates a scatter-gather array from a memory buffer.
-    fn into_sgarray(&self, buf: Buffer) -> Result<demi_sgarray_t, Fail> {
-        let len: usize = buf.len();
-        #[allow(unreachable_patterns)]
-        let (dbuf_ptr, sgaseg): (*const u8, demi_sgaseg_t) = match buf {
-            Buffer::Heap(dbuf) => {
-                let (dbuf_ptr, data_ptr): (*const u8, *const u8) = DataBuffer::into_raw_parts(Clone::clone(&dbuf))?;
-                (
-                    dbuf_ptr,
-                    demi_sgaseg_t {
-                        sgaseg_buf: data_ptr as *mut c_void,
-                        sgaseg_len: len as u32,
-                    },
-                )
-            },
-            _ => return Err(Fail::new(libc::EINVAL, "invalid buffer type")),
+    /// Converts a buffer into a scatter-gather array.
+    fn into_sgarray(&self, buf: DemiBuffer) -> Result<demi_sgarray_t, Fail> {
+        // Create a scatter-gather segment to expose the DemiBuffer to the user.
+        let data: *const u8 = buf.as_ptr();
+        let sga_seg: demi_sgaseg_t = demi_sgaseg_t {
+            sgaseg_buf: data as *mut c_void,
+            sgaseg_len: buf.len() as u32,
         };
+
+        // Create and return a new scatter-gather array (which inherits the DemiBuffer's reference).
         Ok(demi_sgarray_t {
-            sga_buf: dbuf_ptr as *mut c_void,
+            sga_buf: buf.into_raw().as_ptr() as *mut c_void,
             sga_numsegs: 1,
-            sga_segs: [sgaseg],
+            sga_segs: [sga_seg],
             sga_addr: unsafe { mem::zeroed() },
         })
     }
 
     /// Allocates a scatter-gather array.
     fn alloc_sgarray(&self, size: usize) -> Result<demi_sgarray_t, Fail> {
-        // Allocate a heap-managed buffer.
-        let dbuf: DataBuffer = DataBuffer::new(size)?;
-        let (dbuf_ptr, data_ptr): (*const u8, *const u8) = DataBuffer::into_raw_parts(dbuf)?;
-        let sgaseg: demi_sgaseg_t = demi_sgaseg_t {
-            sgaseg_buf: data_ptr as *mut c_void,
+        // ToDo: Allocate an array of buffers if requested size is too large for a single buffer.
+
+        // We can't allocate more than a single buffer.
+        if size > u16::MAX as usize {
+            return Err(Fail::new(libc::EINVAL, "size too large for a single demi_sgaseg_t"));
+        }
+
+        // First allocate the underlying DemiBuffer.
+        let buf: DemiBuffer = DemiBuffer::new(size as u16);
+
+        // Create a scatter-gather segment to expose the DemiBuffer to the user.
+        let data: *const u8 = buf.as_ptr();
+        let sga_seg: demi_sgaseg_t = demi_sgaseg_t {
+            sgaseg_buf: data as *mut c_void,
             sgaseg_len: size as u32,
         };
+
+        // Create and return a new scatter-gather array (which inherits the DemiBuffer's reference).
         Ok(demi_sgarray_t {
-            sga_buf: dbuf_ptr as *mut c_void,
+            sga_buf: buf.into_raw().as_ptr() as *mut c_void,
             sga_numsegs: 1,
-            sga_segs: [sgaseg],
+            sga_segs: [sga_seg],
             sga_addr: unsafe { mem::zeroed() },
         })
     }
@@ -77,32 +83,80 @@ impl MemoryRuntime for IoUringRuntime {
         // Check arguments.
         // TODO: Drop this check once we support scatter-gather arrays with multiple segments.
         if sga.sga_numsegs != 1 {
-            return Err(Fail::new(libc::EINVAL, "scatter-gather array with invalid size"));
+            return Err(Fail::new(libc::EINVAL, "demi_sgarray_t has invalid segment count"));
         }
 
-        // Release heap-managed buffer.
-        let (dbuf_ptr, length): (*mut u8, usize) = (sga.sga_buf as *mut u8, sga.sga_segs[0].sgaseg_len as usize);
-        DataBuffer::from_raw_parts(dbuf_ptr, length)?;
+        if sga.sga_buf == ptr::null_mut() {
+            return Err(Fail::new(libc::EINVAL, "demi_sgarray_t has invalid DemiBuffer token"));
+        }
+
+        // Convert back to a DemiBuffer and drop it.
+        // Safety: The `NonNull::new_unchecked()` call is safe, as we verified `sga.sga_buf` is not null above.
+        let token: NonNull<u8> = unsafe { NonNull::new_unchecked(sga.sga_buf as *mut u8) };
+        // Safety: The `DemiBuffer::from_raw()` call *should* be safe, as the `sga_buf` field in the `demi_sgarray_t`
+        // contained a valid `DemiBuffer` token when we provided it to the user (and the user shouldn't change it).
+        let buf: DemiBuffer = unsafe { DemiBuffer::from_raw(token) };
+        drop(buf);
 
         Ok(())
     }
 
     /// Clones a scatter-gather array.
-    fn clone_sgarray(&self, sga: &demi_sgarray_t) -> Result<Buffer, Fail> {
+    fn clone_sgarray(&self, sga: &demi_sgarray_t) -> Result<DemiBuffer, Fail> {
         // Check arguments.
         // TODO: Drop this check once we support scatter-gather arrays with multiple segments.
         if sga.sga_numsegs != 1 {
-            return Err(Fail::new(libc::EINVAL, "scatter-gather array with invalid size"));
+            return Err(Fail::new(libc::EINVAL, "demi_sgarray_t has invalid segment count"));
         }
 
-        let sgaseg: demi_sgaseg_t = sga.sga_segs[0];
-        let (dbuf_ptr, len): (*mut c_void, usize) = (sga.sga_buf, sgaseg.sgaseg_len as usize);
+        if sga.sga_buf == ptr::null_mut() {
+            return Err(Fail::new(libc::EINVAL, "demi_sgarray_t has invalid DemiBuffer token"));
+        }
 
-        // Clone heap-managed buffer.
-        let seg_slice: &[u8] = unsafe { slice::from_raw_parts(dbuf_ptr as *const u8, len) };
-        let mut dbuf: DataBuffer = DataBuffer::from_slice(seg_slice);
-        let nbytes: usize = unsafe { sgaseg.sgaseg_buf.sub_ptr(sga.sga_buf) };
-        dbuf.adjust(nbytes);
-        Ok(Buffer::Heap(dbuf))
+        // Convert back to a DemiBuffer.
+        // Safety: The `NonNull::new_unchecked()` call is safe, as we verified `sga.sga_buf` is not null above.
+        let token: NonNull<u8> = unsafe { NonNull::new_unchecked(sga.sga_buf as *mut u8) };
+        // Safety: The `DemiBuffer::from_raw()` call *should* be safe, as the `sga_buf` field in the `demi_sgarray_t`
+        // contained a valid `DemiBuffer` token when we provided it to the user (and the user shouldn't change it).
+        let buf: DemiBuffer = unsafe { DemiBuffer::from_raw(token) };
+        let mut clone: DemiBuffer = buf.clone();
+
+        // Don't drop buf, as it holds the same reference to the data as the sgarray (which should keep it).
+        mem::forget(buf);
+
+        // Check to see if the user has reduced the size of the buffer described by the sgarray segment since we
+        // provided it to them.  They could have increased the starting address of the buffer (`sgaseg_buf`),
+        // decreased the ending address of the buffer (`sgaseg_buf + sgaseg_len`), or both.
+        let sga_data: *const u8 = sga.sga_segs[0].sgaseg_buf as *const u8;
+        let sga_len: usize = sga.sga_segs[0].sgaseg_len as usize;
+        let clone_data: *const u8 = clone.as_ptr();
+        let mut clone_len: usize = clone.len();
+        if sga_data != clone_data || sga_len != clone_len {
+            // We need to adjust the DemiBuffer to match the user's changes.
+
+            // First check that the user didn't do something non-sensical, like change the buffer description to
+            // reference address space outside of the DemiBuffer's allocated memory area.
+            if sga_data < clone_data || sga_data.addr() + sga_len > clone_data.addr() + clone_len {
+                return Err(Fail::new(
+                    libc::EINVAL,
+                    "demi_sgarray_t describes data outside backing buffer's allocated region",
+                ));
+            }
+
+            // Calculate the amount the new starting address is ahead of the old.  And then adjust `clone` to match.
+            let adjustment_amount: usize = sga_data.addr() - clone_data.addr();
+            clone.adjust(adjustment_amount)?;
+
+            // An adjustment above would have reduced clone.len() by the adjustment amount.
+            clone_len -= adjustment_amount;
+            debug_assert_eq!(clone_len, clone.len());
+
+            // Trim the clone down to size.
+            let trim_amount: usize = clone_len - sga_len;
+            clone.trim(trim_amount)?;
+        }
+
+        // Return the clone.
+        Ok(clone)
     }
 }

--- a/src/rust/catcollar/runtime/mod.rs
+++ b/src/rust/catcollar/runtime/mod.rs
@@ -13,7 +13,7 @@ use crate::{
     runtime::{
         fail::Fail,
         liburing,
-        memory::Buffer,
+        memory::DemiBuffer,
         Runtime,
     },
     scheduler::scheduler::Scheduler,
@@ -80,7 +80,7 @@ impl IoUringRuntime {
     }
 
     /// Pushes a buffer to the target I/O user ring.
-    pub fn push(&mut self, sockfd: RawFd, buf: Buffer) -> Result<RequestId, Fail> {
+    pub fn push(&mut self, sockfd: RawFd, buf: DemiBuffer) -> Result<RequestId, Fail> {
         let msg_ptr: *const liburing::msghdr = self.io_uring.borrow_mut().push(sockfd, buf)?;
         let request_id: RequestId = RequestId(msg_ptr);
         self.pending.insert(request_id);
@@ -88,7 +88,7 @@ impl IoUringRuntime {
     }
 
     /// Pushes a buffer to the target I/O user ring.
-    pub fn pushto(&mut self, sockfd: i32, addr: SockaddrStorage, buf: Buffer) -> Result<RequestId, Fail> {
+    pub fn pushto(&mut self, sockfd: i32, addr: SockaddrStorage, buf: DemiBuffer) -> Result<RequestId, Fail> {
         let msg_ptr: *const liburing::msghdr = self.io_uring.borrow_mut().pushto(sockfd, addr, buf)?;
         let request_id: RequestId = RequestId(msg_ptr);
         self.pending.insert(request_id);
@@ -96,7 +96,7 @@ impl IoUringRuntime {
     }
 
     /// Pops a buffer from the target I/O user ring.
-    pub fn pop(&mut self, sockfd: RawFd, buf: Buffer) -> Result<RequestId, Fail> {
+    pub fn pop(&mut self, sockfd: RawFd, buf: DemiBuffer) -> Result<RequestId, Fail> {
         let msg_ptr: *const liburing::msghdr = self.io_uring.borrow_mut().pop(sockfd, buf)?;
         let request_id: RequestId = RequestId(msg_ptr);
         self.pending.insert(request_id);

--- a/src/rust/catcollar/runtime/network.rs
+++ b/src/rust/catcollar/runtime/network.rs
@@ -7,7 +7,7 @@
 
 use super::IoUringRuntime;
 use crate::runtime::{
-    memory::Buffer,
+    memory::DemiBuffer,
     network::{
         consts::RECEIVE_BATCH_SIZE,
         NetworkRuntime,
@@ -28,7 +28,7 @@ impl NetworkRuntime for IoUringRuntime {
     }
 
     // TODO: Rely on a default implementation for this.
-    fn receive(&self) -> ArrayVec<Buffer, RECEIVE_BATCH_SIZE> {
+    fn receive(&self) -> ArrayVec<DemiBuffer, RECEIVE_BATCH_SIZE> {
         unreachable!()
     }
 }

--- a/src/rust/catnap/futures/pop.rs
+++ b/src/rust/catnap/futures/pop.rs
@@ -7,10 +7,7 @@
 
 use crate::runtime::{
     fail::Fail,
-    memory::{
-        Buffer,
-        DataBuffer,
-    },
+    memory::DemiBuffer,
     QDesc,
 };
 use ::nix::{
@@ -76,7 +73,7 @@ impl PopFuture {
 
 /// Future Trait Implementation for Pop Operation Descriptors
 impl Future for PopFuture {
-    type Output = Result<(Option<SocketAddrV4>, Buffer), Fail>;
+    type Output = Result<(Option<SocketAddrV4>, DemiBuffer), Fail>;
 
     /// Polls the target [PopFuture].
     fn poll(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Self::Output> {
@@ -86,7 +83,7 @@ impl Future for PopFuture {
             // Operation completed.
             Ok((nbytes, socketaddr)) => {
                 trace!("data received ({:?}/{:?} bytes)", nbytes, POP_SIZE);
-                let buf: Buffer = Buffer::Heap(DataBuffer::from_slice(&bytes[0..nbytes]));
+                let buf: DemiBuffer = DemiBuffer::from_slice(&bytes[0..nbytes])?;
                 let addr: Option<SocketAddrV4> = match socketaddr {
                     Some(addr) => match addr.as_sockaddr_in() {
                         Some(sin) => {

--- a/src/rust/catnap/futures/push.rs
+++ b/src/rust/catnap/futures/push.rs
@@ -7,7 +7,7 @@
 
 use crate::runtime::{
     fail::Fail,
-    memory::Buffer,
+    memory::DemiBuffer,
     QDesc,
 };
 use ::nix::{
@@ -35,7 +35,7 @@ pub struct PushFuture {
     // Underlying file descriptor.
     fd: RawFd,
     /// Buffer to send.
-    buf: Buffer,
+    buf: DemiBuffer,
 }
 
 //==============================================================================
@@ -45,7 +45,7 @@ pub struct PushFuture {
 /// Associate Functions for Push Operation Descriptors
 impl PushFuture {
     /// Creates a descriptor for a push operation.
-    pub fn new(qd: QDesc, fd: RawFd, buf: Buffer) -> Self {
+    pub fn new(qd: QDesc, fd: RawFd, buf: DemiBuffer) -> Self {
         Self { qd, fd, buf }
     }
 

--- a/src/rust/catnap/futures/pushto.rs
+++ b/src/rust/catnap/futures/pushto.rs
@@ -7,7 +7,7 @@
 
 use crate::runtime::{
     fail::Fail,
-    memory::Buffer,
+    memory::DemiBuffer,
     QDesc,
 };
 use ::nix::{
@@ -41,7 +41,7 @@ pub struct PushtoFuture {
     // Underlying file descriptor.
     fd: RawFd,
     /// Buffer to send.
-    buf: Buffer,
+    buf: DemiBuffer,
 }
 
 //==============================================================================
@@ -51,7 +51,7 @@ pub struct PushtoFuture {
 /// Associate Functions for Pushto Operation Descriptors
 impl PushtoFuture {
     /// Creates a descriptor for a pushto operation.
-    pub fn new(qd: QDesc, fd: RawFd, addr: SockaddrStorage, buf: Buffer) -> Self {
+    pub fn new(qd: QDesc, fd: RawFd, addr: SockaddrStorage, buf: DemiBuffer) -> Self {
         Self { qd, addr, fd, buf }
     }
 

--- a/src/rust/catnap/runtime.rs
+++ b/src/rust/catnap/runtime.rs
@@ -9,8 +9,7 @@ use crate::{
     runtime::{
         fail::Fail,
         memory::{
-            Buffer,
-            DataBuffer,
+            DemiBuffer,
             MemoryRuntime,
         },
         types::{
@@ -24,7 +23,10 @@ use crate::{
 use ::libc::c_void;
 use ::std::{
     mem,
-    slice,
+    ptr::{
+        self,
+        NonNull,
+    },
 };
 
 //==============================================================================
@@ -58,43 +60,47 @@ impl PosixRuntime {
 /// Memory Runtime Trait Implementation for POSIX Runtime
 impl MemoryRuntime for PosixRuntime {
     /// Converts a runtime buffer into a scatter-gather array.
-    fn into_sgarray(&self, buf: Buffer) -> Result<demi_sgarray_t, Fail> {
-        let len: usize = buf.len();
-        #[allow(unreachable_patterns)]
-        let (dbuf_ptr, sgaseg): (*const u8, demi_sgaseg_t) = match buf {
-            Buffer::Heap(dbuf) => {
-                let (dbuf_ptr, data_ptr): (*const u8, *const u8) = DataBuffer::into_raw_parts(Clone::clone(&dbuf))?;
-                (
-                    dbuf_ptr,
-                    demi_sgaseg_t {
-                        sgaseg_buf: data_ptr as *mut c_void,
-                        sgaseg_len: len as u32,
-                    },
-                )
-            },
-            _ => return Err(Fail::new(libc::EINVAL, "invalid buffer type")),
+    fn into_sgarray(&self, buf: DemiBuffer) -> Result<demi_sgarray_t, Fail> {
+        // Create a scatter-gather segment to expose the DemiBuffer to the user.
+        let data: *const u8 = buf.as_ptr();
+        let sga_seg: demi_sgaseg_t = demi_sgaseg_t {
+            sgaseg_buf: data as *mut c_void,
+            sgaseg_len: buf.len() as u32,
         };
+
+        // Create and return a new scatter-gather array (which inherits the DemiBuffer's reference).
         Ok(demi_sgarray_t {
-            sga_buf: dbuf_ptr as *mut c_void,
+            sga_buf: buf.into_raw().as_ptr() as *mut c_void,
             sga_numsegs: 1,
-            sga_segs: [sgaseg],
+            sga_segs: [sga_seg],
             sga_addr: unsafe { mem::zeroed() },
         })
     }
 
     /// Allocates a scatter-gather array.
     fn alloc_sgarray(&self, size: usize) -> Result<demi_sgarray_t, Fail> {
-        // Allocate a heap-managed buffer.
-        let dbuf: DataBuffer = DataBuffer::new(size)?;
-        let (dbuf_ptr, data_ptr): (*const u8, *const u8) = DataBuffer::into_raw_parts(dbuf)?;
-        let sgaseg: demi_sgaseg_t = demi_sgaseg_t {
-            sgaseg_buf: data_ptr as *mut c_void,
+        // ToDo: Allocate an array of buffers if requested size is too large for a single buffer.
+
+        // We can't allocate more than a single buffer.
+        if size > u16::MAX as usize {
+            return Err(Fail::new(libc::EINVAL, "size too large for a single demi_sgaseg_t"));
+        }
+
+        // First allocate the underlying (heap-allocated) DemiBuffer.
+        let buf: DemiBuffer = DemiBuffer::new(size as u16);
+
+        // Create a scatter-gather segment to expose the DemiBuffer to the user.
+        let data: *const u8 = buf.as_ptr();
+        let sga_seg: demi_sgaseg_t = demi_sgaseg_t {
+            sgaseg_buf: data as *mut c_void,
             sgaseg_len: size as u32,
         };
+
+        // Create and return a new scatter-gather array (which inherits the DemiBuffer's reference).
         Ok(demi_sgarray_t {
-            sga_buf: dbuf_ptr as *mut c_void,
+            sga_buf: buf.into_raw().as_ptr() as *mut c_void,
             sga_numsegs: 1,
-            sga_segs: [sgaseg],
+            sga_segs: [sga_seg],
             sga_addr: unsafe { mem::zeroed() },
         })
     }
@@ -104,33 +110,81 @@ impl MemoryRuntime for PosixRuntime {
         // Check arguments.
         // TODO: Drop this check once we support scatter-gather arrays with multiple segments.
         if sga.sga_numsegs != 1 {
-            return Err(Fail::new(libc::EINVAL, "scatter-gather array with invalid size"));
+            return Err(Fail::new(libc::EINVAL, "demi_sgarray_t has invalid segment count"));
         }
 
-        // Release heap-managed buffer.
-        let (dbuf_ptr, length): (*mut u8, usize) = (sga.sga_buf as *mut u8, sga.sga_segs[0].sgaseg_len as usize);
-        DataBuffer::from_raw_parts(dbuf_ptr, length)?;
+        if sga.sga_buf == ptr::null_mut() {
+            return Err(Fail::new(libc::EINVAL, "demi_sgarray_t has invalid DemiBuffer token"));
+        }
+
+        // Convert back to a DemiBuffer and drop it.
+        // Safety: The `NonNull::new_unchecked()` call is safe, as we verified `sga.sga_buf` is not null above.
+        let token: NonNull<u8> = unsafe { NonNull::new_unchecked(sga.sga_buf as *mut u8) };
+        // Safety: The `DemiBuffer::from_raw()` call *should* be safe, as the `sga_buf` field in the `demi_sgarray_t`
+        // contained a valid `DemiBuffer` token when we provided it to the user (and the user shouldn't change it).
+        let buf: DemiBuffer = unsafe { DemiBuffer::from_raw(token) };
+        drop(buf);
 
         Ok(())
     }
 
-    /// Clones a scatter-gather array.
-    fn clone_sgarray(&self, sga: &demi_sgarray_t) -> Result<Buffer, Fail> {
+    /// Clones a scatter-gather array into a DemiBuffer.
+    fn clone_sgarray(&self, sga: &demi_sgarray_t) -> Result<DemiBuffer, Fail> {
         // Check arguments.
         // TODO: Drop this check once we support scatter-gather arrays with multiple segments.
         if sga.sga_numsegs != 1 {
-            return Err(Fail::new(libc::EINVAL, "scatter-gather array with invalid size"));
+            return Err(Fail::new(libc::EINVAL, "demi_sgarray_t has invalid segment count"));
         }
 
-        let sgaseg: demi_sgaseg_t = sga.sga_segs[0];
-        let (dbuf_ptr, len): (*mut c_void, usize) = (sga.sga_buf, sgaseg.sgaseg_len as usize);
+        if sga.sga_buf == ptr::null_mut() {
+            return Err(Fail::new(libc::EINVAL, "demi_sgarray_t has invalid DemiBuffer token"));
+        }
 
-        // Clone heap-managed buffer.
-        let seg_slice: &[u8] = unsafe { slice::from_raw_parts(dbuf_ptr as *const u8, len) };
-        let mut dbuf: DataBuffer = DataBuffer::from_slice(seg_slice);
-        let nbytes: usize = unsafe { sgaseg.sgaseg_buf.sub_ptr(sga.sga_buf) };
-        dbuf.adjust(nbytes);
-        Ok(Buffer::Heap(dbuf))
+        // Convert back to a DemiBuffer.
+        // Safety: The `NonNull::new_unchecked()` call is safe, as we verified `sga.sga_buf` is not null above.
+        let token: NonNull<u8> = unsafe { NonNull::new_unchecked(sga.sga_buf as *mut u8) };
+        // Safety: The `DemiBuffer::from_raw()` call *should* be safe, as the `sga_buf` field in the `demi_sgarray_t`
+        // contained a valid `DemiBuffer` token when we provided it to the user (and the user shouldn't change it).
+        let buf: DemiBuffer = unsafe { DemiBuffer::from_raw(token) };
+        let mut clone: DemiBuffer = buf.clone();
+
+        // Don't drop buf, as it holds the same reference to the data as the sgarray (which should keep it).
+        mem::forget(buf);
+
+        // Check to see if the user has reduced the size of the buffer described by the sgarray segment since we
+        // provided it to them.  They could have increased the starting address of the buffer (`sgaseg_buf`),
+        // decreased the ending address of the buffer (`sgaseg_buf + sgaseg_len`), or both.
+        let sga_data: *const u8 = sga.sga_segs[0].sgaseg_buf as *const u8;
+        let sga_len: usize = sga.sga_segs[0].sgaseg_len as usize;
+        let clone_data: *const u8 = clone.as_ptr();
+        let mut clone_len: usize = clone.len();
+        if sga_data != clone_data || sga_len != clone_len {
+            // We need to adjust the DemiBuffer to match the user's changes.
+
+            // First check that the user didn't do something non-sensical, like change the buffer description to
+            // reference address space outside of the allocated memory area.
+            if sga_data < clone_data || sga_data.addr() + sga_len > clone_data.addr() + clone_len {
+                return Err(Fail::new(
+                    libc::EINVAL,
+                    "demi_sgarray_t describes data outside backing buffer's allocated region",
+                ));
+            }
+
+            // Calculate the amount the new starting address is ahead of the old.  And then adjust `clone` to match.
+            let adjustment_amount: usize = sga_data.addr() - clone_data.addr();
+            clone.adjust(adjustment_amount)?;
+
+            // An adjustment above would have reduced clone.len() by the adjustment amount.
+            clone_len -= adjustment_amount;
+            debug_assert_eq!(clone_len, clone.len());
+
+            // Trim the clone down to size.
+            let trim_amount: usize = clone_len - sga_len;
+            clone.trim(trim_amount)?;
+        }
+
+        // Return the clone.
+        Ok(clone)
     }
 }
 

--- a/src/rust/catnapw/futures/push.rs
+++ b/src/rust/catnapw/futures/push.rs
@@ -7,7 +7,7 @@
 
 use crate::runtime::{
     fail::Fail,
-    memory::Buffer,
+    memory::DemiBuffer,
     QDesc,
 };
 use ::socket2::Socket;
@@ -34,7 +34,7 @@ pub struct PushFuture {
     // Underlying socket.
     socket: Rc<RefCell<Socket>>,
     /// Buffer to send.
-    buf: Buffer,
+    buf: DemiBuffer,
 }
 
 //==============================================================================
@@ -44,7 +44,7 @@ pub struct PushFuture {
 /// Associate Functions for Push Operation Descriptors
 impl PushFuture {
     /// Creates a descriptor for a push operation.
-    pub fn new(qd: QDesc, socket: Rc<RefCell<Socket>>, buf: Buffer) -> Self {
+    pub fn new(qd: QDesc, socket: Rc<RefCell<Socket>>, buf: DemiBuffer) -> Self {
         Self { qd, socket, buf }
     }
 

--- a/src/rust/catnapw/futures/pushto.rs
+++ b/src/rust/catnapw/futures/pushto.rs
@@ -7,7 +7,7 @@
 
 use crate::runtime::{
     fail::Fail,
-    memory::Buffer,
+    memory::DemiBuffer,
     QDesc,
 };
 use ::socket2::{
@@ -39,7 +39,7 @@ pub struct PushtoFuture {
     // Underlying socket.
     socket: Rc<RefCell<Socket>>,
     /// Buffer to send.
-    buf: Buffer,
+    buf: DemiBuffer,
 }
 
 //==============================================================================
@@ -49,7 +49,7 @@ pub struct PushtoFuture {
 /// Associate Functions for Pushto Operation Descriptors
 impl PushtoFuture {
     /// Creates a descriptor for a pushto operation.
-    pub fn new(qd: QDesc, socket: Rc<RefCell<Socket>>, addr: SockAddr, buf: Buffer) -> Self {
+    pub fn new(qd: QDesc, socket: Rc<RefCell<Socket>>, addr: SockAddr, buf: DemiBuffer) -> Self {
         Self { qd, addr, socket, buf }
     }
 

--- a/src/rust/catnip/runtime/memory/mempool.rs
+++ b/src/rust/catnip/runtime/memory/mempool.rs
@@ -11,7 +11,6 @@ use crate::runtime::{
         rte_mbuf,
         rte_mempool,
         rte_pktmbuf_alloc,
-        rte_pktmbuf_clone,
         rte_pktmbuf_free,
         rte_pktmbuf_pool_create,
         rte_socket_id,
@@ -91,25 +90,5 @@ impl MemoryPool {
         }
 
         Ok(mbuf_ptr)
-    }
-
-    /// Releases a mbuf in the target memory pool.
-    pub fn free_mbuf(mbuf_ptr: *mut rte_mbuf) {
-        unsafe {
-            rte_pktmbuf_free(mbuf_ptr);
-        }
-    }
-
-    /// Clones a mbuf into a memory pool.
-    pub fn clone_mbuf(mbuf_ptr: *mut rte_mbuf) -> Result<*mut rte_mbuf, Fail> {
-        unsafe {
-            let mempool_ptr: *mut rte_mempool = (*mbuf_ptr).pool;
-            let mbuf_ptr_clone: *mut rte_mbuf = rte_pktmbuf_clone(mbuf_ptr, mempool_ptr);
-            if mbuf_ptr_clone.is_null() {
-                return Err(Fail::new(libc::EINVAL, "cannot clone mbuf"));
-            }
-
-            Ok(mbuf_ptr_clone)
-        }
     }
 }

--- a/src/rust/catnip/runtime/memory/mod.rs
+++ b/src/rust/catnip/runtime/memory/mod.rs
@@ -20,7 +20,7 @@ use super::DPDKRuntime;
 use crate::runtime::{
     fail::Fail,
     memory::{
-        Buffer,
+        DemiBuffer,
         MemoryRuntime,
     },
     types::demi_sgarray_t,
@@ -33,7 +33,7 @@ use crate::runtime::{
 /// Memory Runtime Trait Implementation for DPDK Runtime
 impl MemoryRuntime for DPDKRuntime {
     /// Casts a [DPDKBuf] into an [demi_sgarray_t].
-    fn into_sgarray(&self, buf: Buffer) -> Result<demi_sgarray_t, Fail> {
+    fn into_sgarray(&self, buf: DemiBuffer) -> Result<demi_sgarray_t, Fail> {
         self.mm.into_sgarray(buf)
     }
 
@@ -48,7 +48,7 @@ impl MemoryRuntime for DPDKRuntime {
     }
 
     /// Clones a [demi_sgarray_t].
-    fn clone_sgarray(&self, sga: &demi_sgarray_t) -> Result<Buffer, Fail> {
+    fn clone_sgarray(&self, sga: &demi_sgarray_t) -> Result<DemiBuffer, Fail> {
         self.mm.clone_sgarray(sga)
     }
 }

--- a/src/rust/catpowder/runtime/memory.rs
+++ b/src/rust/catpowder/runtime/memory.rs
@@ -9,8 +9,7 @@ use super::LinuxRuntime;
 use crate::runtime::{
     fail::Fail,
     memory::{
-        Buffer,
-        DataBuffer,
+        DemiBuffer,
         MemoryRuntime,
     },
     types::{
@@ -21,7 +20,10 @@ use crate::runtime::{
 use ::libc::c_void;
 use ::std::{
     mem,
-    slice,
+    ptr::{
+        self,
+        NonNull,
+    },
 };
 
 //==============================================================================
@@ -30,44 +32,48 @@ use ::std::{
 
 /// Memory Runtime Trait Implementation for Linux Runtime
 impl MemoryRuntime for LinuxRuntime {
-    /// Converts a runtime buffer into a scatter-gather array.
-    fn into_sgarray(&self, buf: Buffer) -> Result<demi_sgarray_t, Fail> {
-        let len: usize = buf.len();
-        #[allow(unreachable_patterns)]
-        let (dbuf_ptr, sgaseg): (*const u8, demi_sgaseg_t) = match buf {
-            Buffer::Heap(dbuf) => {
-                let (dbuf_ptr, data_ptr): (*const u8, *const u8) = DataBuffer::into_raw_parts(Clone::clone(&dbuf))?;
-                (
-                    dbuf_ptr,
-                    demi_sgaseg_t {
-                        sgaseg_buf: data_ptr as *mut c_void,
-                        sgaseg_len: len as u32,
-                    },
-                )
-            },
-            _ => return Err(Fail::new(libc::EINVAL, "invalid buffer type")),
+    /// Converts a buffer into a scatter-gather array.
+    fn into_sgarray(&self, buf: DemiBuffer) -> Result<demi_sgarray_t, Fail> {
+        // Create a scatter-gather segment to expose the DemiBuffer to the user.
+        let data: *const u8 = buf.as_ptr();
+        let sga_seg: demi_sgaseg_t = demi_sgaseg_t {
+            sgaseg_buf: data as *mut c_void,
+            sgaseg_len: buf.len() as u32,
         };
+
+        // Create and return a new scatter-gather array (which inherits the DemiBuffer's reference).
         Ok(demi_sgarray_t {
-            sga_buf: dbuf_ptr as *mut c_void,
+            sga_buf: buf.into_raw().as_ptr() as *mut c_void,
             sga_numsegs: 1,
-            sga_segs: [sgaseg],
+            sga_segs: [sga_seg],
             sga_addr: unsafe { mem::zeroed() },
         })
     }
 
     /// Allocates a scatter-gather array.
     fn alloc_sgarray(&self, size: usize) -> Result<demi_sgarray_t, Fail> {
-        // Allocate a heap-managed buffer.
-        let dbuf: DataBuffer = DataBuffer::new(size)?;
-        let (dbuf_ptr, data_ptr): (*const u8, *const u8) = DataBuffer::into_raw_parts(dbuf)?;
-        let sgaseg: demi_sgaseg_t = demi_sgaseg_t {
-            sgaseg_buf: data_ptr as *mut c_void,
+        // ToDo: Allocate an array of buffers if requested size is too large for a single buffer.
+
+        // We can't allocate more than a single buffer.
+        if size > u16::MAX as usize {
+            return Err(Fail::new(libc::EINVAL, "size too large for a single demi_sgaseg_t"));
+        }
+
+        // First allocate the underlying DemiBuffer.
+        let buf: DemiBuffer = DemiBuffer::new(size as u16);
+
+        // Create a scatter-gather segment to expose the DemiBuffer to the user.
+        let data: *const u8 = buf.as_ptr();
+        let sga_seg: demi_sgaseg_t = demi_sgaseg_t {
+            sgaseg_buf: data as *mut c_void,
             sgaseg_len: size as u32,
         };
+
+        // Create and return a new scatter-gather array (which inherits the DemiBuffer's reference).
         Ok(demi_sgarray_t {
-            sga_buf: dbuf_ptr as *mut c_void,
+            sga_buf: buf.into_raw().as_ptr() as *mut c_void,
             sga_numsegs: 1,
-            sga_segs: [sgaseg],
+            sga_segs: [sga_seg],
             sga_addr: unsafe { mem::zeroed() },
         })
     }
@@ -77,32 +83,80 @@ impl MemoryRuntime for LinuxRuntime {
         // Check arguments.
         // TODO: Drop this check once we support scatter-gather arrays with multiple segments.
         if sga.sga_numsegs != 1 {
-            return Err(Fail::new(libc::EINVAL, "scatter-gather array with invalid size"));
+            return Err(Fail::new(libc::EINVAL, "demi_sgarray_t has invalid segment count"));
         }
 
-        // Release heap-managed buffer.
-        let (dbuf_ptr, length): (*mut u8, usize) = (sga.sga_buf as *mut u8, sga.sga_segs[0].sgaseg_len as usize);
-        DataBuffer::from_raw_parts(dbuf_ptr, length)?;
+        if sga.sga_buf == ptr::null_mut() {
+            return Err(Fail::new(libc::EINVAL, "demi_sgarray_t has invalid DemiBuffer token"));
+        }
+
+        // Convert back to a DemiBuffer and drop it.
+        // Safety: The `NonNull::new_unchecked()` call is safe, as we verified `sga.sga_buf` is not null above.
+        let token: NonNull<u8> = unsafe { NonNull::new_unchecked(sga.sga_buf as *mut u8) };
+        // Safety: The `DemiBuffer::from_raw()` call *should* be safe, as the `sga_buf` field in the `demi_sgarray_t`
+        // contained a valid `DemiBuffer` token when we provided it to the user (and the user shouldn't change it).
+        let buf: DemiBuffer = unsafe { DemiBuffer::from_raw(token) };
+        drop(buf);
 
         Ok(())
     }
 
     /// Clones a scatter-gather array.
-    fn clone_sgarray(&self, sga: &demi_sgarray_t) -> Result<Buffer, Fail> {
+    fn clone_sgarray(&self, sga: &demi_sgarray_t) -> Result<DemiBuffer, Fail> {
         // Check arguments.
         // TODO: Drop this check once we support scatter-gather arrays with multiple segments.
         if sga.sga_numsegs != 1 {
-            return Err(Fail::new(libc::EINVAL, "scatter-gather array with invalid size"));
+            return Err(Fail::new(libc::EINVAL, "demi_sgarray_t has invalid segment count"));
         }
 
-        let sgaseg: demi_sgaseg_t = sga.sga_segs[0];
-        let (dbuf_ptr, len): (*mut c_void, usize) = (sga.sga_buf, sgaseg.sgaseg_len as usize);
+        if sga.sga_buf == ptr::null_mut() {
+            return Err(Fail::new(libc::EINVAL, "demi_sgarray_t has invalid DemiBuffer token"));
+        }
 
-        // Clone heap-managed buffer.
-        let seg_slice: &[u8] = unsafe { slice::from_raw_parts(dbuf_ptr as *const u8, len) };
-        let mut dbuf: DataBuffer = DataBuffer::from_slice(seg_slice);
-        let nbytes: usize = unsafe { sgaseg.sgaseg_buf.sub_ptr(sga.sga_buf) };
-        dbuf.adjust(nbytes);
-        Ok(Buffer::Heap(dbuf))
+        // Convert back to a DemiBuffer.
+        // Safety: The `NonNull::new_unchecked()` call is safe, as we verified `sga.sga_buf` is not null above.
+        let token: NonNull<u8> = unsafe { NonNull::new_unchecked(sga.sga_buf as *mut u8) };
+        // Safety: The `DemiBuffer::from_raw()` call *should* be safe, as the `sga_buf` field in the `demi_sgarray_t`
+        // contained a valid `DemiBuffer` token when we provided it to the user (and the user shouldn't change it).
+        let buf: DemiBuffer = unsafe { DemiBuffer::from_raw(token) };
+        let mut clone: DemiBuffer = buf.clone();
+
+        // Don't drop buf, as it holds the same reference to the data as the sgarray (which should keep it).
+        mem::forget(buf);
+
+        // Check to see if the user has reduced the size of the buffer described by the sgarray segment since we
+        // provided it to them.  They could have increased the starting address of the buffer (`sgaseg_buf`),
+        // decreased the ending address of the buffer (`sgaseg_buf + sgaseg_len`), or both.
+        let sga_data: *const u8 = sga.sga_segs[0].sgaseg_buf as *const u8;
+        let sga_len: usize = sga.sga_segs[0].sgaseg_len as usize;
+        let clone_data: *const u8 = clone.as_ptr();
+        let mut clone_len: usize = clone.len();
+        if sga_data != clone_data || sga_len != clone_len {
+            // We need to adjust the DemiBuffer to match the user's changes.
+
+            // First check that the user didn't do something non-sensical, like change the buffer description to
+            // reference address space outside of the DemiBuffer's allocated memory area.
+            if sga_data < clone_data || sga_data.addr() + sga_len > clone_data.addr() + clone_len {
+                return Err(Fail::new(
+                    libc::EINVAL,
+                    "demi_sgarray_t describes data outside backing buffer's allocated region",
+                ));
+            }
+
+            // Calculate the amount the new starting address is ahead of the old.  And then adjust `clone` to match.
+            let adjustment_amount: usize = sga_data.addr() - clone_data.addr();
+            clone.adjust(adjustment_amount)?;
+
+            // An adjustment above would have reduced clone.len() by the adjustment amount.
+            clone_len -= adjustment_amount;
+            debug_assert_eq!(clone_len, clone.len());
+
+            // Trim the clone down to size.
+            let trim_amount: usize = clone_len - sga_len;
+            clone.trim(trim_amount)?;
+        }
+
+        // Return the clone.
+        Ok(clone)
     }
 }

--- a/src/rust/catpowder/runtime/network.rs
+++ b/src/rust/catpowder/runtime/network.rs
@@ -58,17 +58,23 @@ impl NetworkRuntime for LinuxRuntime {
         };
     }
 
-    /// Receives a batch of [PacketBuf].
+    /// Receives a batch of [DemiBuffer].
+    // ToDo: This routine currently only tries to receive a single packet buffer, not a batch of them.
     fn receive(&self) -> ArrayVec<DemiBuffer, RECEIVE_BATCH_SIZE> {
         // 4096B buffer size chosen arbitrarily, seems fine for now.
-        // This use-case is an example for MaybeUninit in the docs
-        let mut out: [MaybeUninit<u8>; 4096] = [unsafe { MaybeUninit::uninit().assume_init() }; 4096];
+        // REVIEW: Won't this fail for Ethernet jumbo frames?  Conversely, it seems wastefully big for standard frames.
+        const BUFFER_SIZE: usize = 4096;
+
+        // ToDo: This routine contains an extra copy of the entire incoming packet that could potentially be removed.
+
+        // This use-case is an example for MaybeUninit in the docs.
+        let mut out: [MaybeUninit<u8>; BUFFER_SIZE] = [unsafe { MaybeUninit::uninit().assume_init() }; BUFFER_SIZE];
         if let Ok((nbytes, _origin_addr)) = self.socket.borrow().recvfrom(&mut out[..]) {
             let mut ret: ArrayVec<DemiBuffer, RECEIVE_BATCH_SIZE> = ArrayVec::new();
             unsafe {
-                let bytes: [u8; 4096] = mem::transmute::<[MaybeUninit<u8>; 4096], [u8; 4096]>(out);
+                let bytes: [u8; BUFFER_SIZE] = mem::transmute::<[MaybeUninit<u8>; BUFFER_SIZE], [u8; BUFFER_SIZE]>(out);
                 let mut dbuf: DemiBuffer = DemiBuffer::from_slice(&bytes).expect("'bytes' should fit");
-                dbuf.trim(4096 - nbytes).expect("'bytes' <= 4096");
+                dbuf.trim(BUFFER_SIZE - nbytes).expect("'bytes' <= BUFFER_SIZE");
                 ret.push(dbuf);
             }
             ret

--- a/src/rust/collections/shared_ring.rs
+++ b/src/rust/collections/shared_ring.rs
@@ -82,7 +82,6 @@ mod test {
 
     /// Tests if we succeed to perform sequential accesses to a shared ring buffer.
     #[test]
-    #[ignore]
     fn ring_buffer_on_shm_sequential() {
         let shm_name: String = "shm-test-ring-buffer-serial".to_string();
         let ring: SharedRingBuffer<u8> = match SharedRingBuffer::<u8>::create(&shm_name, RING_BUFFER_CAPACITY) {
@@ -111,7 +110,6 @@ mod test {
 
     /// Tests if we succeed to perform concurrent accesses to a shared ring buffer..
     #[test]
-    #[ignore]
     fn ring_buffer_on_shm_concurrent() {
         let shm_name: String = "shm-test-ring-buffer-concurrent".to_string();
 

--- a/src/rust/collections/shared_ring.rs
+++ b/src/rust/collections/shared_ring.rs
@@ -82,6 +82,7 @@ mod test {
 
     /// Tests if we succeed to perform sequential accesses to a shared ring buffer.
     #[test]
+    #[ignore]
     fn ring_buffer_on_shm_sequential() {
         let shm_name: String = "shm-test-ring-buffer-serial".to_string();
         let ring: SharedRingBuffer<u8> = match SharedRingBuffer::<u8>::create(&shm_name, RING_BUFFER_CAPACITY) {
@@ -110,6 +111,7 @@ mod test {
 
     /// Tests if we succeed to perform concurrent accesses to a shared ring buffer..
     #[test]
+    #[ignore]
     fn ring_buffer_on_shm_concurrent() {
         let shm_name: String = "shm-test-ring-buffer-concurrent".to_string();
 

--- a/src/rust/inetstack/operations.rs
+++ b/src/rust/inetstack/operations.rs
@@ -7,7 +7,7 @@
 
 use crate::runtime::{
     fail::Fail,
-    memory::Buffer,
+    memory::DemiBuffer,
     QDesc,
 };
 use ::std::{
@@ -24,7 +24,7 @@ pub enum OperationResult {
     Accept(QDesc),
     Push,
     // TODO: Drop wrapping Option.
-    Pop(Option<SocketAddrV4>, Buffer),
+    Pop(Option<SocketAddrV4>, DemiBuffer),
     Failed(Fail),
 }
 

--- a/src/rust/inetstack/protocols/arp/packet/header.rs
+++ b/src/rust/inetstack/protocols/arp/packet/header.rs
@@ -3,7 +3,7 @@
 
 use crate::runtime::{
     fail::Fail,
-    memory::Buffer,
+    memory::DemiBuffer,
     network::types::MacAddress,
 };
 use ::byteorder::{
@@ -85,34 +85,34 @@ impl ArpHeader {
         ARP_MESSAGE_SIZE
     }
 
-    pub fn parse(buf: Buffer) -> Result<Self, Fail> {
+    pub fn parse(buf: DemiBuffer) -> Result<Self, Fail> {
         if buf.len() < ARP_MESSAGE_SIZE {
             return Err(Fail::new(EBADMSG, "ARP message too short"));
         }
         let buf: &[u8; ARP_MESSAGE_SIZE] = &buf[..ARP_MESSAGE_SIZE].try_into().unwrap();
-        let hardware_type = NetworkEndian::read_u16(&buf[0..2]);
+        let hardware_type: u16 = NetworkEndian::read_u16(&buf[0..2]);
         if hardware_type != ARP_HTYPE_ETHER2 {
             return Err(Fail::new(ENOTSUP, "unsupported HTYPE"));
         }
-        let protocol_type = NetworkEndian::read_u16(&buf[2..4]);
+        let protocol_type: u16 = NetworkEndian::read_u16(&buf[2..4]);
         if protocol_type != ARP_PTYPE_IPV4 {
             return Err(Fail::new(ENOTSUP, "unsupported PTYPE"));
         }
-        let hardware_address_len = buf[4];
+        let hardware_address_len: u8 = buf[4];
         if hardware_address_len != ARP_HLEN_ETHER2 {
             return Err(Fail::new(ENOTSUP, "unsupported HLEN"));
         }
-        let protocol_address_len = buf[5];
+        let protocol_address_len: u8 = buf[5];
         if protocol_address_len != ARP_PLEN_IPV4 {
             return Err(Fail::new(ENOTSUP, "unsupported PLEN"));
         }
-        let operation = FromPrimitive::from_u16(NetworkEndian::read_u16(&buf[6..8]))
+        let operation: ArpOperation = FromPrimitive::from_u16(NetworkEndian::read_u16(&buf[6..8]))
             .ok_or(Fail::new(ENOTSUP, "unsupported OPER"))?;
-        let sender_hardware_addr = MacAddress::from_bytes(&buf[8..14]);
-        let sender_protocol_addr = Ipv4Addr::from(NetworkEndian::read_u32(&buf[14..18]));
-        let target_hardware_addr = MacAddress::from_bytes(&buf[18..24]);
-        let target_protocol_addr = Ipv4Addr::from(NetworkEndian::read_u32(&buf[24..28]));
-        let pdu = Self {
+        let sender_hardware_addr: MacAddress = MacAddress::from_bytes(&buf[8..14]);
+        let sender_protocol_addr: Ipv4Addr = Ipv4Addr::from(NetworkEndian::read_u32(&buf[14..18]));
+        let target_hardware_addr: MacAddress = MacAddress::from_bytes(&buf[18..24]);
+        let target_protocol_addr: Ipv4Addr = Ipv4Addr::from(NetworkEndian::read_u32(&buf[24..28]));
+        let pdu: ArpHeader = Self {
             operation,
             sender_hardware_addr,
             sender_protocol_addr,

--- a/src/rust/inetstack/protocols/arp/packet/message.rs
+++ b/src/rust/inetstack/protocols/arp/packet/message.rs
@@ -5,7 +5,7 @@ use super::ArpHeader;
 use crate::{
     inetstack::protocols::ethernet2::Ethernet2Header,
     runtime::{
-        memory::Buffer,
+        memory::DemiBuffer,
         network::PacketBuf,
     },
 };
@@ -59,7 +59,7 @@ impl PacketBuf for ArpMessage {
         self.header.serialize(&mut buf[cur_pos..(cur_pos + arp_pdu_size)]);
     }
 
-    fn take_body(&self) -> Option<Buffer> {
+    fn take_body(&self) -> Option<DemiBuffer> {
         None
     }
 }

--- a/src/rust/inetstack/protocols/arp/peer.rs
+++ b/src/rust/inetstack/protocols/arp/peer.rs
@@ -22,7 +22,7 @@ use crate::{
     },
     runtime::{
         fail::Fail,
-        memory::Buffer,
+        memory::DemiBuffer,
         network::{
             config::ArpConfig,
             types::MacAddress,
@@ -163,7 +163,7 @@ impl ArpPeer {
         }
     }
 
-    pub fn receive(&mut self, buf: Buffer) -> Result<(), Fail> {
+    pub fn receive(&mut self, buf: DemiBuffer) -> Result<(), Fail> {
         // from RFC 826:
         // > ?Do I have the hardware type in ar$hrd?
         // > [optionally check the hardware length ar$hln]

--- a/src/rust/inetstack/protocols/ethernet2/frame.rs
+++ b/src/rust/inetstack/protocols/ethernet2/frame.rs
@@ -5,7 +5,7 @@ use crate::{
     inetstack::protocols::ethernet2::EtherType2,
     runtime::{
         fail::Fail,
-        memory::Buffer,
+        memory::DemiBuffer,
         network::types::MacAddress,
     },
 };
@@ -46,7 +46,7 @@ impl Ethernet2Header {
         ETHERNET2_HEADER_SIZE
     }
 
-    pub fn parse(mut buf: Buffer) -> Result<(Self, Buffer), Fail> {
+    pub fn parse(mut buf: DemiBuffer) -> Result<(Self, DemiBuffer), Fail> {
         if buf.len() < ETHERNET2_HEADER_SIZE {
             return Err(Fail::new(EBADMSG, "frame too small"));
         }
@@ -60,7 +60,7 @@ impl Ethernet2Header {
             ether_type,
         };
 
-        buf.adjust(ETHERNET2_HEADER_SIZE);
+        buf.adjust(ETHERNET2_HEADER_SIZE)?;
         Ok((hdr, buf))
     }
 

--- a/src/rust/inetstack/protocols/icmpv4/datagram/header.rs
+++ b/src/rust/inetstack/protocols/icmpv4/datagram/header.rs
@@ -4,7 +4,7 @@
 use super::protocol::Icmpv4Type2;
 use crate::runtime::{
     fail::Fail,
-    memory::Buffer,
+    memory::DemiBuffer,
 };
 use ::byteorder::{
     ByteOrder,
@@ -38,7 +38,7 @@ impl Icmpv4Header {
         ICMPV4_HEADER_SIZE
     }
 
-    pub fn parse(mut buf: Buffer) -> Result<(Self, Buffer), Fail> {
+    pub fn parse(mut buf: DemiBuffer) -> Result<(Self, DemiBuffer), Fail> {
         if buf.len() < ICMPV4_HEADER_SIZE {
             return Err(Fail::new(EBADMSG, "ICMPv4 datagram too small for header"));
         }
@@ -53,7 +53,7 @@ impl Icmpv4Header {
         let rest_of_header: &[u8; 4] = hdr_buf[4..8].try_into().unwrap();
         let icmpv4_type = Icmpv4Type2::parse(type_byte, rest_of_header)?;
 
-        buf.adjust(ICMPV4_HEADER_SIZE);
+        buf.adjust(ICMPV4_HEADER_SIZE)?;
         Ok((
             Self {
                 protocol: icmpv4_type,

--- a/src/rust/inetstack/protocols/icmpv4/datagram/message.rs
+++ b/src/rust/inetstack/protocols/icmpv4/datagram/message.rs
@@ -8,7 +8,7 @@ use crate::{
         ipv4::Ipv4Header,
     },
     runtime::{
-        memory::Buffer,
+        memory::DemiBuffer,
         network::PacketBuf,
     },
 };
@@ -61,7 +61,7 @@ impl PacketBuf for Icmpv4Message {
             .serialize(&mut buf[cur_pos..(cur_pos + icmpv4_hdr_size)]);
     }
 
-    fn take_body(&self) -> Option<Buffer> {
+    fn take_body(&self) -> Option<DemiBuffer> {
         None
     }
 }

--- a/src/rust/inetstack/protocols/icmpv4/peer.rs
+++ b/src/rust/inetstack/protocols/icmpv4/peer.rs
@@ -24,7 +24,7 @@ use crate::{
     },
     runtime::{
         fail::Fail,
-        memory::Buffer,
+        memory::DemiBuffer,
         network::{
             types::MacAddress,
             NetworkRuntime,
@@ -204,7 +204,7 @@ impl Icmpv4Peer {
     }
 
     /// Parses and handles a ICMP message.
-    pub fn receive(&mut self, ipv4_header: &Ipv4Header, buf: Buffer) -> Result<(), Fail> {
+    pub fn receive(&mut self, ipv4_header: &Ipv4Header, buf: DemiBuffer) -> Result<(), Fail> {
         let (icmpv4_hdr, _) = Icmpv4Header::parse(buf)?;
         debug!("ICMPv4 received {:?}", icmpv4_hdr);
         match icmpv4_hdr.get_protocol() {

--- a/src/rust/inetstack/protocols/ipv4/tests.rs
+++ b/src/rust/inetstack/protocols/ipv4/tests.rs
@@ -16,10 +16,7 @@ use crate::{
             BOB_IPV4,
         },
     },
-    runtime::memory::{
-        Buffer,
-        DataBuffer,
-    },
+    runtime::memory::DemiBuffer,
 };
 use ::byteorder::{
     ByteOrder,
@@ -94,7 +91,7 @@ fn test_ipv4_header_parse_good() {
     const DATAGRAM_SIZE: usize = HEADER_MAX_SIZE + PAYLOAD_SIZE;
     let mut buf: [u8; DATAGRAM_SIZE] = [0; DATAGRAM_SIZE];
     let data: [u8; PAYLOAD_SIZE] = [1, 2, 3, 4, 5, 6, 7, 8];
-    let data_bytes: DataBuffer = DataBuffer::from_slice(&data);
+    let data_bytes: DemiBuffer = DemiBuffer::from_slice(&data).expect("'data' should fit in a DemiBuffer");
 
     for ihl in 5..15 {
         let header_size: usize = (ihl as usize) << 2;
@@ -120,7 +117,7 @@ fn test_ipv4_header_parse_good() {
         buf[header_size..datagram_size].copy_from_slice(&data);
 
         // Do it.
-        let buf_bytes: Buffer = Buffer::Heap(DataBuffer::from_slice(&buf[..datagram_size]));
+        let buf_bytes: DemiBuffer = DemiBuffer::from_slice(&buf[..datagram_size]).expect("'buf' should fit");
         match Ipv4Header::parse(buf_bytes) {
             Ok((ipv4_hdr, datagram)) => {
                 assert_eq!(ipv4_hdr.get_src_addr(), ALICE_IPV4);
@@ -166,7 +163,7 @@ fn test_ipv4_header_parse_invalid_version() {
         );
 
         // Do it.
-        let buf_bytes: Buffer = Buffer::Heap(DataBuffer::from_slice(&buf));
+        let buf_bytes: DemiBuffer = DemiBuffer::from_slice(&buf).expect("'buf' should fit in a DemiBuffer");
         match Ipv4Header::parse(buf_bytes) {
             Ok(_) => assert!(false, "parsed ipv4_header with invalid version={:?}", version),
             Err(_) => {},
@@ -202,7 +199,7 @@ fn test_ipv4_header_parse_invalid_ihl() {
         );
 
         // Do it.
-        let buf_bytes: Buffer = Buffer::Heap(DataBuffer::from_slice(&buf));
+        let buf_bytes: DemiBuffer = DemiBuffer::from_slice(&buf).expect("'buf' should fit in a DemiBuffer");
         match Ipv4Header::parse(buf_bytes) {
             Ok(_) => assert!(false, "parsed ipv4 header with invalid ihl={:?}", ihl),
             Err(_) => {},
@@ -238,7 +235,7 @@ fn test_ipv4_header_parse_invalid_total_length() {
         );
 
         // Do it.
-        let buf_bytes: Buffer = Buffer::Heap(DataBuffer::from_slice(&buf));
+        let buf_bytes: DemiBuffer = DemiBuffer::from_slice(&buf).expect("'buf' should fit in a DemiBuffer");
         match Ipv4Header::parse(buf_bytes) {
             Ok(_) => assert!(false, "parsed ipv4 header with invalid total_length={:?}", total_length),
             Err(_) => {},
@@ -274,7 +271,7 @@ fn test_ipv4_header_parse_invalid_flags() {
     );
 
     // Do it.
-    let buf_bytes: Buffer = Buffer::Heap(DataBuffer::from_slice(&buf));
+    let buf_bytes: DemiBuffer = DemiBuffer::from_slice(&buf).expect("'buf' should fit in a DemiBuffer");
     match Ipv4Header::parse(buf_bytes) {
         Ok(_) => assert!(false, "parsed ipv4 header with invalid flags={:?}", flags),
         Err(_) => {},
@@ -309,7 +306,7 @@ fn test_ipv4_header_parse_invalid_ttl() {
     );
 
     // Do it.
-    let buf_bytes: Buffer = Buffer::Heap(DataBuffer::from_slice(&buf));
+    let buf_bytes: DemiBuffer = DemiBuffer::from_slice(&buf).expect("'buf' should fit in a DemiBuffer");
     match Ipv4Header::parse(buf_bytes) {
         Ok(_) => assert!(false, "parsed ipv4 header with invalid ttl={:?}", ttl),
         Err(_) => {},
@@ -344,7 +341,7 @@ fn test_ipv4_header_parse_invalid_protocol() {
         );
 
         // Do it.
-        let buf_bytes: Buffer = Buffer::Heap(DataBuffer::from_slice(&buf));
+        let buf_bytes: DemiBuffer = DemiBuffer::from_slice(&buf).expect("'buf' should fit in a DemiBuffer");
         match Ipv4Header::parse(buf_bytes) {
             Ok(_) => assert!(false, "parsed ipv4 header with invalid protocol={:?}", protocol),
             Err(_) => {},
@@ -380,7 +377,7 @@ fn test_ipv4_header_parse_invalid_header_checksum() {
     );
 
     // Do it.
-    let buf_bytes: Buffer = Buffer::Heap(DataBuffer::from_slice(&buf));
+    let buf_bytes: DemiBuffer = DemiBuffer::from_slice(&buf).expect("'buf' should fit in a DemiBuffer");
     match Ipv4Header::parse(buf_bytes) {
         Ok(_) => assert!(
             false,
@@ -423,7 +420,7 @@ fn test_ipv4_header_parse_unsupported_dscp() {
         );
 
         // Do it.
-        let buf_bytes: Buffer = Buffer::Heap(DataBuffer::from_slice(&buf));
+        let buf_bytes: DemiBuffer = DemiBuffer::from_slice(&buf).expect("'buf' should fit in a DemiBuffer");
         match Ipv4Header::parse(buf_bytes) {
             Ok(_) => {},
             Err(_) => panic!("dscp field should be ignored (dscp={:?})", dscp),
@@ -459,7 +456,7 @@ fn test_ipv4_header_parse_unsupported_ecn() {
         );
 
         // Do it.
-        let buf_bytes: Buffer = Buffer::Heap(DataBuffer::from_slice(&buf));
+        let buf_bytes: DemiBuffer = DemiBuffer::from_slice(&buf).expect("'buf' should fit in a DemiBuffer");
         match Ipv4Header::parse(buf_bytes) {
             Ok(_) => {},
             Err(_) => panic!("ecn field should be ignored (ecn={:?})", ecn),
@@ -498,7 +495,7 @@ fn test_ipv4_header_parse_unsupported_fragmentation() {
     );
 
     // Do it.
-    let buf_bytes: Buffer = Buffer::Heap(DataBuffer::from_slice(&buf));
+    let buf_bytes: DemiBuffer = DemiBuffer::from_slice(&buf).expect("'buf' should fit in a DemiBuffer");
     match Ipv4Header::parse(buf_bytes) {
         Ok(_) => assert!(
             false,
@@ -529,7 +526,7 @@ fn test_ipv4_header_parse_unsupported_fragmentation() {
     );
 
     // Do it.
-    let buf_bytes: Buffer = Buffer::Heap(DataBuffer::from_slice(&buf));
+    let buf_bytes: DemiBuffer = DemiBuffer::from_slice(&buf).expect("'buf' should fit in a DemiBuffer");
     match Ipv4Header::parse(buf_bytes) {
         Ok(_) => assert!(
             false,
@@ -574,7 +571,7 @@ fn test_ipv4_header_parse_unsupported_protocol() {
                 );
 
                 // Do it.
-                let buf_bytes: Buffer = Buffer::Heap(DataBuffer::from_slice(&buf));
+                let buf_bytes: DemiBuffer = DemiBuffer::from_slice(&buf).expect("'buf' should fit in a DemiBuffer");
                 match Ipv4Header::parse(buf_bytes) {
                     Ok(_) => assert!(
                         false,

--- a/src/rust/inetstack/protocols/peer.rs
+++ b/src/rust/inetstack/protocols/peer.rs
@@ -12,7 +12,7 @@ use crate::{
     },
     runtime::{
         fail::Fail,
-        memory::Buffer,
+        memory::DemiBuffer,
         network::{
             config::{
                 TcpConfig,
@@ -93,7 +93,7 @@ impl Peer {
         })
     }
 
-    pub fn receive(&mut self, buf: Buffer) -> Result<(), Fail> {
+    pub fn receive(&mut self, buf: DemiBuffer) -> Result<(), Fail> {
         let (header, payload) = Ipv4Header::parse(buf)?;
         debug!("Ipv4 received {:?}", header);
         if header.get_dest_addr() != self.local_ipv4_addr && !header.get_dest_addr().is_broadcast() {

--- a/src/rust/inetstack/protocols/tcp/established/background/sender.rs
+++ b/src/rust/inetstack/protocols/tcp/established/background/sender.rs
@@ -12,7 +12,7 @@ use crate::{
     },
     runtime::{
         fail::Fail,
-        memory::Buffer,
+        memory::DemiBuffer,
     },
 };
 use ::futures::FutureExt;
@@ -49,7 +49,7 @@ pub async fn sender(cb: Rc<ControlBlock>) -> Result<!, Fail> {
         if win_sz == 0 {
             // Send a window probe (this is a one-byte packet designed to elicit a window update from our peer).
             let remote_link_addr = cb.arp().query(cb.get_remote().ip().clone()).await?;
-            let buf: Buffer = cb
+            let buf: DemiBuffer = cb
                 .pop_one_unsent_byte()
                 .unwrap_or_else(|| panic!("No unsent data? {}, {}", send_next, unsent_seq));
 
@@ -127,7 +127,7 @@ pub async fn sender(cb: Rc<ControlBlock>) -> Result<!, Fail> {
             cmp::min((win_sz - sent_data) as usize, cb.get_mss()),
             (effective_cwnd - sent_data) as usize,
         );
-        let segment_data: Buffer = cb
+        let segment_data: DemiBuffer = cb
             .pop_unsent_segment(max_size)
             .expect("No unsent data with sequence number gap?");
         let mut segment_data_len: u32 = segment_data.len() as u32;

--- a/src/rust/inetstack/protocols/tcp/established/mod.rs
+++ b/src/rust/inetstack/protocols/tcp/established/mod.rs
@@ -20,7 +20,7 @@ use crate::{
     },
     runtime::{
         fail::Fail,
-        memory::Buffer,
+        memory::DemiBuffer,
         QDesc,
     },
     scheduler::SchedulerHandle,
@@ -61,15 +61,15 @@ impl EstablishedSocket {
         }
     }
 
-    pub fn receive(&self, header: &mut TcpHeader, data: Buffer) {
+    pub fn receive(&self, header: &mut TcpHeader, data: DemiBuffer) {
         self.cb.receive(header, data)
     }
 
-    pub fn send(&self, buf: Buffer) -> Result<(), Fail> {
+    pub fn send(&self, buf: DemiBuffer) -> Result<(), Fail> {
         self.cb.send(buf)
     }
 
-    pub fn poll_recv(&self, ctx: &mut Context) -> Poll<Result<Buffer, Fail>> {
+    pub fn poll_recv(&self, ctx: &mut Context) -> Poll<Result<DemiBuffer, Fail>> {
         self.cb.poll_recv(ctx)
     }
 

--- a/src/rust/inetstack/protocols/tcp/operations.rs
+++ b/src/rust/inetstack/protocols/tcp/operations.rs
@@ -9,7 +9,7 @@ use crate::{
     inetstack::operations::OperationResult,
     runtime::{
         fail::Fail,
-        memory::Buffer,
+        memory::DemiBuffer,
         QDesc,
     },
     scheduler::FutureResult,
@@ -212,7 +212,7 @@ impl fmt::Debug for PopFuture {
 }
 
 impl Future for PopFuture {
-    type Output = Result<Buffer, Fail>;
+    type Output = Result<DemiBuffer, Fail>;
 
     fn poll(self: Pin<&mut Self>, ctx: &mut Context) -> Poll<Self::Output> {
         let self_ = self.get_mut();

--- a/src/rust/inetstack/protocols/tcp/tests/mod.rs
+++ b/src/rust/inetstack/protocols/tcp/tests/mod.rs
@@ -17,7 +17,7 @@ use crate::{
         },
     },
     runtime::{
-        memory::Buffer,
+        memory::DemiBuffer,
         network::types::MacAddress,
     },
 };
@@ -27,7 +27,7 @@ use ::std::net::Ipv4Addr;
 
 /// Checks for a data packet.
 pub fn check_packet_data(
-    bytes: Buffer,
+    bytes: DemiBuffer,
     eth2_src_addr: MacAddress,
     eth2_dst_addr: MacAddress,
     ipv4_src_addr: Ipv4Addr,
@@ -64,7 +64,7 @@ pub fn check_packet_data(
 /// sequence number should always reflect the current SND.NXT (send next).  The original version of this function also
 /// checked the window size (which can't be predicted accurately in some test scenarios), this version no longer does.
 pub fn check_packet_pure_ack(
-    bytes: Buffer,
+    bytes: DemiBuffer,
     eth2_src_addr: MacAddress,
     eth2_dst_addr: MacAddress,
     ipv4_src_addr: Ipv4Addr,

--- a/src/rust/inetstack/protocols/udp/datagram/header.rs
+++ b/src/rust/inetstack/protocols/udp/datagram/header.rs
@@ -12,10 +12,7 @@ use crate::{
     },
     runtime::{
         fail::Fail,
-        memory::{
-            Buffer,
-            DataBuffer,
-        },
+        memory::DemiBuffer,
     },
 };
 use ::byteorder::{
@@ -109,9 +106,9 @@ impl UdpHeader {
     }
 
     /// Parses a buffer into a UDP header.
-    pub fn parse(ipv4_hdr: &Ipv4Header, buf: Buffer, checksum_offload: bool) -> Result<(Self, Buffer), Fail> {
+    pub fn parse(ipv4_hdr: &Ipv4Header, buf: DemiBuffer, checksum_offload: bool) -> Result<(Self, DemiBuffer), Fail> {
         match Self::parse_from_slice(ipv4_hdr, &buf[..], checksum_offload) {
-            Ok((udp_hdr, bytes)) => Ok((udp_hdr, Buffer::Heap(DataBuffer::from_slice(bytes)))),
+            Ok((udp_hdr, bytes)) => Ok((udp_hdr, DemiBuffer::from_slice(bytes)?)),
             Err(e) => Err(e),
         }
     }

--- a/src/rust/inetstack/protocols/udp/datagram/mod.rs
+++ b/src/rust/inetstack/protocols/udp/datagram/mod.rs
@@ -13,7 +13,7 @@ use crate::{
         ipv4::Ipv4Header,
     },
     runtime::{
-        memory::Buffer,
+        memory::DemiBuffer,
         network::PacketBuf,
     },
 };
@@ -39,7 +39,7 @@ pub struct UdpDatagram {
     /// UDP header.
     udp_hdr: UdpHeader,
     /// Payload
-    data: Buffer,
+    data: DemiBuffer,
     /// Offload checksum to hardware?
     checksum_offload: bool,
 }
@@ -55,7 +55,7 @@ impl UdpDatagram {
         ethernet2_hdr: Ethernet2Header,
         ipv4_hdr: Ipv4Header,
         udp_hdr: UdpHeader,
-        data: Buffer,
+        data: DemiBuffer,
         checksum_offload: bool,
     ) -> Self {
         Self {
@@ -112,7 +112,7 @@ impl PacketBuf for UdpDatagram {
     }
 
     /// Returns the payload of the target UDP datagram.
-    fn take_body(&self) -> Option<Buffer> {
+    fn take_body(&self) -> Option<DemiBuffer> {
         Some(self.data.clone())
     }
 }
@@ -134,7 +134,7 @@ mod test {
             ipv4::IPV4_HEADER_DEFAULT_SIZE,
         },
         runtime::{
-            memory::DataBuffer,
+            memory::DemiBuffer,
             network::types::MacAddress,
         },
     };
@@ -165,7 +165,7 @@ mod test {
 
         // Payload.
         let bytes: [u8; 8] = [0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1];
-        let data: Buffer = Buffer::Heap(DataBuffer::from_slice(&bytes));
+        let data: DemiBuffer = DemiBuffer::from_slice(&bytes).expect("bytes should be shorter than u16::MAX");
 
         // Build expected header.
         let mut hdr: [u8; HEADER_SIZE] = [0; HEADER_SIZE];

--- a/src/rust/inetstack/protocols/udp/futures/pop.rs
+++ b/src/rust/inetstack/protocols/udp/futures/pop.rs
@@ -12,7 +12,7 @@ use crate::{
     },
     runtime::{
         fail::Fail,
-        memory::Buffer,
+        memory::DemiBuffer,
         QDesc,
     },
 };
@@ -36,7 +36,7 @@ pub struct UdpPopFuture {
     /// Associated queue descriptor.
     qd: QDesc,
     /// Shared receiving queue.
-    recv_queue: SharedQueue<SharedQueueSlot<Buffer>>,
+    recv_queue: SharedQueue<SharedQueueSlot<DemiBuffer>>,
 }
 
 //==============================================================================
@@ -46,7 +46,7 @@ pub struct UdpPopFuture {
 /// Associate Functions for Pop Operation Descriptor
 impl UdpPopFuture {
     /// Creates a pop operation descritor.
-    pub fn new(qd: QDesc, recv_queue: SharedQueue<SharedQueueSlot<Buffer>>) -> Self {
+    pub fn new(qd: QDesc, recv_queue: SharedQueue<SharedQueueSlot<DemiBuffer>>) -> Self {
         Self { qd, recv_queue }
     }
 
@@ -62,7 +62,7 @@ impl UdpPopFuture {
 
 /// Future Trait implementation for Pop Operation Descriptor
 impl Future for UdpPopFuture {
-    type Output = Result<(SocketAddrV4, Buffer), Fail>;
+    type Output = Result<(SocketAddrV4, DemiBuffer), Fail>;
 
     /// Polls the target pop operation descriptor.
     fn poll(self: Pin<&mut Self>, ctx: &mut Context) -> Poll<Self::Output> {

--- a/src/rust/inetstack/protocols/udp/tests.rs
+++ b/src/rust/inetstack/protocols/udp/tests.rs
@@ -7,10 +7,7 @@ use crate::{
         Engine,
     },
     runtime::{
-        memory::{
-            Buffer,
-            DataBuffer,
-        },
+        memory::DemiBuffer,
         QDesc,
     },
 };
@@ -91,7 +88,7 @@ fn udp_push_pop() {
     bob.udp_bind(bob_fd, bob_addr).unwrap();
 
     // Send data to Bob.
-    let buf: Buffer = Buffer::Heap(DataBuffer::from(&vec![0x5a; 32][..]));
+    let buf: DemiBuffer = DemiBuffer::from_slice(&vec![0x5a; 32][..]).expect("slice should fit in DemiBuffer");
     alice.udp_pushto(alice_fd, buf.clone(), bob_addr).unwrap();
     alice.rt.poll_scheduler();
 
@@ -138,7 +135,7 @@ fn udp_push_pop_wildcard_address() {
         .unwrap();
 
     // Send data to Bob.
-    let buf: Buffer = Buffer::Heap(DataBuffer::from(&vec![0x5a; 32][..]));
+    let buf: DemiBuffer = DemiBuffer::from_slice(&vec![0x5a; 32][..]).expect("slice should fit in DemiBuffer");
     alice.udp_pushto(alice_fd, buf.clone(), bob_addr).unwrap();
     alice.rt.poll_scheduler();
 
@@ -184,7 +181,7 @@ fn udp_ping_pong() {
     bob.udp_bind(bob_fd, bob_addr).unwrap();
 
     // Send data to Bob.
-    let buf_a: Buffer = Buffer::Heap(DataBuffer::from(&vec![0x5a; 32][..]));
+    let buf_a: DemiBuffer = DemiBuffer::from_slice(&vec![0x5a; 32][..]).expect("slice should fit in DemiBuffer");
     alice.udp_pushto(alice_fd, buf_a.clone(), bob_addr).unwrap();
     alice.rt.poll_scheduler();
 
@@ -204,7 +201,7 @@ fn udp_ping_pong() {
     now += Duration::from_micros(1);
 
     // Send data to Alice.
-    let buf_b: Buffer = Buffer::Heap(DataBuffer::from(&vec![0x5a; 32][..]));
+    let buf_b: DemiBuffer = DemiBuffer::from_slice(&vec![0x5a; 32][..]).expect("slice should fit in DemiBuffer");
     bob.udp_pushto(bob_fd, buf_b.clone(), alice_addr).unwrap();
     bob.rt.poll_scheduler();
 
@@ -303,7 +300,7 @@ fn udp_loop2_push_pop() {
     // Loop.
     for b in 0..1000 {
         // Send data to Bob.
-        let buf: Buffer = Buffer::Heap(DataBuffer::from(&vec![(b % 256) as u8; 32][..]));
+        let buf: DemiBuffer = DemiBuffer::from_slice(&vec![(b % 256) as u8; 32][..]).expect("slice should fit");
         alice.udp_pushto(alice_fd, buf.clone(), bob_addr).unwrap();
         alice.rt.poll_scheduler();
 
@@ -360,7 +357,7 @@ fn udp_loop2_ping_pong() {
     // Loop.
     for _ in 0..1000 {
         // Send data to Bob.
-        let buf_a: Buffer = Buffer::Heap(DataBuffer::from(&vec![0x5a; 32][..]));
+        let buf_a: DemiBuffer = DemiBuffer::from_slice(&vec![0x5a; 32][..]).expect("slice should fit in DemiBuffer");
         alice.udp_pushto(alice_fd, buf_a.clone(), bob_addr).unwrap();
         alice.rt.poll_scheduler();
 
@@ -380,7 +377,7 @@ fn udp_loop2_ping_pong() {
         now += Duration::from_micros(1);
 
         // Send data to Alice.
-        let buf_b: Buffer = Buffer::Heap(DataBuffer::from(&vec![0x5a; 32][..]));
+        let buf_b: DemiBuffer = DemiBuffer::from_slice(&vec![0x5a; 32][..]).expect("slice should fit in DemiBuffer");
         bob.udp_pushto(bob_fd, buf_b.clone(), alice_addr).unwrap();
         bob.rt.poll_scheduler();
 
@@ -500,7 +497,7 @@ fn udp_pop_not_bound() {
     // Bob does not create a socket.
 
     // Send data to Bob.
-    let buf: Buffer = Buffer::Heap(DataBuffer::from(&vec![0x5a; 32][..]));
+    let buf: DemiBuffer = DemiBuffer::from_slice(&vec![0x5a; 32][..]).expect("slice should fit in DemiBuffer");
     alice.udp_pushto(alice_fd, buf, bob_addr).unwrap();
     alice.rt.poll_scheduler();
 
@@ -541,7 +538,7 @@ fn udp_push_bad_file_descriptor() {
     bob.udp_bind(bob_fd, bob_addr).unwrap();
 
     // Send data to Bob.
-    let buf: Buffer = Buffer::Heap(DataBuffer::from(&vec![0x5a; 32][..]));
+    let buf: DemiBuffer = DemiBuffer::from_slice(&vec![0x5a; 32][..]).expect("slice should fit in DemiBuffer");
     match alice.udp_pushto(QDesc::try_from(usize::MAX).unwrap(), buf.clone(), bob_addr) {
         Err(e) if e.errno == EBADF => Ok(()),
         _ => Err(()),

--- a/src/rust/inetstack/test_helpers/engine.rs
+++ b/src/rust/inetstack/test_helpers/engine.rs
@@ -19,7 +19,7 @@ use crate::{
     },
     runtime::{
         fail::Fail,
-        memory::Buffer,
+        memory::DemiBuffer,
         network::types::MacAddress,
         queue::IoQueueTable,
         timer::TimerRc,
@@ -88,7 +88,7 @@ impl Engine {
         })
     }
 
-    pub fn receive(&mut self, bytes: Buffer) -> Result<(), Fail> {
+    pub fn receive(&mut self, bytes: DemiBuffer) -> Result<(), Fail> {
         let (header, payload) = Ethernet2Header::parse(bytes)?;
         debug!("Engine received {:?}", header);
         if self.rt.link_addr != header.dst_addr() && !header.dst_addr().is_broadcast() {
@@ -109,7 +109,7 @@ impl Engine {
         self.ipv4.ping(dest_ipv4_addr, timeout)
     }
 
-    pub fn udp_pushto(&self, fd: QDesc, buf: Buffer, to: SocketAddrV4) -> Result<(), Fail> {
+    pub fn udp_pushto(&self, fd: QDesc, buf: DemiBuffer, to: SocketAddrV4) -> Result<(), Fail> {
         self.ipv4.udp.do_pushto(fd, buf, to)
     }
 
@@ -150,7 +150,7 @@ impl Engine {
         self.ipv4.tcp.do_accept(fd, newfd)
     }
 
-    pub fn tcp_push(&mut self, socket_fd: QDesc, buf: Buffer) -> PushFuture {
+    pub fn tcp_push(&mut self, socket_fd: QDesc, buf: DemiBuffer) -> PushFuture {
         self.ipv4.tcp.push(socket_fd, buf)
     }
 

--- a/src/rust/runtime/memory/mod.rs
+++ b/src/rust/runtime/memory/mod.rs
@@ -24,8 +24,8 @@ pub use self::buffer::*;
 
 /// Memory Runtime
 pub trait MemoryRuntime {
-    /// Creates a [demi_sgarray_t] from a [Buffer].
-    fn into_sgarray(&self, buf: Buffer) -> Result<demi_sgarray_t, Fail>;
+    /// Creates a [demi_sgarray_t] from a [DemiBuffer].
+    fn into_sgarray(&self, buf: DemiBuffer) -> Result<demi_sgarray_t, Fail>;
 
     /// Allocates a [demi_sgarray_t].
     fn alloc_sgarray(&self, size: usize) -> Result<demi_sgarray_t, Fail>;
@@ -33,6 +33,6 @@ pub trait MemoryRuntime {
     /// Releases a [demi_sgarray_t].
     fn free_sgarray(&self, sga: demi_sgarray_t) -> Result<(), Fail>;
 
-    /// Clones a [demi_sgarray_t] into a [Buffer].
-    fn clone_sgarray(&self, sga: &demi_sgarray_t) -> Result<Buffer, Fail>;
+    /// Clones a [demi_sgarray_t] into a [DemiBuffer].
+    fn clone_sgarray(&self, sga: &demi_sgarray_t) -> Result<DemiBuffer, Fail>;
 }

--- a/src/rust/runtime/network/consts.rs
+++ b/src/rust/runtime/network/consts.rs
@@ -19,7 +19,7 @@ pub const MAX_MSS: usize = u16::max_value() as usize;
 /// TODO: Auto-Discovery MTU Size
 pub const DEFAULT_MSS: usize = 1450;
 
-/// Length of a [crate::memory::Buffer] batch.
+/// Length of a [crate::memory::DemiBuffer] batch.
 ///
 /// TODO: This Should be Generic
 pub const RECEIVE_BATCH_SIZE: usize = 4;

--- a/src/rust/runtime/network/mod.rs
+++ b/src/rust/runtime/network/mod.rs
@@ -6,7 +6,7 @@
 //==============================================================================
 
 use crate::runtime::{
-    memory::Buffer,
+    memory::DemiBuffer,
     network::consts::RECEIVE_BATCH_SIZE,
 };
 use ::arrayvec::ArrayVec;
@@ -32,7 +32,7 @@ pub trait PacketBuf {
     /// Returns the body size of the target [PacketBuf].
     fn body_size(&self) -> usize;
     /// Consumes and returns the body of the target [PacketBuf].
-    fn take_body(&self) -> Option<Buffer>;
+    fn take_body(&self) -> Option<DemiBuffer>;
 }
 
 /// Network Runtime
@@ -40,6 +40,6 @@ pub trait NetworkRuntime {
     /// Transmits a single [PacketBuf].
     fn transmit(&self, pkt: Box<dyn PacketBuf>);
 
-    /// Receives a batch of [PacketBuf].
-    fn receive(&self) -> ArrayVec<Buffer, RECEIVE_BATCH_SIZE>;
+    /// Receives a batch of [DemiBuffer].
+    fn receive(&self) -> ArrayVec<DemiBuffer, RECEIVE_BATCH_SIZE>;
 }

--- a/src/rust/runtime/types/memory.rs
+++ b/src/rust/runtime/types/memory.rs
@@ -33,11 +33,16 @@ pub struct demi_sgaseg_t {
 }
 
 /// Scatter-Gather Array
+// ToDo: Review the inclusion of the sga_addr field (only used for recvfrom?) in this structure.
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct demi_sgarray_t {
+    /// Reserved.
     pub sga_buf: *mut c_void,
+    /// Number of segments in this scatter-gather array.
     pub sga_numsegs: u32,
+    /// Scatter-gather array segments.
     pub sga_segs: [demi_sgaseg_t; DEMI_SGARRAY_MAXLEN],
+    /// Source address of the data contained in this scatter-gather array (if present).
     pub sga_addr: SockAddr,
 }

--- a/tests/rust/common/libos.rs
+++ b/tests/rust/common/libos.rs
@@ -10,10 +10,7 @@ use ::demikernel::{
     inetstack::InetStack,
     runtime::{
         logging,
-        memory::{
-            Buffer,
-            DataBuffer,
-        },
+        memory::DemiBuffer,
         network::{
             config::{
                 ArpConfig,
@@ -55,8 +52,8 @@ impl DummyLibOS {
     pub fn new(
         link_addr: MacAddress,
         ipv4_addr: Ipv4Addr,
-        tx: Sender<DataBuffer>,
-        rx: Receiver<DataBuffer>,
+        tx: Sender<DemiBuffer>,
+        rx: Receiver<DemiBuffer>,
         arp: HashMap<Ipv4Addr, MacAddress>,
     ) -> InetStack {
         let now: Instant = Instant::now();
@@ -89,10 +86,10 @@ impl DummyLibOS {
     }
 
     /// Cooks a buffer.
-    pub fn cook_data(size: usize) -> Buffer {
+    pub fn cook_data(size: usize) -> DemiBuffer {
         let fill_char: u8 = b'a';
 
-        let mut buf: Buffer = Buffer::Heap(DataBuffer::new(size).unwrap());
+        let mut buf: DemiBuffer = DemiBuffer::new(size as u16);
         for a in &mut buf[..] {
             *a = fill_char;
         }

--- a/tests/rust/tcp.rs
+++ b/tests/rust/tcp.rs
@@ -15,10 +15,7 @@ use ::demikernel::{
         InetStack,
     },
     runtime::{
-        memory::{
-            Buffer,
-            DataBuffer,
-        },
+        memory::DemiBuffer,
         QDesc,
         QToken,
     },
@@ -98,7 +95,7 @@ fn do_passive_connection_setup_wildcard_ephemeral(mut libos: &mut InetStack) {
 /// Tests if a passive socket may be successfully opened and closed.
 #[test]
 fn tcp_connection_setup() {
-    let (tx, rx): (Sender<DataBuffer>, Receiver<DataBuffer>) = crossbeam_channel::unbounded();
+    let (tx, rx): (Sender<DemiBuffer>, Receiver<DemiBuffer>) = crossbeam_channel::unbounded();
     let mut libos: InetStack = DummyLibOS::new(ALICE_MAC, ALICE_IPV4, tx, rx, arp());
 
     do_passive_connection_setup(&mut libos);
@@ -113,8 +110,8 @@ fn tcp_connection_setup() {
 /// Tests if connection may be successfully established by an unbound active socket.
 #[test]
 fn tcp_establish_connection_unbound() {
-    let (alice_tx, alice_rx): (Sender<DataBuffer>, Receiver<DataBuffer>) = crossbeam_channel::unbounded();
-    let (bob_tx, bob_rx): (Sender<DataBuffer>, Receiver<DataBuffer>) = crossbeam_channel::unbounded();
+    let (alice_tx, alice_rx): (Sender<DemiBuffer>, Receiver<DemiBuffer>) = crossbeam_channel::unbounded();
+    let (bob_tx, bob_rx): (Sender<DemiBuffer>, Receiver<DemiBuffer>) = crossbeam_channel::unbounded();
 
     let alice: JoinHandle<()> = thread::spawn(move || {
         let mut libos: InetStack = DummyLibOS::new(ALICE_MAC, ALICE_IPV4, alice_tx, bob_rx, arp());
@@ -163,8 +160,8 @@ fn tcp_establish_connection_unbound() {
 /// Tests if connection may be successfully established by a bound active socket.
 #[test]
 fn tcp_establish_connection_bound() {
-    let (alice_tx, alice_rx): (Sender<DataBuffer>, Receiver<DataBuffer>) = crossbeam_channel::unbounded();
-    let (bob_tx, bob_rx): (Sender<DataBuffer>, Receiver<DataBuffer>) = crossbeam_channel::unbounded();
+    let (alice_tx, alice_rx): (Sender<DemiBuffer>, Receiver<DemiBuffer>) = crossbeam_channel::unbounded();
+    let (bob_tx, bob_rx): (Sender<DemiBuffer>, Receiver<DemiBuffer>) = crossbeam_channel::unbounded();
 
     let alice: JoinHandle<()> = thread::spawn(move || {
         let mut libos: InetStack = DummyLibOS::new(ALICE_MAC, ALICE_IPV4, alice_tx, bob_rx, arp());
@@ -219,8 +216,8 @@ fn tcp_establish_connection_bound() {
 /// Tests if data can be pushed.
 #[test]
 fn tcp_push_remote() {
-    let (alice_tx, alice_rx): (Sender<DataBuffer>, Receiver<DataBuffer>) = crossbeam_channel::unbounded();
-    let (bob_tx, bob_rx): (Sender<DataBuffer>, Receiver<DataBuffer>) = crossbeam_channel::unbounded();
+    let (alice_tx, alice_rx): (Sender<DemiBuffer>, Receiver<DemiBuffer>) = crossbeam_channel::unbounded();
+    let (bob_tx, bob_rx): (Sender<DemiBuffer>, Receiver<DemiBuffer>) = crossbeam_channel::unbounded();
 
     let alice: JoinHandle<()> = thread::spawn(move || {
         let mut libos: InetStack = DummyLibOS::new(ALICE_MAC, ALICE_IPV4, alice_tx, bob_rx, arp());
@@ -268,7 +265,7 @@ fn tcp_push_remote() {
         }
 
         // Cook some data.
-        let bytes: Buffer = DummyLibOS::cook_data(32);
+        let bytes: DemiBuffer = DummyLibOS::cook_data(32);
 
         // Push data.
         let qt: QToken = safe_push2(&mut libos, sockqd, &bytes);
@@ -293,7 +290,7 @@ fn tcp_push_remote() {
 /// Tests for bad socket creation.
 #[test]
 fn tcp_bad_socket() {
-    let (tx, rx): (Sender<DataBuffer>, Receiver<DataBuffer>) = crossbeam_channel::unbounded();
+    let (tx, rx): (Sender<DemiBuffer>, Receiver<DemiBuffer>) = crossbeam_channel::unbounded();
     let mut libos: InetStack = DummyLibOS::new(ALICE_MAC, ALICE_IPV4, tx, rx, arp());
 
     #[cfg(target_os = "linux")]
@@ -401,7 +398,7 @@ fn tcp_bad_socket() {
 /// Test bad calls for `bind()`.
 #[test]
 fn tcp_bad_bind() {
-    let (tx, rx): (Sender<DataBuffer>, Receiver<DataBuffer>) = crossbeam_channel::unbounded();
+    let (tx, rx): (Sender<DemiBuffer>, Receiver<DemiBuffer>) = crossbeam_channel::unbounded();
     let mut libos: InetStack = DummyLibOS::new(ALICE_MAC, ALICE_IPV4, tx, rx, arp());
 
     let local: SocketAddrV4 = SocketAddrV4::new(ALICE_IPV4, PORT_BASE);
@@ -443,7 +440,7 @@ fn tcp_bad_bind() {
 /// Tests bad calls for `listen()`.
 #[test]
 fn tcp_bad_listen() {
-    let (tx, rx): (Sender<DataBuffer>, Receiver<DataBuffer>) = crossbeam_channel::unbounded();
+    let (tx, rx): (Sender<DemiBuffer>, Receiver<DemiBuffer>) = crossbeam_channel::unbounded();
     let mut libos: InetStack = DummyLibOS::new(ALICE_MAC, ALICE_IPV4, tx, rx, arp());
 
     let port: u16 = PORT_BASE;
@@ -493,7 +490,7 @@ fn tcp_bad_listen() {
 /// Tests bad calls for `accept()`.
 #[test]
 fn tcp_bad_accept() {
-    let (tx, rx): (Sender<DataBuffer>, Receiver<DataBuffer>) = crossbeam_channel::unbounded();
+    let (tx, rx): (Sender<DemiBuffer>, Receiver<DemiBuffer>) = crossbeam_channel::unbounded();
     let mut libos: InetStack = DummyLibOS::new(ALICE_MAC, ALICE_IPV4, tx, rx, arp());
 
     // Invalid queue descriptor.
@@ -510,8 +507,8 @@ fn tcp_bad_accept() {
 /// Tests if data can be successfully established.
 #[test]
 fn tcp_bad_connect() {
-    let (alice_tx, alice_rx): (Sender<DataBuffer>, Receiver<DataBuffer>) = crossbeam_channel::unbounded();
-    let (bob_tx, bob_rx): (Sender<DataBuffer>, Receiver<DataBuffer>) = crossbeam_channel::unbounded();
+    let (alice_tx, alice_rx): (Sender<DemiBuffer>, Receiver<DemiBuffer>) = crossbeam_channel::unbounded();
+    let (bob_tx, bob_rx): (Sender<DemiBuffer>, Receiver<DemiBuffer>) = crossbeam_channel::unbounded();
 
     let alice: JoinHandle<()> = thread::spawn(move || {
         let mut libos: InetStack = DummyLibOS::new(ALICE_MAC, ALICE_IPV4, alice_tx, bob_rx, arp());
@@ -581,8 +578,8 @@ fn tcp_bad_connect() {
 /// Tests if bad calls t `close()`.
 #[test]
 fn tcp_bad_close() {
-    let (alice_tx, alice_rx): (Sender<DataBuffer>, Receiver<DataBuffer>) = crossbeam_channel::unbounded();
-    let (bob_tx, bob_rx): (Sender<DataBuffer>, Receiver<DataBuffer>) = crossbeam_channel::unbounded();
+    let (alice_tx, alice_rx): (Sender<DemiBuffer>, Receiver<DemiBuffer>) = crossbeam_channel::unbounded();
+    let (bob_tx, bob_rx): (Sender<DemiBuffer>, Receiver<DemiBuffer>) = crossbeam_channel::unbounded();
 
     let alice: JoinHandle<()> = thread::spawn(move || {
         let mut libos: InetStack = DummyLibOS::new(ALICE_MAC, ALICE_IPV4, alice_tx, bob_rx, arp());
@@ -660,8 +657,8 @@ fn tcp_bad_close() {
 /// Tests bad calls to `push()`.
 #[test]
 fn tcp_bad_push() {
-    let (alice_tx, alice_rx): (Sender<DataBuffer>, Receiver<DataBuffer>) = crossbeam_channel::unbounded();
-    let (bob_tx, bob_rx): (Sender<DataBuffer>, Receiver<DataBuffer>) = crossbeam_channel::unbounded();
+    let (alice_tx, alice_rx): (Sender<DemiBuffer>, Receiver<DemiBuffer>) = crossbeam_channel::unbounded();
+    let (bob_tx, bob_rx): (Sender<DemiBuffer>, Receiver<DemiBuffer>) = crossbeam_channel::unbounded();
 
     let alice: JoinHandle<()> = thread::spawn(move || {
         let mut libos: InetStack = DummyLibOS::new(ALICE_MAC, ALICE_IPV4, alice_tx, bob_rx, arp());
@@ -709,7 +706,7 @@ fn tcp_bad_push() {
         }
 
         // Cook some data.
-        let bytes: Buffer = DummyLibOS::cook_data(32);
+        let bytes: DemiBuffer = DummyLibOS::cook_data(32);
 
         // Push to bad socket.
         match libos.push2(QDesc::from(2), &bytes) {
@@ -719,7 +716,10 @@ fn tcp_bad_push() {
 
         // Push bad data to socket.
         let zero_bytes: [u8; 0] = [];
-        match libos.push2(sockqd, &DataBuffer::from_slice(&zero_bytes)) {
+        match libos.push2(
+            sockqd,
+            &DemiBuffer::from_slice(&zero_bytes).expect("(zero-byte) slice should fit in a DemiBuffer."),
+        ) {
             Ok(_) => panic!("push2() zero-length slice should fail."),
             Err(_) => (),
         };
@@ -747,8 +747,8 @@ fn tcp_bad_push() {
 /// Tests bad calls to `pop()`.
 #[test]
 fn tcp_bad_pop() {
-    let (alice_tx, alice_rx): (Sender<DataBuffer>, Receiver<DataBuffer>) = crossbeam_channel::unbounded();
-    let (bob_tx, bob_rx): (Sender<DataBuffer>, Receiver<DataBuffer>) = crossbeam_channel::unbounded();
+    let (alice_tx, alice_rx): (Sender<DemiBuffer>, Receiver<DemiBuffer>) = crossbeam_channel::unbounded();
+    let (bob_tx, bob_rx): (Sender<DemiBuffer>, Receiver<DemiBuffer>) = crossbeam_channel::unbounded();
 
     let alice: JoinHandle<()> = thread::spawn(move || {
         let mut libos: InetStack = DummyLibOS::new(ALICE_MAC, ALICE_IPV4, alice_tx, bob_rx, arp());
@@ -802,7 +802,7 @@ fn tcp_bad_pop() {
         }
 
         // Cook some data.
-        let bytes: Buffer = DummyLibOS::cook_data(32);
+        let bytes: DemiBuffer = DummyLibOS::cook_data(32);
 
         // Push data.
         let qt: QToken = safe_push2(&mut libos, sockqd, &bytes);

--- a/tests/rust/udp.rs
+++ b/tests/rust/udp.rs
@@ -15,10 +15,7 @@ use ::demikernel::{
         InetStack,
     },
     runtime::{
-        memory::{
-            Buffer,
-            DataBuffer,
-        },
+        memory::DemiBuffer,
         QDesc,
         QToken,
     },
@@ -90,7 +87,7 @@ fn do_udp_setup_wildcard_ephemeral(libos: &mut InetStack) {
 /// Tests if a socket can be successfully setup.
 #[test]
 fn udp_setup() {
-    let (tx, rx): (Sender<DataBuffer>, Receiver<DataBuffer>) = crossbeam_channel::unbounded();
+    let (tx, rx): (Sender<DemiBuffer>, Receiver<DemiBuffer>) = crossbeam_channel::unbounded();
     let mut libos: InetStack = DummyLibOS::new(ALICE_MAC, ALICE_IPV4, tx, rx, arp());
     do_udp_setup(&mut libos);
     do_udp_setup_ephemeral(&mut libos);
@@ -100,7 +97,7 @@ fn udp_setup() {
 /// Tests if a connection can be successfully established in loopback mode.
 #[test]
 fn udp_connect_loopback() {
-    let (tx, rx): (Sender<DataBuffer>, Receiver<DataBuffer>) = crossbeam_channel::unbounded();
+    let (tx, rx): (Sender<DemiBuffer>, Receiver<DemiBuffer>) = crossbeam_channel::unbounded();
     let mut libos: InetStack = DummyLibOS::new(ALICE_MAC, ALICE_IPV4, tx, rx, arp());
 
     let port: u16 = PORT_BASE;
@@ -120,8 +117,8 @@ fn udp_connect_loopback() {
 /// itself.
 #[test]
 fn udp_push_remote() {
-    let (alice_tx, alice_rx): (Sender<DataBuffer>, Receiver<DataBuffer>) = crossbeam_channel::unbounded();
-    let (bob_tx, bob_rx): (Sender<DataBuffer>, Receiver<DataBuffer>) = crossbeam_channel::unbounded();
+    let (alice_tx, alice_rx): (Sender<DemiBuffer>, Receiver<DemiBuffer>) = crossbeam_channel::unbounded();
+    let (bob_tx, bob_rx): (Sender<DemiBuffer>, Receiver<DemiBuffer>) = crossbeam_channel::unbounded();
 
     let bob_port: u16 = PORT_BASE;
     let bob_addr: SocketAddrV4 = SocketAddrV4::new(BOB_IPV4, bob_port);
@@ -136,7 +133,7 @@ fn udp_push_remote() {
         libos.bind(sockfd, alice_addr).unwrap();
 
         // Cook some data.
-        let bytes: Buffer = DummyLibOS::cook_data(32);
+        let bytes: DemiBuffer = DummyLibOS::cook_data(32);
 
         // Push data.
         let qt: QToken = libos.pushto2(sockfd, &bytes, bob_addr).unwrap();
@@ -177,7 +174,7 @@ fn udp_push_remote() {
             Ok((qd, qr)) => (qd, qr),
             Err(e) => panic!("operation failed: {:?}", e.cause),
         };
-        let bytes: Buffer = match qr {
+        let bytes: DemiBuffer = match qr {
             OperationResult::Pop(_, bytes) => bytes,
             _ => panic!("pop() failed"),
         };
@@ -204,8 +201,8 @@ fn udp_push_remote() {
 /// Tests if data can be successfully pushed/popped in loopback mode.
 #[test]
 fn udp_loopback() {
-    let (alice_tx, alice_rx): (Sender<DataBuffer>, Receiver<DataBuffer>) = crossbeam_channel::unbounded();
-    let (bob_tx, bob_rx): (Sender<DataBuffer>, Receiver<DataBuffer>) = crossbeam_channel::unbounded();
+    let (alice_tx, alice_rx): (Sender<DemiBuffer>, Receiver<DemiBuffer>) = crossbeam_channel::unbounded();
+    let (bob_tx, bob_rx): (Sender<DemiBuffer>, Receiver<DemiBuffer>) = crossbeam_channel::unbounded();
 
     let bob_port: u16 = PORT_BASE;
     let bob_addr: SocketAddrV4 = SocketAddrV4::new(ALICE_IPV4, bob_port);
@@ -220,7 +217,7 @@ fn udp_loopback() {
         libos.bind(sockfd, alice_addr).unwrap();
 
         // Cook some data.
-        let bytes: Buffer = DummyLibOS::cook_data(32);
+        let bytes: DemiBuffer = DummyLibOS::cook_data(32);
 
         // Push data.
         let qt: QToken = libos.pushto2(sockfd, &bytes, bob_addr).unwrap();
@@ -261,7 +258,7 @@ fn udp_loopback() {
             Ok((qd, qr)) => (qd, qr),
             Err(e) => panic!("operation failed: {:?}", e.cause),
         };
-        let bytes: Buffer = match qr {
+        let bytes: DemiBuffer = match qr {
             OperationResult::Pop(_, bytes) => bytes,
             _ => panic!("pop() failed"),
         };


### PR DESCRIPTION
This PR replaces the `Buffer` enum (which was backed by the `DataBuffer` and `DPDKBuffer` structures) with the `DemiBuffer` type (which was introduced in PR #298).  It does not yet remove either the `Buffer` or `DataBuffer` structs (that will come in a future PR).  The `DPDKBuffer` also remains, at least for the near future, but is only still used in a small subset of the catnip LibOs-specific code.

This PR (along with #298) also fixes Issues #169 and #170, which were about changing the API of `adjust()` and `trim()` to return an error (instead of panicking) if called with too large a number of bytes to remove from the buffer.

This PR touches a large number of files (57, I believe) but most of the changes are fairly straightforward replacements of one type for the other.  The slightly less straightforward changes are due to handling the new adjust/trim API.  Probably the biggest actual changes in this integration are to the code that handles sgarrays (`demi_sgarray_t`).  Each LibOs has LibOs-specific code to allocate, free, and convert into/out of the `demi_sgarray_t` type (functions `alloc_sgarray()`, `free_sgarray()`, `into_sgarray()`, and `clone_sgarray()`, respectively).  The switch to `DemiBuffer`s has unified this code somewhat (the catnap, catcollar, and catpowder versions are now almost identical), as much of the support for DPDK-allocated buffers is now handled internally to `DemiBuffer`s.  Nevertheless, this is probably the part of this PR that could use the most reviewer eyes.

The other largeish change is to the `DemiBuffer` itself, as I waited until I performed the integration to improve/solidify its API.  The changes to the `DemiBuffer` include:
- `adjust()`, `trim()`, and `split_off()` now take a `usize` (instead of a `u16`) parameter.  This is more in keeping with the spirit of other things in Rust's standard library and fits better with the existing code.
- Added `as_ptr()` for getting a raw `u8` pointer to the data in the `DemiBuffer`.
- Added `into_raw()` and `from_raw()` for converting `DemiBuffer`s into a semi-opaque type we can hand across a C language interface and back.
- Fixed a bug in the `DemiBuffer` implementation where cloning a zero-length `DemiBuffer` resulted in a clone that couldn't later be `drop`ped without crashing.
- Added another unit test to verify the above bug fix, test `into_raw()`/`from_raw()`, and check for other potential drop-related errors.

Finally, this PR adds #[ignore] markers to the `SharedRingBuffer` tests, as I got tired of manually logging into all of the test machines to delete the shared memory regions that these tests tend to leave behind if they or some other test crashes the test infrastructure.  (I filed Issue #318 about this problem) These tests do pass, however, if one runs them after the errant shared memory regions have been deleted.  I'd be happy to remove these markers from this PR if people think they should be added via a separate PR (or not at all).  Once the tests have been fixed, these markers should be removed.