### PR TITLE
[pal] Bad Level When Setting `SO_REUSEPORT`

### DIFF
--- a/src/rust/pal/linux/mod.rs
+++ b/src/rust/pal/linux/mod.rs
@@ -41,7 +41,7 @@ pub unsafe fn set_so_reuseport(fd: RawFd) -> i32 {
     let option_len: libc::socklen_t = mem::size_of_val(&value) as libc::socklen_t;
     libc::setsockopt(
         fd,
-        libc::IPPROTO_TCP,
+        libc::SOL_SOCKET,
         libc::SO_REUSEPORT,
         value_ptr as *const libc::c_void,
         option_len,


### PR DESCRIPTION
## Description

This PR fixes https://github.com/demikernel/demikernel/issues/405

## Summary of Changes

- Fixed the API level for `setsockopt()` when setting `SO_REUSEPORT`.