### PR TITLE
[pdpix] Timeout Interval Parameter to `demi_wait()` and `demi_wait_any()`

### DIFF
--- a/examples/c/tcp-ping-pong.c
+++ b/examples/c/tcp-ping-pong.c
@@ -56,7 +56,7 @@ static int accept_wait(int qd)
     assert(demi_accept(&qt, qd) == 0);
 
     /* Wait for operation to complete. */
-    assert(demi_wait(&qr, qt) == 0);
+    assert(demi_wait(&qr, qt, NULL) == 0);
 
     /* Parse operation result. */
     assert(qr.qr_opcode == DEMI_OPC_ACCEPT);
@@ -83,7 +83,7 @@ static void connect_wait(int qd, const struct sockaddr_in *saddr)
     assert(demi_connect(&qt, qd, (const struct sockaddr *)saddr, sizeof(struct sockaddr_in)) == 0);
 
     /* Wait for operation to complete. */
-    assert(demi_wait(&qr, qt) == 0);
+    assert(demi_wait(&qr, qt, NULL) == 0);
 
     /* Parse operation result. */
     assert(qr.qr_opcode == DEMI_OPC_CONNECT);
@@ -108,7 +108,7 @@ static void push_wait(int qd, demi_sgarray_t *sga, demi_qresult_t *qr)
     assert(demi_push(&qt, qd, sga) == 0);
 
     /* Wait push operation to complete. */
-    assert(demi_wait(qr, qt) == 0);
+    assert(demi_wait(qr, qt, NULL) == 0);
 
     /* Parse operation result. */
     assert(qr->qr_opcode == DEMI_OPC_PUSH);
@@ -132,7 +132,7 @@ static void pop_wait(int qd, demi_qresult_t *qr)
     assert(demi_pop(&qt, qd) == 0);
 
     /* Wait for pop operation to complete. */
-    assert(demi_wait(qr, qt) == 0);
+    assert(demi_wait(qr, qt, NULL) == 0);
 
     /* Parse operation result. */
     assert(qr->qr_opcode == DEMI_OPC_POP);

--- a/examples/c/tcp-push-pop.c
+++ b/examples/c/tcp-push-pop.c
@@ -28,7 +28,7 @@ static int accept_get_newsockqd(struct sockaddr_in *addr)
     assert(demi_bind(sockqd, (const struct sockaddr *)addr, sizeof(struct sockaddr_in)) == 0);
     assert(demi_listen(sockqd, 16) == 0);
     assert(demi_accept(&tok, sockqd) == 0);
-    assert(demi_wait(&res, tok) == 0);
+    assert(demi_wait(&res, tok, NULL) == 0);
     assert(res.qr_opcode == DEMI_OPC_ACCEPT);
     return res.qr_value.ares.qd;
 }
@@ -40,7 +40,7 @@ static int pop_get_received_nbytes(int sockqd)
     int recv_bytes = 0;
 
     assert(demi_pop(&tok, sockqd) == 0);
-    assert(demi_wait(&res, tok) == 0);
+    assert(demi_wait(&res, tok, NULL) == 0);
     assert(res.qr_opcode == DEMI_OPC_POP);
     assert(res.qr_value.sga.sga_segs != 0);
     recv_bytes = res.qr_value.sga.sga_segs[0].sgaseg_len;
@@ -70,7 +70,7 @@ static int connect_get_sockqd(const struct sockaddr_in *const addr)
 
     assert(demi_socket(&sockqd, AF_INET, SOCK_STREAM, 0) == 0);
     assert(demi_connect(&tok, sockqd, (const struct sockaddr *)addr, sizeof(struct sockaddr_in)) == 0);
-    assert(demi_wait(&res, tok) == 0);
+    assert(demi_wait(&res, tok, NULL) == 0);
     assert(res.qr_opcode == DEMI_OPC_CONNECT);
     return sockqd;
 }
