### PR TITLE
[inetstack] Accept Ethernet Multicast Packets

### DIFF
--- a/src/rust/inetstack/mod.rs
+++ b/src/rust/inetstack/mod.rs
@@ -565,10 +565,11 @@ impl InetStack {
         timer!("inetstack::engine::receive");
         let (header, payload) = Ethernet2Header::parse(bytes)?;
         debug!("Engine received {:?}", header);
-        if self.local_link_addr != header.dst_addr() && !header.dst_addr().is_broadcast() {
-            // ToDo: Add support for is_multicast() to MacAddress type.  Then remove following trace and restore return.
-            trace!("Need to add && !header.dst_addr().is_multicast()");
-            //return Err(Fail::new(EINVAL, "physical destination address mismatch"));
+        if self.local_link_addr != header.dst_addr()
+            && !header.dst_addr().is_broadcast()
+            && !header.dst_addr().is_multicast()
+        {
+            return Err(Fail::new(EINVAL, "physical destination address mismatch"));
         }
         match header.ether_type() {
             EtherType2::Arp => self.arp.receive(payload),


### PR DESCRIPTION
This PR fixes Issue #194.

Basically, we have a filter at the Ethernet layer that is intended to drop packets not actually addressed to us (Ethernet MAC address).  In the past, we accepted incoming packets addressed to our actual EUI-48, and also ones sent to the broadcast address (needed for ARP).  But we dropped packets addressed to a multicast address that our NIC was listening on (after printing a warning).

This PR now allows multicast packets to be received by the Ethernet layer of our stack (they still have to pass the IP address checks of course).

Note: There used to be a [linked Issue in a different repo](https://github.com/demikernel/runtime/issues/17) (back when we had these separate) to add the `is_multicast()` functionality.  I added that in a separate PR before the repos were recombined.