### PR TITLE
[tools] Adding support for test directories and log files with hostnames

### DIFF
--- a/tools/demikernel-ci.py
+++ b/tools/demikernel-ci.py
@@ -6,6 +6,9 @@ import argparse
 import string
 import subprocess
 import time
+from os import mkdir
+from shutil import move,rmtree
+from os.path import isdir
 from typing import List
 
 # ======================================================================================================================
@@ -23,30 +26,28 @@ def timing(f):
     return wrap
 
 
-def wait_jobs(name: string, jobs: List):
+def wait_jobs(log_directory: string, jobs: dict):
     @timing
-    def wait_jobs2(name: string, jobs: List) -> List:
+    def wait_jobs2(log_directory: string, jobs: dict) -> List:
         status: list[int] = []
 
-        for j in jobs:
+        for job_name, j in jobs.items():
             stdout, stderr = j.communicate()
             status.append((j.pid, j.returncode))
-            job_name: string = "{}-{}".format(name, str(j.pid))
-            with open(job_name + ".stdout", "w") as file:
+            with open(log_directory + "/" + job_name + ".stdout", "w") as file:
                 file.write("{}".format(stdout))
-            with open(job_name + ".stderr", "w") as file:
+            with open(log_directory + "/" + job_name + ".stderr", "w") as file:
                 file.write("{}".format(stderr))
 
         # Cleanup list of jobs.
-        while len(jobs) > 0:
-            jobs.pop(0)
+        jobs.clear()
 
         return status
-    return wait_jobs2(name, jobs)
+    return wait_jobs2(log_directory, jobs)
 
 
-def wait_and_report(name: string, jobs: List, all_pass=True):
-    ret = wait_jobs(name, jobs)
+def wait_and_report(name: string, log_directory: string, jobs: dict, all_pass=True):
+    ret = wait_jobs(log_directory, jobs)
     passed: bool = False
     status: List = ret[0]
     duration: float = ret[1]
@@ -102,50 +103,56 @@ def remote_cleanup(host: string, workspace: string, default_branch: string = "de
 # ======================================================================================================================
 
 
-def job_checkout(repository: string, branch: string, server: string, client: string, enable_nfs: bool) -> bool:
-    jobs: list[subprocess.Popen[str]] = []
-    jobs.append(remote_checkout(server, repository, branch))
+def job_checkout(repository: string, branch: string, server: string, client: string, enable_nfs: bool, log_directory: string) -> bool:
+    # Jobs is a map of job names (server name, repository and compile mode)
+    jobs: dict[string, subprocess.Popen[str]] = {}
+    test_name = "checkout"
+    jobs[test_name + "-server-"+ server] = remote_checkout(server, repository, branch)
     if not enable_nfs:
-        jobs.append(remote_checkout(client, repository, branch))
-    return wait_and_report("checkout", jobs)
+        jobs[test_name + "-client-" + client] = remote_checkout(client, repository, branch)
+    return wait_and_report(test_name, log_directory, jobs)
 
 
-def job_compile(repository: string, libos: string, is_debug: bool, server: string, client: string, enable_nfs: bool) -> bool:
-    jobs: list[subprocess.Popen[str]] = []
-    jobs.append(remote_compile(server, repository, "all LIBOS={}".format(libos), is_debug))
+def job_compile(repository: string, libos: string, is_debug: bool, server: string, client: string, enable_nfs: bool, log_directory: string) -> bool:
+    jobs: dict[string, subprocess.Popen[str]] = {}
+    test_name = "compile-{}".format("debug" if is_debug else "release")
+    jobs[test_name + "-server-" + server] = remote_compile(server, repository, "all LIBOS={}".format(libos), is_debug)
     if not enable_nfs:
-        jobs.append(remote_compile(client, repository, "all LIBOS={}".format(libos), is_debug))
-    return wait_and_report("compile-{}".format("debug" if is_debug else "release"), jobs)
+        jobs[test_name + "-client-" + client] = remote_compile(client, repository, "all LIBOS={}".format(libos), is_debug)
+    return wait_and_report(test_name, log_directory, jobs)
 
 
 def job_test_system_rust(
         test_name: string, repo: string, libos: string, is_debug: bool, server: string, client: string,
-        server_args: string, client_args: string, is_sudo: bool, all_pass: bool, delay: float, config_path: string) -> bool:
+        server_args: string, client_args: string, is_sudo: bool, all_pass: bool, delay: float, config_path: string, 
+        log_directory: string) -> bool:
     server_cmd: string = "test-system-rust LIBOS={} TEST={} ARGS=\\\"{}\\\"".format(libos, test_name, server_args)
     client_cmd: string = "test-system-rust LIBOS={} TEST={} ARGS=\\\"{}\\\"".format(libos, test_name, client_args)
