### PR TITLE
[pal] Helper Function to Convert `std::net::SocketAddrV4` to `libc::sockaddr_in`

### DIFF
--- a/src/rust/catnap/mod.rs
+++ b/src/rust/catnap/mod.rs
@@ -25,6 +25,7 @@ use self::futures::{
 use crate::{
     demikernel::config::Config,
     inetstack::operations::OperationResult,
+    pal::linux,
     runtime::{
         fail::Fail,
         memory::MemoryRuntime,
@@ -412,17 +413,7 @@ fn pack_result(rt: &PosixRuntime, result: OperationResult, qd: QDesc, qt: u64) -
         OperationResult::Pop(addr, bytes) => match rt.into_sgarray(bytes) {
             Ok(mut sga) => {
                 if let Some(endpoint) = addr {
-                    let saddr: libc::sockaddr_in = {
-                        // TODO: check the following byte order conversion.
-                        libc::sockaddr_in {
-                            sin_family: libc::AF_INET as u16,
-                            sin_port: endpoint.port().into(),
-                            sin_addr: libc::in_addr {
-                                s_addr: u32::from_le_bytes(endpoint.ip().octets()),
-                            },
-                            sin_zero: [0; 8],
-                        }
-                    };
+                    let saddr: libc::sockaddr_in = linux::socketaddrv4_to_sockaddr_in(&endpoint);
                     sga.sga_addr = unsafe { mem::transmute::<libc::sockaddr_in, libc::sockaddr>(saddr) };
                 }
                 let qr_value: demi_qr_value_t = demi_qr_value_t { sga };

--- a/src/rust/catpowder/interop.rs
+++ b/src/rust/catpowder/interop.rs
@@ -3,6 +3,7 @@
 
 use crate::{
     catpowder::LinuxRuntime,
+    pal::linux,
     runtime::{
         memory::MemoryRuntime,
         types::{
@@ -52,17 +53,7 @@ pub fn pack_result(rt: Rc<LinuxRuntime>, result: OperationResult, qd: QDesc, qt:
         OperationResult::Pop(addr, bytes) => match rt.into_sgarray(bytes) {
             Ok(mut sga) => {
                 if let Some(endpoint) = addr {
-                    let saddr: libc::sockaddr_in = {
-                        // TODO: check the following byte order conversion.
-                        libc::sockaddr_in {
-                            sin_family: libc::AF_INET as u16,
-                            sin_port: endpoint.port().into(),
-                            sin_addr: libc::in_addr {
-                                s_addr: u32::from_le_bytes(endpoint.ip().octets()),
-                            },
-                            sin_zero: [0; 8],
-                        }
-                    };
+                    let saddr: libc::sockaddr_in = linux::socketaddrv4_to_sockaddr_in(&endpoint);
                     sga.sga_addr = unsafe { mem::transmute::<libc::sockaddr_in, libc::sockaddr>(saddr) };
                 }
                 let qr_value = demi_qr_value_t { sga };

--- a/src/rust/pal/linux/mod.rs
+++ b/src/rust/pal/linux/mod.rs
@@ -13,6 +13,7 @@ pub mod shm;
 
 use ::std::{
     mem,
+    net::SocketAddrV4,
     os::unix::prelude::RawFd,
 };
 
@@ -60,4 +61,21 @@ pub unsafe fn set_nonblock(fd: RawFd) -> i32 {
     // Set file flags.
     flags |= libc::O_NONBLOCK;
     libc::fcntl(fd, libc::F_SETFL, flags, 1)
+}
+
+/// Converts a [std::net::SocketAddrV4] into a [libc::sockaddr_in].
+pub fn socketaddrv4_to_sockaddr_in(addr: &SocketAddrV4) -> libc::sockaddr_in {
+    libc::sockaddr_in {
+        sin_family: libc::AF_INET as libc::sa_family_t,
+        sin_port: u16::to_be(addr.port()),
+        #[cfg(target_endian = "big")]
+        sin_addr: libc::in_addr {
+            s_addr: u32::to_be(u32::from_be_bytes(addr.ip().octets())) as libc::in_addr_t,
+        },
+        #[cfg(target_endian = "little")]
+        sin_addr: libc::in_addr {
+            s_addr: u32::from_le_bytes(addr.ip().octets()),
+        },
+        sin_zero: [0; 8],
+    }
 }


### PR DESCRIPTION
## Description

This PR closes https://github.com/demikernel/demikernel/issues/412

## Summary of Changes

- Added a helper function`sockaddrv4_to_sockaddr_in()` to perform the conversion between a `std::net::SocketAddrV4` to `libc::sockaddr_in`
- Changed the concerned code to rely on the helper function.
- Changed the conversion of `sin_port` and `sin_addr.s_addr` to be on network order.