### PR TITLE
[pdpix] Remote Address Is Not Set In `demi_accept_result_t`

### DIFF
--- a/src/rust/catcollar/futures/accept.rs
+++ b/src/rust/catcollar/futures/accept.rs
@@ -15,6 +15,7 @@ use crate::{
 use ::std::{
     future::Future,
     mem,
+    net::SocketAddrV4,
     os::unix::prelude::RawFd,
     pin::Pin,
     task::{
@@ -74,7 +75,7 @@ impl AcceptFuture {
 
 /// Future Trait Implementation for Accept Operation Descriptors
 impl Future for AcceptFuture {
-    type Output = Result<RawFd, Fail>;
+    type Output = Result<(RawFd, SocketAddrV4), Fail>;
 
     /// Polls the underlying accept operation.
     fn poll(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Self::Output> {
@@ -107,7 +108,8 @@ impl Future for AcceptFuture {
                     }
                 }
 
-                Poll::Ready(Ok(new_fd))
+                let addr: SocketAddrV4 = linux::sockaddr_in_to_socketaddrv4(&self_.sockaddr);
+                Poll::Ready(Ok((new_fd, addr)))
             },
 
             // Operation not completed, thus parse errno to find out what happened.

--- a/src/rust/catcollar/futures/mod.rs
+++ b/src/rust/catcollar/futures/mod.rs
@@ -71,12 +71,12 @@ impl Operation {
             // Accept operation.
             Operation::Accept(FutureResult {
                 future,
-                done: Some(Ok(new_fd)),
+                done: Some(Ok((new_fd, addr))),
             }) => (
                 future.get_qd(),
                 Some(future.get_new_qd()),
                 Some(new_fd),
-                OperationResult::Accept(future.get_new_qd()),
+                OperationResult::Accept((future.get_new_qd(), addr)),
             ),
             Operation::Accept(FutureResult {
                 future,

--- a/src/rust/catcollar/mod.rs
+++ b/src/rust/catcollar/mod.rs
@@ -398,12 +398,15 @@ fn pack_result(rt: &IoUringRuntime, result: OperationResult, qd: QDesc, qt: u64)
             qr_qt: qt,
             qr_value: unsafe { mem::zeroed() },
         },
-        OperationResult::Accept(new_qd) => {
-            let sin = unsafe { mem::zeroed() };
-            let qr_value = demi_qr_value_t {
+        OperationResult::Accept((new_qd, addr)) => {
+            let saddr: libc::sockaddr = {
+                let sin: libc::sockaddr_in = linux::socketaddrv4_to_sockaddr_in(&addr);
+                unsafe { mem::transmute::<libc::sockaddr_in, libc::sockaddr>(sin) }
+            };
+            let qr_value: demi_qr_value_t = demi_qr_value_t {
                 ares: demi_accept_result_t {
                     qd: new_qd.into(),
-                    addr: sin,
+                    addr: saddr,
                 },
             };
             demi_qresult_t {

--- a/src/rust/catloop/mod.rs
+++ b/src/rust/catloop/mod.rs
@@ -26,6 +26,7 @@ use crate::{
     },
     catmem::CatmemLibOS,
     demi_sgarray_t,
+    pal::linux,
     runtime::{
         fail::Fail,
         queue::IoQueueTable,
@@ -428,12 +429,15 @@ fn pack_result(result: OperationResult, qd: QDesc, qt: u64) -> demi_qresult_t {
             qr_qt: qt,
             qr_value: unsafe { mem::zeroed() },
         },
-        OperationResult::Accept((new_qd, _)) => {
-            let sin = unsafe { mem::zeroed() };
-            let qr_value = demi_qr_value_t {
+        OperationResult::Accept((new_qd, (addr, _))) => {
+            let saddr: libc::sockaddr = {
+                let sin: libc::sockaddr_in = linux::socketaddrv4_to_sockaddr_in(&addr);
+                unsafe { mem::transmute::<libc::sockaddr_in, libc::sockaddr>(sin) }
+            };
+            let qr_value: demi_qr_value_t = demi_qr_value_t {
                 ares: demi_accept_result_t {
                     qd: new_qd.into(),
-                    addr: sin,
+                    addr: saddr,
                 },
             };
             demi_qresult_t {

--- a/src/rust/catnap/futures/accept.rs
+++ b/src/rust/catnap/futures/accept.rs
@@ -15,6 +15,7 @@ use crate::{
 use ::std::{
     future::Future,
     mem,
+    net::SocketAddrV4,
     os::unix::prelude::RawFd,
     pin::Pin,
     task::{
@@ -72,7 +73,7 @@ impl AcceptFuture {
 
 /// Future Trait Implementation for Accept Operation Descriptors
 impl Future for AcceptFuture {
-    type Output = Result<RawFd, Fail>;
+    type Output = Result<(RawFd, SocketAddrV4), Fail>;
 
     /// Polls the target [AcceptFuture].
     fn poll(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Self::Output> {
@@ -105,7 +106,8 @@ impl Future for AcceptFuture {
                     }
                 }
 
-                Poll::Ready(Ok(new_fd))
+                let addr: SocketAddrV4 = linux::sockaddr_in_to_socketaddrv4(&self_.sockaddr);
+                Poll::Ready(Ok((new_fd, addr)))
             },
 
             _ => {

--- a/src/rust/catnap/futures/mod.rs
+++ b/src/rust/catnap/futures/mod.rs
@@ -71,12 +71,12 @@ impl Operation {
             // Accept operation.
             Operation::Accept(FutureResult {
                 future,
-                done: Some(Ok(new_fd)),
+                done: Some(Ok((new_fd, addr))),
             }) => (
                 future.get_qd(),
                 Some(future.get_new_qd()),
                 Some(new_fd),
-                OperationResult::Accept(future.get_new_qd()),
+                OperationResult::Accept((future.get_new_qd(), addr)),
             ),
             Operation::Accept(FutureResult {
                 future,

--- a/src/rust/catnap/mod.rs
+++ b/src/rust/catnap/mod.rs
@@ -383,12 +383,15 @@ fn pack_result(rt: &PosixRuntime, result: OperationResult, qd: QDesc, qt: u64) -
             qr_qt: qt,
             qr_value: unsafe { mem::zeroed() },
         },
-        OperationResult::Accept(new_qd) => {
-            let sin = unsafe { mem::zeroed() };
-            let qr_value = demi_qr_value_t {
+        OperationResult::Accept((new_qd, addr)) => {
+            let saddr: libc::sockaddr = {
+                let sin: libc::sockaddr_in = linux::socketaddrv4_to_sockaddr_in(&addr);
+                unsafe { mem::transmute::<libc::sockaddr_in, libc::sockaddr>(sin) }
+            };
+            let qr_value: demi_qr_value_t = demi_qr_value_t {
                 ares: demi_accept_result_t {
                     qd: new_qd.into(),
-                    addr: sin,
+                    addr: saddr,
                 },
             };
             demi_qresult_t {

--- a/src/rust/catpowder/interop.rs
+++ b/src/rust/catpowder/interop.rs
@@ -29,12 +29,15 @@ pub fn pack_result(rt: Rc<LinuxRuntime>, result: OperationResult, qd: QDesc, qt:
             qr_qt: qt,
             qr_value: unsafe { mem::zeroed() },
         },
-        OperationResult::Accept(new_qd) => {
-            let sin = unsafe { mem::zeroed() };
-            let qr_value = demi_qr_value_t {
+        OperationResult::Accept((new_qd, addr)) => {
+            let saddr: libc::sockaddr = {
+                let sin: libc::sockaddr_in = linux::socketaddrv4_to_sockaddr_in(&addr);
+                unsafe { mem::transmute::<libc::sockaddr_in, libc::sockaddr>(sin) }
+            };
+            let qr_value: demi_qr_value_t = demi_qr_value_t {
                 ares: demi_accept_result_t {
                     qd: new_qd.into(),
-                    addr: sin,
+                    addr: saddr,
                 },
             };
             demi_qresult_t {

--- a/src/rust/inetstack/operations.rs
+++ b/src/rust/inetstack/operations.rs
@@ -21,7 +21,7 @@ use ::std::{
 
 pub enum OperationResult {
     Connect,
-    Accept(QDesc),
+    Accept((QDesc, SocketAddrV4)),
     Push,
     // TODO: Drop wrapping Option.
     Pop(Option<SocketAddrV4>, DemiBuffer),

--- a/src/rust/inetstack/protocols/tcp/operations.rs
+++ b/src/rust/inetstack/protocols/tcp/operations.rs
@@ -18,6 +18,7 @@ use ::std::{
     cell::RefCell,
     fmt,
     future::Future,
+    net::SocketAddrV4,
     pin::Pin,
     rc::Rc,
     task::{
@@ -86,8 +87,8 @@ impl TcpOperation {
             // Accept operation.
             TcpOperation::Accept(FutureResult {
                 future,
-                done: Some(Ok(new_qd)),
-            }) => (future.qd, Some(future.new_qd), OperationResult::Accept(new_qd)),
+                done: Some(Ok((new_qd, addr))),
+            }) => (future.qd, Some(future.new_qd), OperationResult::Accept((new_qd, addr))),
             TcpOperation::Accept(FutureResult {
                 future,
                 done: Some(Err(e)),
@@ -165,7 +166,7 @@ impl fmt::Debug for AcceptFuture {
 
 /// Future Trait Implementation for Accept Operation Descriptors
 impl Future for AcceptFuture {
-    type Output = Result<QDesc, Fail>;
+    type Output = Result<(QDesc, SocketAddrV4), Fail>;
 
     /// Polls the underlying accept operation.
     fn poll(self: Pin<&mut Self>, context: &mut Context) -> Poll<Self::Output> {

--- a/src/rust/inetstack/protocols/tcp/tests/established.rs
+++ b/src/rust/inetstack/protocols/tcp/tests/established.rs
@@ -290,8 +290,9 @@ pub fn test_send_recv_loop() {
         .checked_shl(window_scale as u32)
         .unwrap();
 
-    let (server_fd, client_fd): (QDesc, QDesc) =
+    let ((server_fd, addr), client_fd): ((QDesc, SocketAddrV4), QDesc) =
         connection_setup(&mut ctx, &mut now, &mut server, &mut client, listen_port, listen_addr);
+    assert_eq!(addr.ip(), &test_helpers::ALICE_IPV4);
 
     let bufsize: u32 = 64;
     let buf: DemiBuffer = cook_buffer(bufsize as usize, None);
@@ -330,8 +331,9 @@ pub fn test_send_recv_round_loop() {
         .checked_shl(window_scale as u32)
         .unwrap();
 
-    let (server_fd, client_fd): (QDesc, QDesc) =
+    let ((server_fd, addr), client_fd): ((QDesc, SocketAddrV4), QDesc) =
         connection_setup(&mut ctx, &mut now, &mut server, &mut client, listen_port, listen_addr);
+    assert_eq!(addr.ip(), &test_helpers::ALICE_IPV4);
 
     let bufsize: u32 = 64;
     let buf: DemiBuffer = cook_buffer(bufsize as usize, None);
@@ -373,8 +375,9 @@ pub fn test_send_recv_with_delay() {
         .checked_shl(window_scale as u32)
         .unwrap();
 
-    let (server_fd, client_fd): (QDesc, QDesc) =
+    let ((server_fd, addr), client_fd): ((QDesc, SocketAddrV4), QDesc) =
         connection_setup(&mut ctx, &mut now, &mut server, &mut client, listen_port, listen_addr);
+    assert_eq!(addr.ip(), &test_helpers::ALICE_IPV4);
 
     let bufsize: u32 = 64;
     let buf: DemiBuffer = cook_buffer(bufsize as usize, None);
@@ -438,8 +441,9 @@ fn test_connect_disconnect() {
     let mut server: Engine = test_helpers::new_bob2(now);
     let mut client: Engine = test_helpers::new_alice2(now);
 
-    let (server_fd, client_fd): (QDesc, QDesc) =
+    let ((server_fd, addr), client_fd): ((QDesc, SocketAddrV4), QDesc) =
         connection_setup(&mut ctx, &mut now, &mut server, &mut client, listen_port, listen_addr);
+    assert_eq!(addr.ip(), &test_helpers::ALICE_IPV4);
 
     connection_hangup(&mut ctx, &mut now, &mut server, &mut client, server_fd, client_fd);
 }

--- a/src/rust/inetstack/protocols/tcp/tests/setup.rs
+++ b/src/rust/inetstack/protocols/tcp/tests/setup.rs
@@ -489,7 +489,7 @@ pub fn connection_setup(
     client: &mut Engine,
     listen_port: u16,
     listen_addr: SocketAddrV4,
-) -> (QDesc, QDesc) {
+) -> ((QDesc, SocketAddrV4), QDesc) {
     // Server: LISTEN state at T(0).
     let mut accept_future: AcceptFuture = connection_setup_closed_listen(server, listen_addr);
 
@@ -547,7 +547,7 @@ pub fn connection_setup(
     // Server: ESTABLISHED at T(4).
     connection_setup_sync_rcvd_established(server, bytes);
 
-    let server_fd = match Future::poll(Pin::new(&mut accept_future), ctx) {
+    let (server_fd, addr) = match Future::poll(Pin::new(&mut accept_future), ctx) {
         Poll::Ready(Ok(server_fd)) => Ok(server_fd),
         _ => Err(()),
     }
@@ -558,7 +558,7 @@ pub fn connection_setup(
     }
     .unwrap();
 
-    (server_fd, client_fd)
+    ((server_fd, addr), client_fd)
 }
 
 /// Tests basic 3-way connection setup.
@@ -575,6 +575,6 @@ fn test_good_connect() {
     let mut server = test_helpers::new_bob2(now);
     let mut client = test_helpers::new_alice2(now);
 
-    let (_, _): (QDesc, QDesc) =
+    let ((_, _), _): ((QDesc, SocketAddrV4), QDesc) =
         connection_setup(&mut ctx, &mut now, &mut server, &mut client, listen_port, listen_addr);
 }

--- a/tests/rust/tcp.rs
+++ b/tests/rust/tcp.rs
@@ -126,7 +126,7 @@ fn tcp_establish_connection_unbound() {
         let (_, qr): (QDesc, OperationResult) = safe_wait2(&mut libos, qt);
 
         let qd: QDesc = match qr {
-            OperationResult::Accept(qd) => qd,
+            OperationResult::Accept((qd, addr)) if addr.ip() == &BOB_IPV4 => qd,
             _ => panic!("accept() has failed"),
         };
 
@@ -176,7 +176,7 @@ fn tcp_establish_connection_bound() {
         let (_, qr): (QDesc, OperationResult) = safe_wait2(&mut libos, qt);
 
         let qd: QDesc = match qr {
-            OperationResult::Accept(qd) => qd,
+            OperationResult::Accept((qd, addr)) if addr.ip() == &BOB_IPV4 => qd,
             _ => panic!("accept() has failed"),
         };
 
@@ -232,7 +232,7 @@ fn tcp_push_remote() {
         let qt: QToken = safe_accept(&mut libos, sockqd);
         let (_, qr): (QDesc, OperationResult) = safe_wait2(&mut libos, qt);
         let qd: QDesc = match qr {
-            OperationResult::Accept(qd) => qd,
+            OperationResult::Accept((qd, addr)) if addr.ip() == &BOB_IPV4 => qd,
             _ => panic!("accept() has failed"),
         };
 
@@ -522,7 +522,7 @@ fn tcp_bad_connect() {
         let qt: QToken = safe_accept(&mut libos, sockqd);
         let (_, qr): (QDesc, OperationResult) = safe_wait2(&mut libos, qt);
         let qd: QDesc = match qr {
-            OperationResult::Accept(qd) => qd,
+            OperationResult::Accept((qd, addr)) if addr.ip() == &BOB_IPV4 => qd,
             _ => panic!("accept() has failed"),
         };
 
@@ -594,7 +594,7 @@ fn tcp_bad_close() {
         let qt: QToken = safe_accept(&mut libos, sockqd);
         let (_, qr): (QDesc, OperationResult) = safe_wait2(&mut libos, qt);
         let qd: QDesc = match qr {
-            OperationResult::Accept(qd) => qd,
+            OperationResult::Accept((qd, addr)) if addr.ip() == &BOB_IPV4 => qd,
             _ => panic!("accept() has failed"),
         };
 
@@ -673,7 +673,7 @@ fn tcp_bad_push() {
         let qt: QToken = safe_accept(&mut libos, sockqd);
         let (_, qr): (QDesc, OperationResult) = safe_wait2(&mut libos, qt);
         let qd: QDesc = match qr {
-            OperationResult::Accept(qd) => qd,
+            OperationResult::Accept((qd, addr)) if addr.ip() == &BOB_IPV4 => qd,
             _ => panic!("accept() has failed"),
         };
 
@@ -763,7 +763,7 @@ fn tcp_bad_pop() {
         let qt: QToken = safe_accept(&mut libos, sockqd);
         let (_, qr): (QDesc, OperationResult) = safe_wait2(&mut libos, qt);
         let qd: QDesc = match qr {
-            OperationResult::Accept(qd) => qd,
+            OperationResult::Accept((qd, addr)) if addr.ip() == &BOB_IPV4 => qd,
             _ => panic!("accept() has failed"),
         };
 


### PR DESCRIPTION
## Description

This commit fixes https://github.com/demikernel/demikernel/issues/364

## Summary of Changes

- Changed Futures system in all LibOSes to output the accepted IPv4 address.
- Fixed method for crafting a `demi_accept_result_t` in all LibOses.
- Fixed concerned unit tests.