### PR TITLE
[arp] Add Remove Function

### DIFF
--- a/src/rust/inetstack/collections/hashttlcache/mod.rs
+++ b/src/rust/inetstack/collections/hashttlcache/mod.rs
@@ -114,8 +114,19 @@ where
     }
 
     /// Removes an entry from the cache.
-    pub fn remove(&mut self, _key: &K) -> Option<V> {
-        todo!()
+    pub fn remove(&mut self, key: &K) -> Option<V> {
+        match self.get(key) {
+            Some(_) => {
+                let (k, v): (K, Record<V>) = self.map.remove_entry(key).unwrap();
+                // FIXME: should be returning the removed memory not the old one from
+                // the graveyard, but we can't without cloning the removed value
+                self.graveyard.insert(k, v.value)
+            },
+            None => {
+                warn!("Trying to remove key that does not exist");
+                None
+            },
+        }
     }
 
     // Gets an entry from the cache.

--- a/src/rust/inetstack/collections/hashttlcache/tests.rs
+++ b/src/rust/inetstack/collections/hashttlcache/tests.rs
@@ -126,3 +126,27 @@ fn replace_object() {
     cache.cleanup();
     assert!(cache.get(&"a").is_none());
 }
+
+#[test]
+fn add_and_remove_object() {
+    let now: Instant = Instant::now();
+    let ttl: Duration = Duration::from_secs(2);
+    let default_ttl: Duration = Duration::from_secs(1);
+    let mut cache: HashTtlCache<&str, char> = HashTtlCache::<&str, char>::new(now, Some(default_ttl));
+    // insert object with default TTL
+    cache.insert("a", 'a');
+    // insert object with some TTL
+    cache.insert_with_ttl("b", 'b', Some(ttl));
+
+    // make sure object is in the cache
+    assert!(cache.get(&"a") == Some(&'a'));
+    assert!(cache.get(&"b") == Some(&'b'));
+
+    // remove object
+    cache.remove(&"a");
+    cache.remove(&"b");
+
+    // make sure object is not in cache
+    assert!(cache.get(&"a").is_none());
+    assert!(cache.get(&"b").is_none());
+}


### PR DESCRIPTION
This PR add a remove function for the hashttlcache. Due to the removed value being placed in the graveyard, we do not currently return the removed value as well because that would require us to clone it. I believe this is incorrect behavior but we're unclear on what the graveyard's functionality is or if we will use it going forward so I will just leave this fix as is for now.