### PR TITLE
[pdpix] Multiplex `demi_wait()` on Top of `demi_timedwait()`

### DIFF
--- a/man/demi_wait.md
+++ b/man/demi_wait.md
@@ -22,7 +22,11 @@ int demi_wait_any(demi_qresult_t *qr_out, int *ready_offset, demi_qtoken_t qts[]
 ## Description
 
 `demi_wait()` waits for the completion of the asynchronous I/O operation associated with the queue token `qt`. This
-system call may cause the calling thread to block (spin) indefinitely.
+system call may cause the calling thread to block (spin) indefinitely. This `demi_wait(qr, qt)` call is equivalent to:
+
+```c
+demi_timedwait(qr, qt, NULL);
+```
 
 `demi_timedwait()` waits for the completion of the asynchronous I/O operation associated with the queue token `qt` or
 for the expiration of a timeout, whichever happens first. If the `abstime` parameter is non null, then it is taken as an
@@ -115,7 +119,6 @@ On error, one of the following positive error codes is returned:
 - `EINVAL` - The `qt` argument refers to an invalid queue token.
 - `EINVAL` - The `num_qts` argument has an invalid size.
 - `EINVAL` - The `qts` argument contains an invalid queue token.
-- `EINVAL` - The `abtime` argument does not point to a valid structure.
 - `ETIMEDOUT` - The system call timed out before an I/O operation was completed.
 
 ## Conforming To

--- a/man/demi_wait.md
+++ b/man/demi_wait.md
@@ -15,6 +15,7 @@
 #include <demi/types.h> /* For demi_qresult_t and demi_qtoken_t. */
 
 int demi_wait(demi_qresult_t *qr_out, demi_qtoken_t qt);
+int demi_timedwait(demi_qresult_t *qr_out, demi_qtoken_t qt, const struct timespec *abstime);
 int demi_wait_any(demi_qresult_t *qr_out, int *ready_offset, demi_qtoken_t qts[], int num_qts);
 ```
 
@@ -24,10 +25,12 @@ int demi_wait_any(demi_qresult_t *qr_out, int *ready_offset, demi_qtoken_t qts[]
 system call may cause the calling thread to block (spin) indefinitely.
 
 `demi_timedwait()` waits for the completion of the asynchronous I/O operation associated with the queue token `qt` or
-for the expiration of a timeout, whichever happens first. The `abstime` parameter specifies an absolute timeout in
-seconds and nanoseconds since the Epoch.  If the I/O operation has already completed when `demi_timedwait()` is called,
-then this system call never fails with a timeout error, regardless of the value of `abstime`. This system call may cause
-the calling thread to block (spin) until the timeout `abstime` expires.
+for the expiration of a timeout, whichever happens first. If the `abstime` parameter is non null, then it is taken as an
+absolute timeout in seconds and nanoseconds since the Epoch. On the one hand, if the I/O operation has already completed
+when `demi_timedwait()` is called, then this system call never fails with a timeout error, regardless of the value of
+`abstime`. On this mode, the `demi_timedwait()` system call may cause the calling thread to block (spin) until the
+timeout `abstime` expires. On the other hand, if the `abstime` parameter has a null value, then the calling thread
+blocks (spins) indefinitely until the I/O operation associated with the queue token `qt` completes.
 
 `demi_wait_any()` waits for the first asynchronous I/O operation in a set to complete. The set of I/O operations is
 specified by the list of queue tokens `qts` and it has a length of `num_qts`. This system call may cause the calling

--- a/src/rust/demikernel/bindings.rs
+++ b/src/rust/demikernel/bindings.rs
@@ -452,24 +452,8 @@ pub extern "C" fn demi_timedwait(
 pub extern "C" fn demi_wait(qr_out: *mut demi_qresult_t, qt: demi_qtoken_t) -> c_int {
     trace!("demi_wait()");
 
-    // Issue wait operation.
-    let ret: Result<i32, Fail> = do_syscall(|libos| match libos.wait(qt.into()) {
-        Ok(r) => {
-            if !qr_out.is_null() {
-                unsafe { *qr_out = r };
-            }
-            0
-        },
-        Err(e) => {
-            warn!("wait() failed: {:?}", e);
-            e.errno
-        },
-    });
-
-    match ret {
-        Ok(ret) => ret,
-        Err(e) => e.errno,
-    }
+    // Forward wait operation.
+    demi_timedwait(qr_out, qt, ptr::null())
 }
 
 //======================================================================================================================

--- a/src/rust/demikernel/libos/mod.rs
+++ b/src/rust/demikernel/libos/mod.rs
@@ -166,18 +166,7 @@ impl LibOS {
     pub fn wait(&mut self, qt: QToken) -> Result<demi_qresult_t, Fail> {
         trace!("wait(): qt={:?}", qt);
 
-        // Retrieve associated schedule handle.
-        let handle: SchedulerHandle = self.schedule(qt)?;
-
-        loop {
-            // Poll first, so as to give pending operations a chance to complete.
-            self.poll();
-
-            // The operation has completed, so extract the result and return.
-            if handle.has_completed() {
-                return Ok(self.pack_result(handle, qt)?);
-            }
-        }
+        self.timedwait(qt, None)
     }
 
     /// Waits for an I/O operation to complete or a timeout to expire.


### PR DESCRIPTION
Description
-------------

This is a fix for https://github.com/demikernel/demikernel/issues/323.

Summary of Changes
-------------------------

- Changed semantics of `demi_timedwait()` to enable indefinite wait
- Multiplex implementation of `demi_wait()` on top of `demi_timedwait()`
- Updated manual pages accordinly