-    jobs: list[subprocess.Popen[str]] = []
-    jobs.append(remote_run(server, repo, is_debug, server_cmd, is_sudo, config_path))
+    jobs: dict[string, subprocess.Popen[str]] = {}
+    jobs[test_name + "-server-" + server] = remote_run(server, repo, is_debug, server_cmd, is_sudo, config_path)
     time.sleep(delay)
-    jobs.append(remote_run(client, repo, is_debug, client_cmd, is_sudo, config_path))
-    return wait_and_report(test_name, jobs, all_pass)
+    jobs[test_name + "-client-" + client] = remote_run(client, repo, is_debug, client_cmd, is_sudo, config_path)
+    return wait_and_report(test_name, log_directory, jobs, all_pass)
 
 
 def job_test_unit_rust(repo: string, libos: string, is_debug: bool, server: string, client: string,
-                       is_sudo: bool, config_path: string) -> bool:
+                       is_sudo: bool, config_path: string, log_directory: string) -> bool:
     server_cmd: string = "test-unit-rust LIBOS={}".format(libos)
     client_cmd: string = "test-unit-rust LIBOS={}".format(libos)
-    jobs: list[subprocess.Popen[str]] = []
-    jobs.append(remote_run(server, repo, is_debug, server_cmd, is_sudo, config_path))
-    jobs.append(remote_run(client, repo, is_debug, client_cmd, is_sudo, config_path))
-    return wait_and_report("unit-tests", jobs, True)
+    test_name = "unit-test"
+    jobs: dict[string, subprocess.Popen[str]] = {}
+    jobs[test_name + "-server-" + server] = remote_run(server, repo, is_debug, server_cmd, is_sudo, config_path)
+    jobs[test_name + "-client-" + client] = remote_run(client, repo, is_debug, client_cmd, is_sudo, config_path)
+    return wait_and_report(test_name, log_directory, jobs, True)
 
 
-def job_cleanup(repository: string, server: string, client: string, enable_nfs: bool) -> bool:
-    jobs: list[subprocess.Popen[str]] = []
-    jobs.append(remote_cleanup(server, repository))
+def job_cleanup(repository: string, server: string, client: string, enable_nfs: bool, log_directory: string) -> bool:
+    test_name = "cleanup"
+    jobs: dict[string, subprocess.Popen[str]] = {}
+    jobs[test_name + "-server-" + server] = remote_cleanup(server, repository)
     if not enable_nfs:
-        jobs.append(remote_cleanup(client, repository))
-    return wait_and_report("cleanup", jobs)
+        jobs[test_name + "-client-" + client + "-"] = remote_cleanup(client, repository)
+    return wait_and_report(test_name, log_directory, jobs)
 
 
 # ======================================================================================================================
