### PR TITLE
[memory] Marking old APIs as deprecated

### DIFF
--- a/src/rust/runtime/memory/buffer/databuffer.rs
+++ b/src/rust/runtime/memory/buffer/databuffer.rs
@@ -23,6 +23,8 @@ use std::{
 /// Data Buffer
 #[derive(Clone, Debug)]
 pub struct DataBuffer {
+    #[deprecated]
+
     /// Underlying data.
     data: Option<Arc<[u8]>>,
 
@@ -40,6 +42,7 @@ pub struct DataBuffer {
 /// Associated Functions for Data Buffers
 impl DataBuffer {
     /// Removes bytes from the front of the target data buffer.
+    #[deprecated]
     pub fn adjust(&mut self, nbytes: usize) {
         if nbytes > self.len {
             panic!("adjusting past end of buffer: {} vs {}", nbytes, self.len);
@@ -49,6 +52,7 @@ impl DataBuffer {
     }
 
     /// Removes bytes from the end of the target data buffer.
+    #[deprecated]
     pub fn trim(&mut self, nbytes: usize) {
         if nbytes > self.len {
             panic!("trimming past beginning of buffer: {} vs {}", nbytes, self.len);
@@ -57,6 +61,7 @@ impl DataBuffer {
     }
 
     // Creates a data buffer with a given capacity.
+    #[deprecated]
     pub fn new(capacity: usize) -> Result<Self, Fail> {
         // Check if argument is valid.
         if capacity == 0 {
@@ -72,6 +77,7 @@ impl DataBuffer {
     }
 
     /// Creates a data buffer from a raw pointer and a length.
+    #[deprecated]
     pub fn from_raw_parts(data: *mut u8, len: usize) -> Result<Self, Fail> {
         // Check if arguments are valid.
         if len == 0 {
@@ -95,6 +101,7 @@ impl DataBuffer {
     }
 
     /// Consumes the data buffer returning a raw pointer to the underlying buffer and data.
+    #[deprecated]
     pub fn into_raw_parts(dbuf: DataBuffer) -> Result<(*const u8, *const u8), Fail> {
         if let Some(data) = dbuf.data {
             let offset: usize = dbuf.offset;
@@ -107,6 +114,7 @@ impl DataBuffer {
     }
 
     /// Creates an empty buffer.
+    #[deprecated]
     pub fn empty() -> Self {
         Self {
             data: None,
@@ -116,6 +124,7 @@ impl DataBuffer {
     }
 
     /// Creates a data buffer from a slice.
+    #[deprecated]
     pub fn from_slice(src: &[u8]) -> Self {
         src.into()
     }

--- a/src/rust/runtime/memory/buffer/dpdkbuffer.rs
+++ b/src/rust/runtime/memory/buffer/dpdkbuffer.rs
@@ -30,6 +30,7 @@ use ::std::{
 
 /// DPDK-Managed Buffer
 #[derive(Debug)]
+#[deprecated]
 pub struct DPDKBuffer {
     /// Underlying DPDK buffer.
     ptr: *mut rte_mbuf,
@@ -42,6 +43,7 @@ pub struct DPDKBuffer {
 /// Associate Functions for DPDK-Managed Buffers
 impl DPDKBuffer {
     /// Removes `len` bytes at the beginning of the target [Mbuf].
+    #[deprecated]
     pub fn adjust(&mut self, nbytes: usize) {
         assert!(nbytes <= self.len(), "nbytes={:?} self.len()={:?}", nbytes, self.len());
         if unsafe { rte_pktmbuf_adj(self.ptr, nbytes as u16) } == ptr::null_mut() {
@@ -50,6 +52,7 @@ impl DPDKBuffer {
     }
 
     /// Removes `len` bytes at the end of the target [Mbuf].
+    #[deprecated]
     pub fn trim(&mut self, nbytes: usize) {
         assert!(nbytes <= self.len(), "nbytes={:?} self.len()={:?}", nbytes, self.len());
         assert!(nbytes <= self.len());
@@ -59,11 +62,13 @@ impl DPDKBuffer {
     }
 
     /// Creates a [Mbuf].
+    #[deprecated]
     pub fn new(ptr: *mut rte_mbuf) -> Self {
         DPDKBuffer { ptr }
     }
 
     /// Returns a pointer to the data stored in the target [Mbuf].
+    #[deprecated]
     pub fn data_ptr(&self) -> *mut u8 {
         unsafe {
             let buf_ptr = (*self.ptr).buf_addr as *mut u8;
@@ -72,21 +77,25 @@ impl DPDKBuffer {
     }
 
     /// Returns the length of the data stored in the target [Mbuf].
+    #[deprecated]
     pub fn len(&self) -> usize {
         unsafe { (*self.ptr).data_len as usize }
     }
 
     /// Converts the target [Mbuf] into a mutable [u8] slice.
+    #[deprecated]
     pub unsafe fn slice_mut(&mut self) -> &mut [u8] {
         slice::from_raw_parts_mut(self.data_ptr(), self.len())
     }
 
     /// Converts the target [Mbuf] into a raw DPDK buffer.
+    #[deprecated]
     pub fn into_raw(mut self) -> *mut rte_mbuf {
         mem::replace(&mut self.ptr, ptr::null_mut())
     }
 
     /// Returns a pointer to the underlying DPDK buffer stored in the target [Mbuf].
+    #[deprecated]
     pub fn get_ptr(&self) -> *mut rte_mbuf {
         self.ptr
     }
@@ -140,6 +149,7 @@ impl Drop for DPDKBuffer {
 //==============================================================================
 
 /// Releases a mbuf in the target memory pool.
+#[deprecated]
 fn free_mbuf(mbuf_ptr: *mut rte_mbuf) {
     unsafe {
         rte_pktmbuf_free(mbuf_ptr);


### PR DESCRIPTION
This resolves issue #377. The new DemiBuffer abstraction has replaced our older code and the old APIs should no longer be used. This marks the old APIs deprecated so we can move towards deleting them.