@@ -85,7 +85,7 @@ static int push_get_sent_nbytes(const struct sockaddr_in *const addr, const int 
     assert(sga.sga_segs != 0);
     memset(sga.sga_segs[0].sgaseg_buf, 1, DATA_SIZE);
     assert(demi_pushto(&tok, sockqd, &sga, (const struct sockaddr *)addr, sizeof(struct sockaddr_in)) == 0);
-    assert(demi_wait(&res, tok) == 0);
+    assert(demi_wait(&res, tok, NULL) == 0);
     assert(res.qr_opcode == DEMI_OPC_PUSH);
     sent_bytes = sga.sga_segs[0].sgaseg_len;
     assert(demi_sgafree(&sga) == 0);

--- a/examples/c/udp-ping-pong.c
+++ b/examples/c/udp-ping-pong.c
@@ -56,7 +56,7 @@ static void pushto_wait(int qd, demi_sgarray_t *sga, demi_qresult_t *qr, const s
     assert(demi_pushto(&qt, qd, sga, (const struct sockaddr *)dest, sizeof(struct sockaddr_in)) == 0);
 
     /* Wait push operation to complete. */
-    assert(demi_wait(qr, qt) == 0);
+    assert(demi_wait(qr, qt, NULL) == 0);
 
     /* Parse operation result. */
     assert(qr->qr_opcode == DEMI_OPC_PUSH);
@@ -80,7 +80,7 @@ static void pop_wait(int qd, demi_qresult_t *qr)
     assert(demi_pop(&qt, qd) == 0);
 
     /* Wait for pop operation to complete. */
-    assert(demi_wait(qr, qt) == 0);
+    assert(demi_wait(qr, qt, NULL) == 0);
 
     /* Parse operation result. */
     assert(qr->qr_opcode == DEMI_OPC_POP);

--- a/examples/c/udp-push-pop.c
+++ b/examples/c/udp-push-pop.c
@@ -70,7 +70,7 @@ static void server(int argc, char *const argv[], struct sockaddr_in *local)
         assert(demi_pop(&qt, sockqd) == 0);
 
         /* Wait for pop operation to complete. */
-        assert(demi_wait(&qr, qt) == 0);
+        assert(demi_wait(&qr, qt, NULL) == 0);
 
         /* Parse operation result. */
         assert(qr.qr_opcode == DEMI_OPC_POP);
@@ -125,7 +125,7 @@ static void client(int argc, char *const argv[], struct sockaddr_in *local, stru
         assert(demi_pushto(&qt, sockqd, &sga, (const struct sockaddr *)remote, sizeof(struct sockaddr_in)) == 0);
 
         /* Wait push operation to complete. */
-        assert(demi_wait(&qr, qt) == 0);
+        assert(demi_wait(&qr, qt, NULL) == 0);
 
         /* Parse operation result. */
         assert(qr.qr_opcode == DEMI_OPC_PUSH);

--- a/examples/rust/tcp-dump.rs
+++ b/examples/rust/tcp-dump.rs
@@ -155,7 +155,7 @@ impl Application {
             Ok(qt) => qt,
             Err(e) => panic!("failed to accept connection on socket: {:?}", e.cause),
         };
-        let (qd, mut qt): (QDesc, QToken) = match self.libos.wait(qt) {
+        let (qd, mut qt): (QDesc, QToken) = match self.libos.wait(qt, None) {
             Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_ACCEPT => {
                 println!("connection accepted!");
                 let qd: QDesc = unsafe { qr.qr_value.ares.qd.into() };
@@ -180,7 +180,7 @@ impl Application {
             }
 
             // Drain packets.
-            match self.libos.wait(qt) {
+            match self.libos.wait(qt, None) {
                 Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_POP => {
                     let sga: demi_sgarray_t = unsafe { qr.qr_value.sga };
                     nbytes += sga.sga_segs[0].sgaseg_len as usize;

--- a/examples/rust/tcp-echo.rs
+++ b/examples/rust/tcp-echo.rs
@@ -203,7 +203,7 @@ impl Application {
                 Ok(qt) => qt,
                 Err(e) => panic!("failed to connect socket: {:?}", e.cause),
             };
-            match libos.wait(qt) {
+            match libos.wait(qt, None) {
                 Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_CONNECT => println!("connected!"),
                 Err(e) => panic!("operation failed: {:?}", e),
                 _ => panic!("unexpected result"),
@@ -290,7 +290,7 @@ impl Application {
                 last_log = Instant::now();
             }
 
-            let (i, qr) = match self.libos.wait_any(&qtokens) {
+            let (i, qr) = match self.libos.wait_any(&qtokens, None) {
                 Ok((i, qr)) => (i, qr),
                 Err(e) => panic!("operation failed: {:?}", e),
             };
@@ -359,7 +359,7 @@ impl Application {
                 Ok(qt) => qt,
                 Err(e) => panic!("failed to push data to socket: {:?}", e.cause),
             };
-            match self.libos.wait(qt) {
+            match self.libos.wait(qt, None) {
                 Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_PUSH => {},
                 Err(e) => panic!("operation failed: {:?}", e.cause),
                 _ => panic!("unexpected result"),
@@ -375,7 +375,7 @@ impl Application {
                 Ok(qt) => qt,
                 Err(e) => panic!("failed to pop data from socket: {:?}", e.cause),
             };
-            match self.libos.wait(qt) {
+            match self.libos.wait(qt, None) {
                 Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_POP => {
                     let sga: demi_sgarray_t = unsafe { qr.qr_value.sga };
                     nbytes += sga.sga_segs[0].sgaseg_len as usize;

--- a/examples/rust/tcp-ping-pong.rs
+++ b/examples/rust/tcp-ping-pong.rs
@@ -104,7 +104,7 @@ fn server(local: SocketAddrV4) -> Result<()> {
         Ok(qt) => qt,
         Err(e) => panic!("accept failed: {:?}", e.cause),
     };
-    let qd: QDesc = match libos.wait(qt) {
+    let qd: QDesc = match libos.wait(qt, None) {
         Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_ACCEPT => unsafe { qr.qr_value.ares.qd.into() },
         Err(e) => panic!("operation failed: {:?}", e.cause),
         _ => panic!("unexpected result"),
@@ -117,7 +117,7 @@ fn server(local: SocketAddrV4) -> Result<()> {
             Ok(qt) => qt,
             Err(e) => panic!("pop failed: {:?}", e.cause),
         };
-        let sga: demi_sgarray_t = match libos.wait(qt) {
+        let sga: demi_sgarray_t = match libos.wait(qt, None) {
             Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_POP => unsafe { qr.qr_value.sga },
             Err(e) => panic!("operation failed: {:?}", e.cause),
             _ => panic!("unexpected result"),
@@ -136,7 +136,7 @@ fn server(local: SocketAddrV4) -> Result<()> {
             Ok(qt) => qt,
             Err(e) => panic!("push failed: {:?}", e.cause),
         };
-        match libos.wait(qt) {
+        match libos.wait(qt, None) {
             Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_PUSH => (),
             Err(e) => panic!("operation failed: {:?}", e.cause),
             _ => panic!("unexpected result"),
@@ -181,7 +181,7 @@ fn client(remote: SocketAddrV4) -> Result<()> {
         Ok(qt) => qt,
         Err(e) => panic!("connect failed: {:?}", e.cause),
     };
-    match libos.wait(qt) {
+    match libos.wait(qt, None) {
         Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_CONNECT => println!("connected!"),
         Err(e) => panic!("operation failed: {:?}", e),
         _ => panic!("unexpected result"),
@@ -196,7 +196,7 @@ fn client(remote: SocketAddrV4) -> Result<()> {
             Ok(qt) => qt,
             Err(e) => panic!("push failed: {:?}", e.cause),
         };
-        match libos.wait(qt) {
+        match libos.wait(qt, None) {
             Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_PUSH => (),
             Err(e) => panic!("operation failed: {:?}", e.cause),
             _ => panic!("unexpected result"),
@@ -211,7 +211,7 @@ fn client(remote: SocketAddrV4) -> Result<()> {
             Ok(qt) => qt,
             Err(e) => panic!("pop failed: {:?}", e.cause),
         };
-        let sga: demi_sgarray_t = match libos.wait(qt) {
+        let sga: demi_sgarray_t = match libos.wait(qt, None) {
             Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_POP => unsafe { qr.qr_value.sga },
             Err(e) => panic!("operation failed: {:?}", e.cause),
             _ => panic!("unexpected result"),

--- a/examples/rust/tcp-pktgen.rs
+++ b/examples/rust/tcp-pktgen.rs
@@ -210,7 +210,7 @@ impl Application {
             Ok(qt) => qt,
             Err(e) => panic!("failed to connect socket: {:?}", e.cause),
         };
-        match libos.wait(qt) {
+        match libos.wait(qt, None) {
             Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_CONNECT => println!("connected!"),
             Err(e) => panic!("operation failed: {:?}", e),
             _ => panic!("unexpected result"),
@@ -248,7 +248,7 @@ impl Application {
                     Ok(qt) => qt,
                     Err(e) => panic!("failed to push data to socket: {:?}", e.cause),
                 };
-                match self.libos.wait(qt) {
+                match self.libos.wait(qt, None) {
                     Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_PUSH => (),
                     Err(e) => panic!("operation failed: {:?}", e.cause),
                     _ => panic!("unexpected result"),

--- a/examples/rust/tcp-push-pop.rs
+++ b/examples/rust/tcp-push-pop.rs
@@ -104,7 +104,7 @@ fn server(local: SocketAddrV4) -> Result<()> {
         Ok(qt) => qt,
         Err(e) => panic!("accept failed: {:?}", e.cause),
     };
-    let qd: QDesc = match libos.wait(qt) {
+    let qd: QDesc = match libos.wait(qt, None) {
         Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_ACCEPT => unsafe { qr.qr_value.ares.qd.into() },
         Err(e) => panic!("operation failed: {:?}", e.cause),
         _ => panic!("unexpected result"),
@@ -118,7 +118,7 @@ fn server(local: SocketAddrV4) -> Result<()> {
             Ok(qt) => qt,
             Err(e) => panic!("pop failed: {:?}", e.cause),
         };
-        let sga: demi_sgarray_t = match libos.wait(qt) {
+        let sga: demi_sgarray_t = match libos.wait(qt, None) {
             Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_POP => unsafe { qr.qr_value.sga },
             Err(e) => panic!("operation failed: {:?}", e.cause),
             _ => panic!("unexpected result"),
@@ -172,7 +172,7 @@ fn client(remote: SocketAddrV4) -> Result<()> {
         Ok(qt) => qt,
         Err(e) => panic!("connect failed: {:?}", e.cause),
     };
-    match libos.wait(qt) {
+    match libos.wait(qt, None) {
         Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_CONNECT => println!("connected!"),
         Err(e) => panic!("operation failed: {:?}", e),
         _ => panic!("unexpected result"),
@@ -188,7 +188,7 @@ fn client(remote: SocketAddrV4) -> Result<()> {
             Ok(qt) => qt,
             Err(e) => panic!("push failed: {:?}", e.cause),
         };
-        match libos.wait(qt) {
+        match libos.wait(qt, None) {
             Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_PUSH => (),
             Err(e) => panic!("operation failed: {:?}", e.cause),
             _ => panic!("unexpected result"),

--- a/examples/rust/udp-dump.rs
+++ b/examples/rust/udp-dump.rs
@@ -157,7 +157,7 @@ impl Application {
                 Ok(qt) => qt,
                 Err(e) => panic!("failed to pop data from socket: {:?}", e.cause),
             };
-            match self.libos.wait(qt) {
+            match self.libos.wait(qt, None) {
                 Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_POP => {
                     let sga: demi_sgarray_t = unsafe { qr.qr_value.sga };
                     nbytes += sga.sga_segs[0].sgaseg_len as usize;

--- a/examples/rust/udp-echo.rs
+++ b/examples/rust/udp-echo.rs
@@ -172,7 +172,7 @@ impl Application {
                 last_log = Instant::now();
             }
 
-            let (i, qr) = match self.libos.wait_any(&qtokens) {
+            let (i, qr) = match self.libos.wait_any(&qtokens, None) {
                 Ok((i, qr)) => (i, qr),
                 Err(e) => panic!("operation failed: {:?}", e),
             };

--- a/examples/rust/udp-ping-pong.rs
+++ b/examples/rust/udp-ping-pong.rs
@@ -102,7 +102,7 @@ fn server(local: SocketAddrV4, remote: SocketAddrV4) -> ! {
             Ok(qt) => qt,
             Err(e) => panic!("pop failed: {:?}", e.cause),
         };
-        let sga: demi_sgarray_t = match libos.wait(qt) {
+        let sga: demi_sgarray_t = match libos.wait(qt, None) {
             Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_POP => unsafe { qr.qr_value.sga },
             Err(e) => panic!("operation failed: {:?}", e.cause),
             _ => panic!("unexpected result"),
@@ -121,7 +121,7 @@ fn server(local: SocketAddrV4, remote: SocketAddrV4) -> ! {
             Ok(qt) => qt,
             Err(e) => panic!("push failed: {:?}", e.cause),
         };
-        match libos.wait(qt) {
+        match libos.wait(qt, None) {
             Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_PUSH => (),
             Err(e) => panic!("operation failed: {:?}", e.cause),
             _ => panic!("unexpected result"),
@@ -180,7 +180,7 @@ fn client(local: SocketAddrV4, remote: SocketAddrV4) -> Result<()> {
     // Send packets.
     let mut i: usize = 0;
     while i < npings {
-        let (idx, qr): (usize, demi_qresult_t) = match libos.wait_any(&qts) {
+        let (idx, qr): (usize, demi_qresult_t) = match libos.wait_any(&qts, None) {
             Ok((idx, qr)) => (idx, qr),
             Err(e) => panic!("operation failed: {:?}", e.cause),
         };

--- a/examples/rust/udp-pktgen.rs
+++ b/examples/rust/udp-pktgen.rs
@@ -278,7 +278,7 @@ impl Application {
                     Ok(qt) => qt,
                     Err(e) => panic!("failed to push data to socket: {:?}", e.cause),
                 };
-                match self.libos.wait(qt) {
+                match self.libos.wait(qt, None) {
                     Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_PUSH => (),
                     Err(e) => panic!("operation failed: {:?}", e.cause),
                     _ => panic!("unexpected result"),

--- a/examples/rust/udp-push-pop.rs
+++ b/examples/rust/udp-push-pop.rs
@@ -101,7 +101,7 @@ fn server(local: SocketAddrV4) -> Result<()> {
             Ok(qt) => qt,
             Err(e) => panic!("pop failed: {:?}", e.cause),
         };
-        let sga: demi_sgarray_t = match libos.wait(qt) {
+        let sga: demi_sgarray_t = match libos.wait(qt, None) {
             Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_POP => unsafe { qr.qr_value.sga },
             Err(e) => panic!("operation failed: {:?}", e.cause),
             _ => panic!("unexpected result"),
@@ -163,7 +163,7 @@ fn client(local: SocketAddrV4, remote: SocketAddrV4) -> Result<()> {
             Ok(qt) => qt,
             Err(e) => panic!("push failed: {:?}", e.cause),
         };
-        match libos.wait(qt) {
+        match libos.wait(qt, None) {
             Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_PUSH => (),
             Err(e) => panic!("operation failed: {:?}", e.cause),
             _ => panic!("unexpected result"),

--- a/examples/rust/udp-relay.rs
+++ b/examples/rust/udp-relay.rs
@@ -193,7 +193,7 @@ impl Application {
                 last_log = Instant::now();
             }
 
-            let (i, qr) = match self.libos.wait_any(&qtokens) {
+            let (i, qr) = match self.libos.wait_any(&qtokens, None) {
                 Ok((i, qr)) => (i, qr),
                 Err(e) => panic!("operation failed: {:?}", e),
             };

--- a/include/demi/wait.h
+++ b/include/demi/wait.h
@@ -15,12 +15,13 @@ extern "C"
     /**
      * @brief Waits for an asynchronous I/O operation to complete.
      *
-     * @param qr_out Store location for the result of the completed I/O operation.
-     * @param qt     I/O queue token of the target operation to wait for completion.
+     * @param qr_out  Store location for the result of the completed I/O operation.
+     * @param qt      I/O queue token of the target operation to wait for completion.
+     * @param timeout Timeout interval in seconds and nanoseconds.
      *
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
-    extern int demi_wait(demi_qresult_t *qr_out, demi_qtoken_t qt);
+    extern int demi_wait(demi_qresult_t *qr_out, demi_qtoken_t qt, const struct timespec *timeout);
 
     /**
      * @brief Waits for an asynchronous I/O operation to complete or a timeout to expire.
@@ -40,10 +41,11 @@ extern "C"
      * @param ready_offset Store location for the offset in the list of I/O queue tokens of the completed I/O operation.
      * @param qts          List of I/O queue tokens to wait for completion.
      * @param num_qts      Length of the list of I/O queue tokens to wait for completion.
+     * @param timeout      Timeout interval in seconds and nanoseconds.
      *
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
-    extern int demi_wait_any(demi_qresult_t *qr_out, int *ready_offset, const demi_qtoken_t qts[], int num_qts);
+    extern int demi_wait_any(demi_qresult_t *qr_out, int *ready_offset, const demi_qtoken_t qts[], int num_qts, const struct timespec *timeout);
 
 #ifdef __cplusplus
 }

--- a/man/demi_wait.md
+++ b/man/demi_wait.md
@@ -2,11 +2,11 @@
 
 ## Name
 
-`demi_wait` - Waits for an asynchronous I/O operation to complete.
+`demi_wait` - Waits for an asynchronous I/O operation to complete or a timeout to expire.
 
 `demi_timedwait` - Waits for an asynchronous I/O operation to complete or a timeout to expire.
 
-`demi_wait_any` - Waits for the first asynchronous I/O operation in a list to complete.
+`demi_wait_any` - Waits for the first asynchronous I/O operation in a list to complete or a timeout to expire.
 
 ## Synopsis
 
@@ -14,14 +14,16 @@
 #include <demi/wait.h>
 #include <demi/types.h> /* For demi_qresult_t and demi_qtoken_t. */
 
-int demi_wait(demi_qresult_t *qr_out, demi_qtoken_t qt);
-int demi_wait_any(demi_qresult_t *qr_out, int *ready_offset, demi_qtoken_t qts[], int num_qts);
+int demi_wait(demi_qresult_t *qr_out, demi_qtoken_t qt, struct timespec *timeout)
+int demi_wait_any(demi_qresult_t *qr_out, int *ready_offset, demi_qtoken_t qts[], int num_qts, struct timespec *timeout);
 ```
 
 ## Description
 
-`demi_wait()` waits for the completion of the asynchronous I/O operation associated with the queue token `qt`. This
-system call may cause the calling thread to block (spin) indefinitely.
+`demi_wait()` waits for the completion of the asynchronous I/O operation associated with the queue token `qt` or for
+the expiration of a timeout, whichever happens first.  The `timeout` parameter specifies an interval timeout in seconds
+and nanoseconds.  If the `timeout` parameter is NULL, then the timeout will be treated as infinite.  If the I/O
+operation has already completed when `demi_wait()` is called, then this system call never fails with a timeout error, regardless of the value of `timeout`. This system call may cause the calling thread to block (spin) until the timeout `timeout` expires, or indefinitely if the `timeout` is not specified (i.e. is NULL).
 
 `demi_timedwait()` waits for the completion of the asynchronous I/O operation associated with the queue token `qt` or
 for the expiration of a timeout, whichever happens first. The `abstime` parameter specifies an absolute timeout in
@@ -30,8 +32,11 @@ then this system call never fails with a timeout error, regardless of the value 
 the calling thread to block (spin) until the timeout `abstime` expires.
 
 `demi_wait_any()` waits for the first asynchronous I/O operation in a set to complete. The set of I/O operations is
-specified by the list of queue tokens `qts` and it has a length of `num_qts`. This system call may cause the calling
-thread to block (spin) indefinitely.
+specified by the list of queue tokens `qts` and it has a length of `num_qts`.  The `timeout` parameter specifies an
+interval timeout in seconds and nanoseconds.  If the `timeout` parameter is NULL, then the timeout will be treated as
+infinite.  If the I/O operation has already completed when `demi_wait()` is called, then this system call never fails
+with a timeout error, regardless of the value of `timeout`. This system call may cause the calling thread to block
+(spin) until the timeout `timeout` expires, or indefinitely if the `timeout` is not specified (i.e. is NULL).
 
 When `demi_wait()` and `demi_timedwait()` successfully completes, the structure pointed to by `qr_out` is filled in with
 the result value of the I/O operation that has completed. The `demi_wait_any()` system call behaves similarly, but it

--- a/tests/c/syscalls.c
+++ b/tests/c/syscalls.c
@@ -171,8 +171,9 @@ static bool inval_wait(void)
 {
     demi_qresult_t *qr = NULL;
     demi_qtoken_t qt = -1;
+    struct timespec *timeout = NULL;
 
-    return (demi_wait(qr, qt) != 0);
+    return (demi_wait(qr, qt, timeout) != 0);
 }
 
 /**
@@ -184,8 +185,9 @@ static bool inval_wait_any(void)
     int *ready_offset = NULL;
     demi_qtoken_t *qts = NULL;
     int num_qts = -1;
+    struct timespec *timeout = NULL;
 
-    return (demi_wait_any(qr, ready_offset, qts, num_qts) != 0);
+    return (demi_wait_any(qr, ready_offset, qts, num_qts, timeout) != 0);
 }
 
 /*===================================================================================================================*


### PR DESCRIPTION
This PR is a fix for Issue #61.

- Added an interval timeout parameter to `demi_wait()` and `demi_wait_any()`.
- Updated all test and example code in the demikernel repo that uses these call(s) to supply the additional parameter.
- Updated the manual page.
- Changed the internal Rust `wait()` call's implementation to call `wait_any()`.

Note: I originally planned to re-implement `demi_wait()` and `demi_wait_any()` on top of `demi_timedwait()` (i.e. convert the wait interval to an absolute timeout) but had to abort that plan once I noticed in the documentation that `SystemTime` is not guaranteed to be monotonically increasing, and thus isn't suitable for interval timing.  (While the implementation of these is technically system-dependent, Rust expects `SystemTime` to be implemented using the real-time clock, which can be adjusted by NTP or the user, and thus can go backwards.  `Instant` is expected to be implemented using tick-counts or something similar, which is guaranteed to be monotonically increasing)  So I implemented `demi_wait_any()` using `Instant`s, and `demi_wait()` is now implemented using `demi_wait_any()`.

I left `demi_timedwait()` in place until we have time to discuss what to do about it.