### PR TITLE
[doc] Moving Build Instructions to Standalone Document

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To get details about the system, read our paper in [SOSP '21](https://doi.org/10
 
 ## Building
 
-> **Follow these instructions to build Demikernel on a fresh Ubuntu 20.04 system.**
+> **Follow these instructions to build Demikernel on a fresh Ubuntu 22.04 system.**
 
 ### 1. Clone This Repository
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To get details about the system, read our paper in [SOSP '21](https://doi.org/10
 
 > To read more about Demikernel check out <https://aka.ms/demikernel>.
 
-## Building
+## Setting Up the Environment
 
 > **Follow these instructions to build Demikernel on a fresh Ubuntu 22.04 system.**
 
@@ -46,27 +46,9 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh    # Get Rust too
 ./scripts/setup/dpdk.sh
 ```
 
-### 4. Build Demikernel with Default Parameters
+## Building Demikernel
 
-```bash
-make
-```
-
-### 5. Build Demikernel with Custom Parameters (Optional)
-
-```bash
-make LIBOS=[catnap|catnip|catpowder|catcollar]    # Build using a specific LibOS.
-make DRIVER=[mlx4|mlx5]                           # Build using a specific driver.
-make LD_LIBRARY_PATH=/path/to/libs                # Override path to shared libraries. Applicable to Catnap and Catcollar.
-make PKG_CONFIG_PATH=/path/to/pkgconfig           # Override path to config files. Applicable to Catnap and Catcollar.
-```
-
-### 6. Install Artifacts (Optional)
-
-```bash
-make install                                     # Copies build artifacts to your $HOME directory.
-make install INSTALL_PREFIX=/path/to/location    # Copies build artifacts to a specific location.
-```
+See [doc/testing.md](./doc/building.md) for instructions and details.
 
 ## Running
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Join us on Slack!](https://img.shields.io/badge/chat-on%20Slack-e01563.svg)](https://join.slack.com/t/demikernel/shared_invite/zt-11i6lgaw5-HFE_IAls7gUX3kp1XSab0g)
 [![Catnip LibOS](https://github.com/demikernel/demikernel/actions/workflows/catnip.yml/badge.svg)](https://github.com/demikernel/demikernel/actions/workflows/catnip.yml)
 [![Catnap LibOS](https://github.com/demikernel/demikernel/actions/workflows/catnap.yml/badge.svg)](https://github.com/demikernel/demikernel/actions/workflows/catnap.yml)
+[![Catmem LibOS](https://github.com/demikernel/demikernel/actions/workflows/catmem.yml/badge.svg)](https://github.com/demikernel/demikernel/actions/workflows/catmem.yml)
 [![Catpowder LibOS](https://github.com/demikernel/demikernel/actions/workflows/catpowder.yml/badge.svg)](https://github.com/demikernel/demikernel/actions/workflows/catpowder.yml)
 [![Catcollar LibOS](https://github.com/demikernel/demikernel/actions/workflows/catcollar.yml/badge.svg)](https://github.com/demikernel/demikernel/actions/workflows/catcollar.yml)
 

--- a/doc/building.md
+++ b/doc/building.md
@@ -1,0 +1,103 @@
+
+# Building Demikernel
+
+This document contains instructions on how to build Demikernel on Linux.
+
+> The instructions in this file assume that you have at your disposal at one
+Linux machine with Demikernel's development environment set up. For more
+information on how to set up Demikernel's development environment, check out
+instructions in the `README.md` file.
+
+## Table of Contents
+
+- [Table of Contents](#table-of-contents)
+- [Building Demikernel with Default Parameters](#building-demikernel-with-default-parameters)
+  - [Installing Artifacts (Optional)](#installing-artifacts-optional)
+- [Custom Build Parameters for Catnip LibOS (Optional)](#custom-build-parameters-for-catnip-libos-optional)
+  - [Override Default Path for DPDK Libraries](#override-default-path-for-dpdk-libraries)
+  - [Override Path to DPDK Package Config File](#override-path-to-dpdk-package-config-file)
+- [Custom Build Parameters for Catcollar LibOS (Optional)](#custom-build-parameters-for-catcollar-libos-optional)
+  - [Override Default Path for I/O Uring Libraries](#override-default-path-for-io-uring-libraries)
+  - [Override Path to I/O Uring Package Config File](#override-path-to-io-uring-package-config-file)
+
+## Building Demikernel with Default Parameters
+
+```bash
+# Builds Demikernel with default LibOS.
+# This defaults to LIBOS=catnap.
+make
+
+# Build Demikernel with I/O Uring LibOS.
+make LIBOS=catcollar
+
+# Build Demikernel with Shared Memory LibOS.
+make LIBOS=catmem
+
+# Build Demikernel with Sockets LibOS.
+make LIBOS=catnap
+
+# Build Demikernel with DPDK LibOS.
+make LIBOS=catnip
+
+# Build Demikernel with Raw Sockets LibOS
+make LIBOS=catpowder
+```
+
+### Installing Artifacts (Optional)
+
+```bash
+# Copies build artifacts to your $HOME directory.
+make install
+
+# Copies build artifacts to a specific location.
+make install INSTALL_PREFIX=/path/to/location
+```
+
+## Custom Build Parameters for Catnip LibOS (Optional)
+
+The following instructions enable you to tweak the building process for Catnip
+LibOS.
+
+### Override Default Path for DPDK Libraries
+
+Override this parameter if your `libdpdk` installation is not located in your
+`$HOME` directory.
+
+```bash
+# Build Catnip LibOS with a custom location for DPDK libraries.
+make LIBOS=catnip LD_LIBRARY_PATH=/path/to/dpdk/libs
+```
+
+### Override Path to DPDK Package Config File
+
+Override this parameter if your `libdpdk` installation is not located in your
+`$HOME` directory.
+
+```bash
+# Build Catnip LibOS with a custom location for DPDK package config files.
+make PKG_CONFIG_PATH=/path/to/dpdk/pkgconfig
+```
+
+## Custom Build Parameters for Catcollar LibOS (Optional)
+
+The following instructions enable you to tweak the building process for Catcollar LibOS.
+
+### Override Default Path for I/O Uring Libraries
+
+Override this parameter if your `liburing` installation is not located in your
+`$HOME` directory.
+
+```bash
+# Build Catcollar LibOS with a custom location for DPDK libraries.
+make LIBOS=catcollar LD_LIBRARY_PATH=/path/to/dpdk/libs
+```
+
+### Override Path to I/O Uring Package Config File
+
+Override this parameter if your `liburing` installation is not located in your
+`$HOME` directory.
+
+```bash
+# Build Catcollar LibOS with a custom location for DPDK package config files.
+make PKG_CONFIG_PATH=/path/to/dpdk/pkgconfig
+```

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -1,15 +1,18 @@
 # Testing Demikernel
 
-This document contains instructions on how to test Demikernel. What it is covered:
+This document contains instructions on how to test Demikernel.
+
+> The instructions listed in this file assume that you have at your disposal at
+least a pair of machines with Demikernel's development environment set up. For
+more information on how to set up Demikernel's development environment, check
+out instructions in the `README.md` file.
+
+## Table of Contents
 
 - [What are unit tests](#what-are-unit-tests)
 - [How to run unit tests](#how-to-run-unit-tests)
 - [What are system-level tests](#what-are-system-level-tests)
 - [How to run system-level tests](#how-to-run-system-level-tests)
-
-> The instructions in this file assume that you have at your disposal at least one machine with Demikernel's development
-environment set up. For more information on how to set up Demikernel's development environment, check out instructions
-in the `README.md` file.
 
 ## What Are Unit Tests
 


### PR DESCRIPTION
## Description

This PR closes https://github.com/demikernel/demikernel/issues/359

## Summary of Changes

- Fixed outdated Ubuntu version in `README.md`.
- Fixed missing Catmem LibOS badge in `README.md`.
- Moved build instructions to a standalone document.