### PR TITLE
[catnip] Use PAL in Catnip

### DIFF
--- a/examples/rust/udp-echo.rs
+++ b/examples/rust/udp-echo.rs
@@ -25,8 +25,9 @@ use ::demikernel::{
     QDesc,
     QToken,
 };
+#[cfg(target_os = "linux")]
+use ::std::mem;
 use ::std::{
-    mem,
     net::{
         Ipv4Addr,
         SocketAddrV4,

--- a/src/rust/pal/functions.rs
+++ b/src/rust/pal/functions.rs
@@ -3,9 +3,41 @@
 
 use crate::pal::data_structures::SockAddrIn;
 
+#[cfg(feature = "catnip-libos")]
+const NUM_OCTETS_IN_IPV4: usize = 4;
+
+#[cfg(feature = "catnip-libos")]
+const NUM_SIN_ZERO_BYTES: usize = 8;
+
+#[cfg(all(feature = "catnip-libos", target_os = "windows"))]
+use windows::Win32::Foundation::CHAR;
+
+#[cfg(all(feature = "catnip-libos", target_os = "windows"))]
+use windows::Win32::Networking::WinSock::IN_ADDR;
+
+#[cfg(all(feature = "catnip-libos", target_os = "windows"))]
+use windows::Win32::Networking::WinSock::IN_ADDR_0;
+
+#[cfg(all(feature = "catnip-libos", target_os = "linux"))]
+use libc::in_addr;
+
 //======================================================================================================================
 // Windows functions
 //======================================================================================================================
+
+#[cfg(all(feature = "catnip-libos", target_os = "windows"))]
+pub fn create_sin_addr(octets: &[u8; NUM_OCTETS_IN_IPV4]) -> IN_ADDR {
+    IN_ADDR {
+        S_un: (IN_ADDR_0 {
+            S_addr: u32::from_le_bytes(*octets),
+        }),
+    }
+}
+
+#[cfg(all(feature = "catnip-libos", target_os = "windows"))]
+pub fn create_sin_zero() -> [CHAR; NUM_SIN_ZERO_BYTES] {
+    [CHAR(0); 8]
+}
 
 #[cfg(target_os = "windows")]
 pub fn get_addr_from_sock_addr_in(sock_addr_in: &SockAddrIn) -> u32 {
@@ -15,6 +47,18 @@ pub fn get_addr_from_sock_addr_in(sock_addr_in: &SockAddrIn) -> u32 {
 //======================================================================================================================
 // Linux functions
 //======================================================================================================================
+
+#[cfg(all(feature = "catnip-libos", target_os = "linux"))]
+pub fn create_sin_addr(octets: &[u8; NUM_OCTETS_IN_IPV4]) -> in_addr {
+    in_addr {
+        s_addr: u32::from_le_bytes(*octets),
+    }
+}
+
+#[cfg(all(feature = "catnip-libos", target_os = "linux"))]
+pub fn create_sin_zero() -> [u8; NUM_SIN_ZERO_BYTES] {
+    [0; 8]
+}
 
 #[cfg(target_os = "linux")]
 pub fn get_addr_from_sock_addr_in(sock_addr_in: &SockAddrIn) -> u32 {


### PR DESCRIPTION
The Platform Abstraction Layer (PAL) implements the OS specific artifacts for the LibOSes. The aim is to isolate these implementation details at a single place (i.e. the PAL).

Partially addresses issue https://github.com/demikernel/demikernel/issues/274.