### PR TITLE
[build] Set `RUST_LOG=trace` when Running in Debug Mode

### DIFF
--- a/linux.mk
+++ b/linux.mk
@@ -16,6 +16,7 @@ export LD_LIBRARY_PATH ?= $(HOME)/lib:$(shell find $(PREFIX)/lib/ -name '*x86_64
 
 export BUILD := release
 ifeq ($(DEBUG),yes)
+export RUST_LOG := trace
 export BUILD := dev
 endif
 


### PR DESCRIPTION
## Description

This commit is a partial fix for https://github.com/demikernel/demikernel/issues/403

## Summary of Changes

- Set `RUST_LOG=trace` on Linux, when running in debug mode.