### PR TITLE
[perftools] Dump Timer Information in Seconds

### DIFF
--- a/src/rust/perftools/profiler/mod.rs
+++ b/src/rust/perftools/profiler/mod.rs
@@ -8,7 +8,7 @@ use ::std::{
     cell::RefCell,
     io,
     rc::Rc,
-    time::{SystemTime, UNIX_EPOCH},
+    time::{SystemTime, UNIX_EPOCH, Duration},
 };
 
 #[cfg(feature = "auto-calibrate")]
@@ -314,16 +314,16 @@ impl Profiler {
     }
 
     fn measure_ns_per_cycle() -> f64 {
-        let start = SystemTime::now();
+        let start: SystemTime = SystemTime::now();
         let (start_cycle, _): (u64, u32) = unsafe { x86::time::rdtscp() };
         
         test::black_box((0..10000).fold(0, |old, new| old ^ new)); // dummy calculations for measurement
 
         let (end_cycle, _): (u64, u32) = unsafe { x86::time::rdtscp() };
-        let since_the_epoch = SystemTime::now()
+        let since_the_epoch: Duration = SystemTime::now()
             .duration_since(start)
             .expect("Time went backwards");
-        let in_ns = since_the_epoch.as_secs() * 1_000_000_000 +
+        let in_ns: u64 = since_the_epoch.as_secs() * 1_000_000_000 +
             since_the_epoch.subsec_nanos() as u64;
 
 


### PR DESCRIPTION
## Description
* This PR fixes #179 

## Summary of Changes
* Approximately measure nanoseconds-per-cycle at initialization
* Print out duration in both cycles and nanoseconds