@@ -154,68 +161,69 @@ def job_cleanup(repository: string, server: string, client: string, enable_nfs: 
 
 def test_udp_ping_pong(
         server: string, client: string, libos: string, is_debug: bool, is_sudo: bool, repository: string,
-        server_addr: string, client_addr: string, delay: float, config_path: string) -> bool:
+        server_addr: string, client_addr: string, delay: float, config_path: string, log_directory: string) -> bool:
     test_name: string = "udp-ping-pong"
     server_args: string = "--server {}:12345 {}:23456".format(server_addr, client_addr)
     client_args: string = "--client {}:23456 {}:12345".format(client_addr, server_addr)
     return job_test_system_rust(
         test_name, repository, libos, is_debug, server, client, server_args, client_args, is_sudo, False, delay,
-        config_path)
+        config_path, log_directory)
 
 
 def test_udp_push_pop(
         server: string, client: string, libos: string, is_debug: bool, is_sudo: bool, repository: string,
-        server_addr: string, client_addr: string, delay: float, config_path: string) -> bool:
+        server_addr: string, client_addr: string, delay: float, config_path: string, log_directory: string) -> bool:
     test_name: string = "udp-push-pop"
     server_args: string = "--server {}:12345 {}:23456".format(server_addr, client_addr)
     client_args: string = "--client {}:23456 {}:12345".format(client_addr, server_addr)
     return job_test_system_rust(
         test_name, repository, libos, is_debug, server, client, server_args, client_args, is_sudo, True, delay,
-        config_path)
+        config_path, log_directory)
 
 
 def test_tcp_ping_pong(
         server: string, client: string, libos: string, is_debug: bool, is_sudo: bool, repository: string,
-        server_addr: string, delay: float, config_path: string) -> bool:
+        server_addr: string, delay: float, config_path: string, log_directory: string) -> bool:
     test_name: string = "tcp-ping-pong"
     server_args: string = "--server {}:12345".format(server_addr)
     client_args: string = "--client {}:12345".format(server_addr)
     return job_test_system_rust(
         test_name, repository, libos, is_debug, server, client, server_args, client_args, is_sudo, True, delay,
-        config_path)
+        config_path, log_directory)
 
 
 def test_tcp_push_pop(
         server: string, client: string, libos: string, is_debug: bool, is_sudo: bool, repository: string,
-        server_addr: string, delay: float, config_path: string) -> bool:
+        server_addr: string, delay: float, config_path: string, log_directory: string) -> bool:
     test_name: string = "tcp-push-pop"
     server_args: string = "--server {}:12345".format(server_addr)
     client_args: string = "--client {}:12345".format(server_addr)
     return job_test_system_rust(
         test_name, repository, libos, is_debug, server, client, server_args, client_args, is_sudo, True, delay,
-        config_path)
+        config_path, log_directory)
 
 
 def test_pipe_ping_pong(
-        server: string, client: string, is_debug: bool, repository: string, delay: float, config_path: string) -> bool:
+        server: string, client: string, is_debug: bool, repository: string, delay: float, 
+        config_path: string, log_directory: string) -> bool:
     test_name: string = "pipe-ping-pong"
     pipe_name: string = "demikernel-test-pipe-ping-pong"
     server_args: string = "--server demikernel-test-pipe-ping-pong".format(pipe_name)
     client_args: string = "--client demikernel-test-pipe-ping-pong".format(pipe_name)
     return job_test_system_rust(
         test_name, repository, "catmem", is_debug, server, client, server_args, client_args, False, True, delay,
-        config_path)
+        config_path, log_directory)
 
 
 def test_pipe_push_pop(server: string, client: string, is_debug: bool, repository: string, delay: float,
-                       config_path: string) -> bool:
+                       config_path: string, log_directory: string) -> bool:
     test_name: string = "pipe-push-pop"
     pipe_name: string = "demikernel-test-pipe-push-pop"
     server_args: string = "--server demikernel-test-pipe-push-pop".format(pipe_name)
     client_args: string = "--client demikernel-test-pipe-push-pop".format(pipe_name)
     return job_test_system_rust(
         test_name, repository, "catmem", is_debug, server, client, server_args, client_args, False, True, delay,
-        config_path)
+        config_path, log_directory)
 
 # =====================================================================================================================
 
