### PR TITLE
[tools] Initial Azure Tables support

### DIFF
--- a/doc/testing.md
+++ b/doc/testing.md
@@ -25,7 +25,7 @@ implementation, search for `mod tests` and `cfg(test)` in the code base.
 
 Unit tests may be run in multiple ways:
 
-- [Using the Demikernel's CI tool (ie; `demikernel-ci`)](#running-unit-tests-with-demikernels-ci-tool-ie-demikernel-ci). This is the preferred method.
+- [Using the Demikernel's CI tool (ie; `demikernel_ci`)](#running-unit-tests-with-demikernels-ci-tool-ie-demikernel-ci). This is the preferred method.
 - [Using Demikernel's build system (ie. make)](#running-unit-tests-from-the-shell-ie-bash). This method is strongly discouraged.
 
 > Regardless the method you choose to follow:
@@ -34,7 +34,7 @@ Unit tests may be run in multiple ways:
 information on how to set up Demikernel's development environment, check out instructions in the `README.md` file.
 > - Catnip and Catpowder LibOSes require you to have superuser privileges on the testing machines.
 
-### Running Unit Tests with Demikernel's CI Tool (ie. `demikernel-ci`)
+### Running Unit Tests with Demikernel's CI Tool (ie. `demikernel_ci`)
 
 In order to use this method, you should first do the following setup once:
 
@@ -53,7 +53,7 @@ export DEMIKERNEL_BRANCH=dev
 export LIBOS=catnap
 
 # Run all system tests for the target LIBOS.
-python3 tools/demikernel-ci.py \
+python3 tools/demikernel_ci.py \
     --server $SERVER_HOSTNAME \
     --client $CLIENT_HOSTNAME \
     --repository $DEMIKERNEL_PATH \
@@ -99,7 +99,7 @@ These tests are located in `demikernel/examples/` and detailed in the following 
 
 System-level tests may be run in multiple ways:
 
-- [Using the Demikernel's CI tool (ie. `demikernel-ci`)](#running-system-level-tests-with-demikernels-ci-tool-ie-demikernel-ci). This is the preferred method.
+- [Using the Demikernel's CI tool (ie. `demikernel_ci`)](#running-system-level-tests-with-demikernels-ci-tool-ie-demikernel-ci). This is the preferred method.
 - [Using Demikernel's build system (ie. `make`)](#running-system-level-tests-with-demikernels-build-system-ie-make). This method is discouraged, because you will have to deal by yourself with specific arguments for each test.
 - [Directly from the shell (ie. `bash`)](#running-system-level-tests-from-the-shell-ie-bash). This method is strongly discouraged, because you will have to not only deal with
 specific arguments for each test, but also with intricacies of your shell.
@@ -110,7 +110,7 @@ specific arguments for each test, but also with intricacies of your shell.
 information on how to set up Demikernel's development environment, check out instructions in the `README.md` file.
 > - Catnip and Catpowder LibOSes require you to have superuser privileges on the testing machines.
 
-### Running System-Level Tests with Demikernel's CI Tool (ie. `demikernel-ci`)
+### Running System-Level Tests with Demikernel's CI Tool (ie. `demikernel_ci`)
 
 In order to use this method, you should first do the following setup once:
 
@@ -131,7 +131,7 @@ export DEMIKERNEL_BRANCH=dev
 export LIBOS=catnap
 
 # Run all system-level tests for the target LIBOS.
-python3 tools/demikernel-ci.py \
+python3 tools/demikernel_ci.py \
     --server $SERVER_HOSTNAME \
     --client $CLIENT_HOSTNAME \
     --repository $DEMIKERNEL_PATH \

--- a/scripts/setup/debian.sh
+++ b/scripts/setup/debian.sh
@@ -10,4 +10,6 @@ PACKAGES="librdmacm-dev libmnl-dev build-essential clang libnuma-dev pkg-config 
 apt-get update
 apt-get -y install $PACKAGES
 
-pip3 install pyelftools
+# This dependency is only needed on machines that drive the Azure Tables script
+# for continuous integration 
+pip3 install azure-data-tables

--- a/tools/azure_tables.py
+++ b/tools/azure_tables.py
@@ -1,0 +1,111 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+import sys
+import argparse
+from azure.data.tables import TableServiceClient
+import demikernel_ci
+
+def read_args() ->argparse.Namespace:
+    description: str = ""
+    description += "Use this utility automate regression testing of Demikernel on a pair of remote host machines and report the results to Azure Tables.\n"
+    description += "Before using this utility, ensure that you have correctly setup the development environment on the remote machines and created the Azure table for storing the results.\n"
+    description += "For more information, check out the README.md file of the project."
+
+    # Initialize parser.
+    parser = argparse.ArgumentParser(prog="azure_tables.py", description=description)
+
+    # Host options.
+    parser.add_argument("--server", required=True, help="set server host name")
+    parser.add_argument("--client", required=True, help="set client host name")
+
+    # Build options.
+    parser.add_argument("--repository", required=True, help="set location of target repository in remote hosts")
+    parser.add_argument("--branch", required=False, help="set target branch in remote hosts")
+    parser.add_argument("--libos", required=False, help="set target libos in remote hosts")
+    parser.add_argument("--debug", required=False, action='store_true', help="sets debug build mode")
+    parser.add_argument("--release", required=False, action='store_true', help="sets release build mode")
+    parser.add_argument("--delay", default=1.0, type=float, required=False,
+                        help="set delay between server and host for system-level tests")
+    parser.add_argument("--enable-nfs", required=False, default=False,
+                        action="store_true", help="enable building on nfs directories")
+
+    # Test options.
+    parser.add_argument("--server-addr", required="--test-system" in sys.argv, help="sets server address in tests")
+    parser.add_argument("--client-addr", required="--test-system" in sys.argv, help="sets client address in tests")
+    parser.add_argument("--config-path", required=False, default="\$HOME/config.yaml", help="sets config path")
+    parser.add_argument("--test-unit", action='store_true', required=False, help="run unit tests only")
+    parser.add_argument("--test-system", action='store_true', required=False, help="run unit and system tests")
+    parser.add_argument("--connection-string", required=True, help="connection string to access Azure tables")
+    parser.add_argument("--table-name", required=True, help="Azure table to place results")
+
+    return parser.parse_args()
+
+def main():
+    args: argparse.Namespace = read_args()
+
+    # Extract host options.
+    server: str = args.server
+    client: str = args.client
+
+    # Extract build options.
+    repository: str = args.repository
+    delay: float = args.delay
+    config_path: str = args.config_path
+    enable_nfs: bool = args.enable_nfs
+
+    # Set up list of tests to run.
+    debug_modes: List = []
+    liboses: List = []
+    branches: List = []
+    if args.debug is None and args.release is None:
+        debug_modes = [True, False]
+    else:
+        if args.debug:
+            debug_modes.append(True)
+        if args.release:
+            debug_modes.append(False)
+    
+    if args.libos is None:
+        liboses = ["catnap", "catnip", "catcollar", "catmem", "catpowder"]
+    else:
+        liboses = [args.libos]
+
+    if args.branch is None:
+        branches = ["dev"]
+    else:
+        branches = [args.branch
+]
+    # Extract test options.
+    test_unit: bool = args.test_unit
+    test_system: bool = args.test_system
+    server_addr: str = args.server_addr if test_system else ""
+    client_addr: str = args.client_addr if test_system else ""
+    conn_string: str = args.connection_string
+    table_name: str = args.table_name
+
+    # Connect to Azure Tables.
+    table_service = TableServiceClient.from_connection_string(conn_string)
+    table_client = table_service.get_table_client(table_name)
+
+
+    # Run tests.
+    for is_debug in debug_modes:
+        for libos in liboses:
+            for branch in branches:
+                row_key = libos
+                partition_key = branch + "-{}".format("debug" if is_debug else "release")
+                print("Running test for " + partition_key + " in branch and mode: "+row_key)
+                status = demikernel_ci.run_pipeline(repository, branch, libos, is_debug, server,
+                                                    client, test_unit, test_system, server_addr,
+                                                    client_addr, delay, config_path, enable_nfs)
+                status["PartitionKey"] = partition_key
+                status["RowKey"] = row_key
+                # Clear out the entity for a new clean result
+                table_client.delete_entity(partition_key,row_key)
+                table_client.create_entity(status)
+
+    sys.exit(0)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This change adds support for running a suite of tests and reporting the results in Azure Tables. Summary of changes:
* Add installation of azure-data-tables python package. This is only needed on the machine running the tests, but I thought there was no harm installing it along with other dependencies.
* Demikernel CI python script changed to module. We can now include the CI script functionality in other files, especially the run_pipeline method, which can be used to trigger a specific set of tests. run_pipeline now returns a hashmap of test names and a boolean reflecting whether the test passed, instead of a packed bit string. 
* A new Azure Tables python script. This script takes a similar set of arguments to the CI script but additionally will take an Azure connection string and table name to log the results of the test runs. Unlike the CI script, if no specific test parameters are specified, then all tests will be run. For example, if no libOS is specified, then all libOSes will be tested. If neither release nor debug is specified, then both will be tested.

We may consider later combining this script into the CI script as there is some overlapping code.