### PR TITLE
[pdpix] Use trace Logging Level to Propagate Unexpected Conditions

### DIFF
--- a/src/rust/demikernel/bindings.rs
+++ b/src/rust/demikernel/bindings.rs
@@ -160,7 +160,7 @@ pub extern "C" fn demi_bind(qd: c_int, saddr: *const sockaddr, size: Socklen) ->
 //======================================================================================================================
 
 #[no_mangle]
-pub extern "C" fn demi_listen(fd: c_int, backlog: c_int) -> c_int {
+pub extern "C" fn demi_listen(sockqd: c_int, backlog: c_int) -> c_int {
     trace!("demi_listen()");
 
     // Check if socket backlog is invalid.
@@ -169,7 +169,7 @@ pub extern "C" fn demi_listen(fd: c_int, backlog: c_int) -> c_int {
     }
 
     // Issue listen operation.
-    let ret: Result<i32, Fail> = do_syscall(|libos| match libos.listen(fd.into(), backlog as usize) {
+    let ret: Result<i32, Fail> = do_syscall(|libos| match libos.listen(sockqd.into(), backlog as usize) {
         Ok(..) => 0,
         Err(e) => {
             trace!("demi_listen() failed: {:?}", e);
@@ -218,7 +218,7 @@ pub extern "C" fn demi_accept(qtok_out: *mut demi_qtoken_t, sockqd: c_int) -> c_
 #[no_mangle]
 pub extern "C" fn demi_connect(
     qtok_out: *mut demi_qtoken_t,
-    qd: c_int,
+    sockqd: c_int,
     saddr: *const sockaddr,
     size: Socklen,
 ) -> c_int {
@@ -244,7 +244,7 @@ pub extern "C" fn demi_connect(
     };
 
     // Issue connect operation.
-    let ret: Result<i32, Fail> = do_syscall(|libos| match libos.connect(qd.into(), endpoint) {
+    let ret: Result<i32, Fail> = do_syscall(|libos| match libos.connect(sockqd.into(), endpoint) {
         Ok(qt) => {
             unsafe { *qtok_out = qt.into() };
             0
@@ -291,7 +291,7 @@ pub extern "C" fn demi_close(qd: c_int) -> c_int {
 #[no_mangle]
 pub extern "C" fn demi_pushto(
     qtok_out: *mut demi_qtoken_t,
-    qd: c_int,
+    sockqd: c_int,
     sga: *const demi_sgarray_t,
     saddr: *const sockaddr,
     size: Socklen,
@@ -324,7 +324,7 @@ pub extern "C" fn demi_pushto(
         },
     };
 
-    let ret: Result<i32, Fail> = do_syscall(|libos| match libos.pushto(qd.into(), sga, endpoint) {
+    let ret: Result<i32, Fail> = do_syscall(|libos| match libos.pushto(sockqd.into(), sga, endpoint) {
         Ok(qt) => {
             unsafe { *qtok_out = qt.into() };
             0

--- a/src/rust/demikernel/bindings.rs
+++ b/src/rust/demikernel/bindings.rs
@@ -77,7 +77,7 @@ pub extern "C" fn demi_init(argc: c_int, argv: *mut *mut c_char) -> c_int {
     let libos: LibOS = match LibOS::new(libos_name) {
         Ok(libos) => libos,
         Err(e) => {
-            warn!("failed to initialize libos: {:?}", e.cause);
+            trace!("demi_init() failed: {:?}", e);
             return -e.errno;
         },
     };
@@ -102,7 +102,7 @@ pub extern "C" fn demi_socket(qd_out: *mut c_int, domain: c_int, socket_type: c_
             0
         },
         Err(e) => {
-            warn!("socket() failed: {:?}", e);
+            trace!("demi_socket() failed: {:?}", e);
             e.errno
         },
     });
@@ -135,7 +135,7 @@ pub extern "C" fn demi_bind(qd: c_int, saddr: *const sockaddr, size: Socklen) ->
     let endpoint: SocketAddrV4 = match sockaddr_to_socketaddrv4(saddr) {
         Ok(endpoint) => endpoint,
         Err(e) => {
-            warn!("bind() failed: {:?}", e);
+            trace!("demi_bind() failed: {:?}", e);
             return e.errno;
         },
     };
@@ -144,7 +144,7 @@ pub extern "C" fn demi_bind(qd: c_int, saddr: *const sockaddr, size: Socklen) ->
     let ret: Result<i32, Fail> = do_syscall(|libos| match libos.bind(qd.into(), endpoint) {
         Ok(..) => 0,
         Err(e) => {
-            warn!("bind() failed: {:?}", e);
+            trace!("demi_bind() failed: {:?}", e);
             e.errno
         },
     });
@@ -172,7 +172,7 @@ pub extern "C" fn demi_listen(fd: c_int, backlog: c_int) -> c_int {
     let ret: Result<i32, Fail> = do_syscall(|libos| match libos.listen(fd.into(), backlog as usize) {
         Ok(..) => 0,
         Err(e) => {
-            warn!("listen() failed: {:?}", e);
+            trace!("demi_listen() failed: {:?}", e);
             e.errno
         },
     });
@@ -197,7 +197,7 @@ pub extern "C" fn demi_accept(qtok_out: *mut demi_qtoken_t, sockqd: c_int) -> c_
             *qtok_out = match libos.accept(sockqd.into()) {
                 Ok(qt) => qt.into(),
                 Err(e) => {
-                    warn!("accept() failed: {:?}", e);
+                    trace!("demi_accept() failed: {:?}", e);
                     return e.errno;
                 },
             }
@@ -238,7 +238,7 @@ pub extern "C" fn demi_connect(
     let endpoint: SocketAddrV4 = match sockaddr_to_socketaddrv4(saddr) {
         Ok(endpoint) => endpoint,
         Err(e) => {
-            warn!("connect() failed: {:?}", e);
+            trace!("demi_connect() failed: {:?}", e);
             return e.errno;
         },
     };
@@ -250,7 +250,7 @@ pub extern "C" fn demi_connect(
             0
         },
         Err(e) => {
-            warn!("connect() failed: {:?}", e);
+            trace!("demi_connect() failed: {:?}", e);
             e.errno
         },
     });
@@ -273,7 +273,7 @@ pub extern "C" fn demi_close(qd: c_int) -> c_int {
     let ret: Result<i32, Fail> = do_syscall(|libos| match libos.close(qd.into()) {
         Ok(..) => 0,
         Err(e) => {
-            warn!("close() failed: {:?}", e);
+            trace!("demi_close() failed: {:?}", e);
             e.errno
         },
     });
@@ -319,7 +319,7 @@ pub extern "C" fn demi_pushto(
     let endpoint: SocketAddrV4 = match sockaddr_to_socketaddrv4(saddr) {
         Ok(endpoint) => endpoint,
         Err(e) => {
-            warn!("pushto() failed: {:?}", e);
+            trace!("demi_pushto() failed: {:?}", e);
             return e.errno;
         },
     };
@@ -330,7 +330,7 @@ pub extern "C" fn demi_pushto(
             0
         },
         Err(e) => {
-            warn!("pushto() failed: {:?}", e);
+            trace!("demi_pushto() failed: {:?}", e);
             e.errno
         },
     });
@@ -363,7 +363,7 @@ pub extern "C" fn demi_push(qtok_out: *mut demi_qtoken_t, qd: c_int, sga: *const
             0
         },
         Err(e) => {
-            warn!("push() failed: {:?}", e);
+            trace!("demi_push() failed: {:?}", e);
             e.errno
         },
     });
@@ -389,7 +389,7 @@ pub extern "C" fn demi_pop(qtok_out: *mut demi_qtoken_t, qd: c_int) -> c_int {
             0
         },
         Err(e) => {
-            warn!("pop() failed: {:?}", e);
+            trace!("demi_pop() failed: {:?}", e);
             e.errno
         },
     });
@@ -438,7 +438,7 @@ pub extern "C" fn demi_timedwait(
             0
         },
         Err(e) => {
-            warn!("timedwait() failed: {:?}", e);
+            trace!("demi_timedwait() failed: {:?}", e);
             e.errno
         },
     });
@@ -474,7 +474,7 @@ pub extern "C" fn demi_wait(qr_out: *mut demi_qresult_t, qt: demi_qtoken_t, time
             0
         },
         Err(e) => {
-            warn!("wait() failed: {:?}", e);
+            trace!("demi_wait() failed: {:?}", e);
             e.errno
         },
     });
@@ -535,7 +535,7 @@ pub extern "C" fn demi_wait_any(
             0
         },
         Err(e) => {
-            warn!("wait_any() failed: {:?}", e);
+            trace!("demi_wait_any() failed: {:?}", e);
             e.errno
         },
     });
@@ -552,7 +552,7 @@ pub extern "C" fn demi_wait_any(
 
 #[no_mangle]
 pub extern "C" fn demi_sgaalloc(size: libc::size_t) -> demi_sgarray_t {
-    trace!("demi_sgalloc()");
+    trace!("demi_sgaalloc()");
 
     let null_sga: demi_sgarray_t = {
         demi_sgarray_t {
@@ -570,13 +570,19 @@ pub extern "C" fn demi_sgaalloc(size: libc::size_t) -> demi_sgarray_t {
     let ret: Result<demi_sgarray_t, Fail> = do_syscall(|libos| -> demi_sgarray_t {
         match libos.sgaalloc(size) {
             Ok(sga) => sga,
-            Err(_) => null_sga,
+            Err(e) => {
+                trace!("demi_sgaalloc() failed: {:?}", e);
+                null_sga
+            },
         }
     });
 
     match ret {
         Ok(ret) => ret,
-        Err(_) => null_sga,
+        Err(e) => {
+            trace!("demi_sgaalloc() failed: {:?}", e);
+            null_sga
+        },
     }
 }
 
@@ -597,7 +603,7 @@ pub extern "C" fn demi_sgafree(sga: *mut demi_sgarray_t) -> c_int {
     let ret: Result<i32, Fail> = do_syscall(|libos| match libos.sgafree(unsafe { *sga }) {
         Ok(()) => 0,
         Err(e) => {
-            warn!("sgafree() failed: {:?}", e);
+            trace!("demi_sgafree() failed: {:?}", e);
             e.errno
         },
     });

--- a/src/rust/demikernel/libos/mod.rs
+++ b/src/rust/demikernel/libos/mod.rs
@@ -175,9 +175,9 @@ impl LibOS {
         let qt_array: [QToken; 1] = [qt];
 
         // Call wait_any() to do the real work.
-        let result = self.wait_any(&qt_array, timeout)?;
-        debug_assert_eq!(result.0, 0);
-        Ok(result.1)
+        let (offset, qr): (usize, demi_qresult_t) = self.wait_any(&qt_array, timeout)?;
+        debug_assert_eq!(offset, 0);
+        Ok(qr)
     }
 
     /// Waits for an I/O operation to complete or a timeout to expire.

--- a/src/rust/demikernel/libos/mod.rs
+++ b/src/rust/demikernel/libos/mod.rs
@@ -131,21 +131,21 @@ impl LibOS {
         }
     }
 
-    /// Initiates a connection with a remote TCP pper.
+    /// Initiates a connection with a remote TCP socket.
     pub fn connect(&mut self, sockqd: QDesc, remote: SocketAddrV4) -> Result<QToken, Fail> {
         match self {
             LibOS::NetworkLibOS(libos) => libos.connect(sockqd, remote),
         }
     }
 
-    /// Closes a socket.
+    /// Closes an I/O queue.
     pub fn close(&mut self, qd: QDesc) -> Result<(), Fail> {
         match self {
             LibOS::NetworkLibOS(libos) => libos.close(qd),
         }
     }
 
-    /// Pushes a scatter-gather array to a TCP socket.
+    /// Pushes a scatter-gather array to an I/O queue.
     pub fn push(&mut self, qd: QDesc, sga: &demi_sgarray_t) -> Result<QToken, Fail> {
         match self {
             LibOS::NetworkLibOS(libos) => libos.push(qd, sga),
@@ -159,7 +159,7 @@ impl LibOS {
         }
     }
 
-    /// Pops data from a socket.
+    /// Pops data from a an I/O queue.
     pub fn pop(&mut self, qd: QDesc) -> Result<QToken, Fail> {
         match self {
             LibOS::NetworkLibOS(libos) => libos.pop(qd),


### PR DESCRIPTION
Description
-------------

This is a partial fix for [pdpix] Use trace Logging Level to Propagate Unexpected Conditions.

Summary of Changes
------------------------
- Changed logging messages on PDPIX to `trace` level.
  - These do not concern the point where the unexpected situation happened.
- Renamed socket queue descriptors in PDPIX layer to `sockqd` to match the used convention in the file.
- Fixed some types in the API docs in the PDPIX layer.
- Added missing types in `wait()`.