@@ -230,21 +238,32 @@ def run_pipeline(
     step: int = 0
     status: int = 0
 
+    # Create folder for test logs
+    log_directory = "{}-{}-{}".format(libos, branch, "debug" if is_debug else "release")
+    if isdir(log_directory):
+        # Keep the last run
+        old_dir: string = log_directory + ".old"
+        if isdir(old_dir):
+            rmtree(old_dir)
+        move(log_directory, old_dir)
+    mkdir(log_directory)
+
     # STEP 1: Check out.
-    passed = job_checkout(repository, branch, server, client, enable_nfs)
+    passed = job_checkout(repository, branch, server, client, enable_nfs, log_directory)
     status |= (0 if passed else 1) << step
     step += 1
 
     # STEP 2: Compile debug.
     if passed:
-        passed = job_compile(repository, libos, is_debug, server, client, enable_nfs)
+        passed = job_compile(repository, libos, is_debug, server, client, enable_nfs, log_directory)
         status |= (0 if passed else 1) << step
         step += 1
 
     # STEP 3: Run unit tests.
     if test_unit | test_system:
         if passed:
-            passed = job_test_unit_rust(repository, libos, is_debug, server, client, is_sudo, config_path)
+            passed = job_test_unit_rust(repository, libos, is_debug, server, client, 
+            is_sudo, config_path, log_directory)
             status |= (0 if passed else 1) << step
             step += 1
 
@@ -253,31 +272,37 @@ def run_pipeline(
         if passed:
             if libos != "catmem":
                 passed = test_udp_ping_pong(server, client, libos, is_debug, is_sudo,
-                                            repository, server_addr, client_addr, delay, config_path)
+                                            repository, server_addr, client_addr, delay,
+                                            config_path, log_directory)
                 status |= (0 if passed else 1) << step
                 step += 1
                 passed = test_udp_push_pop(server, client, libos, is_debug, is_sudo,
-                                           repository, server_addr, client_addr, delay, config_path)
+                                           repository, server_addr, client_addr, delay, config_path,
+                                           log_directory)
                 status |= (0 if passed else 1) << step
                 step += 1
                 passed = test_tcp_ping_pong(server, client, libos, is_debug, is_sudo,
-                                            repository, server_addr, delay, config_path)
+                                            repository, server_addr, delay, config_path,
+                                            log_directory)
                 status |= (0 if passed else 1) << step
                 step += 1
                 passed = test_tcp_push_pop(server, client, libos, is_debug, is_sudo,
-                                           repository, server_addr, delay, config_path)
+                                           repository, server_addr, delay, config_path,
+                                           log_directory)
                 status |= (0 if passed else 1) << step
                 step += 1
             else:
-                passed = test_pipe_ping_pong(server, server, is_debug, repository, delay, config_path)
+                passed = test_pipe_ping_pong(server, server, is_debug, repository, delay, 
+                                             config_path, log_directory)
                 status |= (0 if passed else 1) << step
                 step += 1
-                passed = test_pipe_push_pop(client, client, is_debug, repository, delay, config_path)
+                passed = test_pipe_push_pop(client, client, is_debug, repository, delay,
+                                            config_path, log_directory)
                 status |= (0 if passed else 1) << step
                 step += 1
 
     # Setp 5: Clean up.
-    passed = job_cleanup(repository, server, client, enable_nfs)
+    passed = job_cleanup(repository, server, client, enable_nfs, log_directory)
     status |= (0 if passed else 1) << step
     step += 1
 


### PR DESCRIPTION
This PR addresses #414. It adds support for creating a separate directory for each run of the demikernel-ci.py script. It keeps one older version from the last run and creates a new directory with the test configuration (libos, branch, compile mode). It then names each of the log files after the test name and whether the host was the server or client and the hostname where it ran. This should make it easier to debug and sort through our testing logs.