### PR TITLE
[runtime] 32-Bit Queue Descriptors

### DIFF
--- a/src/rust/inetstack/protocols/udp/tests.rs
+++ b/src/rust/inetstack/protocols/udp/tests.rs
@@ -431,14 +431,14 @@ fn udp_bind_bad_file_descriptor() {
     let now = Instant::now();
 
     // Setup Alice.
-    let mut alice = test_helpers::new_alice2(now);
-    let alice_port = 80;
-    let alice_addr = SocketAddrV4::new(test_helpers::ALICE_IPV4, alice_port);
-    let alice_fd: QDesc = QDesc::try_from(usize::MAX).unwrap();
+    let mut alice: Engine = test_helpers::new_alice2(now);
+    let alice_port: u16 = 80;
+    let alice_addr: SocketAddrV4 = SocketAddrV4::new(test_helpers::ALICE_IPV4, alice_port);
+    let alice_fd: QDesc = QDesc::try_from(u32::MAX).unwrap();
 
     // Try to bind Alice.
     match alice.udp_bind(alice_fd, alice_addr) {
-        Err(e) if e.errno == EBADF => Ok(()),
+        Err(e) if e.errno == libc::EBADF => Ok(()),
         _ => Err(()),
     }
     .unwrap();
@@ -453,14 +453,14 @@ fn udp_udp_close_bad_file_descriptor() {
     let now = Instant::now();
 
     // Setup Alice.
-    let mut alice = test_helpers::new_alice2(now);
+    let mut alice: Engine = test_helpers::new_alice2(now);
     let alice_fd: QDesc = alice.udp_socket().unwrap();
-    let alice_port = 80;
-    let alice_addr = SocketAddrV4::new(test_helpers::ALICE_IPV4, alice_port);
+    let alice_port: u16 = 80;
+    let alice_addr: SocketAddrV4 = SocketAddrV4::new(test_helpers::ALICE_IPV4, alice_port);
     alice.udp_bind(alice_fd, alice_addr).unwrap();
 
     // Try to udp_close bad file descriptor.
-    match alice.udp_close(QDesc::try_from(usize::MAX).unwrap()) {
+    match alice.udp_close(QDesc::try_from(u32::MAX).unwrap()) {
         Err(e) if e.errno == EBADF => Ok(()),
         _ => Err(()),
     }
@@ -524,22 +524,22 @@ fn udp_push_bad_file_descriptor() {
     let mut now = Instant::now();
 
     // Setup Alice.
-    let mut alice = test_helpers::new_alice2(now);
-    let alice_port = 80;
-    let alice_addr = SocketAddrV4::new(test_helpers::ALICE_IPV4, alice_port);
+    let mut alice: Engine = test_helpers::new_alice2(now);
+    let alice_port: u16 = 80;
+    let alice_addr: SocketAddrV4 = SocketAddrV4::new(test_helpers::ALICE_IPV4, alice_port);
     let alice_fd: QDesc = alice.udp_socket().unwrap();
     alice.udp_bind(alice_fd, alice_addr).unwrap();
 
     // Setup Bob.
-    let mut bob = test_helpers::new_bob2(now);
-    let bob_port = 80;
-    let bob_addr = SocketAddrV4::new(test_helpers::BOB_IPV4, bob_port);
+    let mut bob: Engine = test_helpers::new_bob2(now);
+    let bob_port: u16 = 80;
+    let bob_addr: SocketAddrV4 = SocketAddrV4::new(test_helpers::BOB_IPV4, bob_port);
     let bob_fd: QDesc = bob.udp_socket().unwrap();
     bob.udp_bind(bob_fd, bob_addr).unwrap();
 
     // Send data to Bob.
     let buf: DemiBuffer = DemiBuffer::from_slice(&vec![0x5a; 32][..]).expect("slice should fit in DemiBuffer");
-    match alice.udp_pushto(QDesc::try_from(usize::MAX).unwrap(), buf.clone(), bob_addr) {
+    match alice.udp_pushto(QDesc::try_from(u32::MAX).unwrap(), buf.clone(), bob_addr) {
         Err(e) if e.errno == EBADF => Ok(()),
         _ => Err(()),
     }

--- a/src/rust/runtime/queue/mod.rs
+++ b/src/rust/runtime/queue/mod.rs
@@ -44,7 +44,7 @@ impl IoQueueTable {
     /// When Demikernel is interposing system calls of the underlying OS
     /// this offset enables us to distinguish I/O queue descriptors from
     /// file descriptors.
-    const BASE_QD: usize = 1_000_000;
+    const BASE_QD: u32 = 1_000_000;
 
     /// Creates an I/O queue descriptors table.
     pub fn new() -> Self {
@@ -54,28 +54,36 @@ impl IoQueueTable {
     /// Allocates a new entry in the target I/O queue descriptors table.
     pub fn alloc(&mut self, qtype: u32) -> QDesc {
         let index: usize = self.table.insert(qtype);
-        QDesc::from(index + Self::BASE_QD)
+
+        // Ensure that the allocation would yield to a safe conversion between usize to u32.
+        // Note: This imposes a limit on the number of open queue descriptors in u32::MAX.
+        assert!(
+            (index as u32) + Self::BASE_QD <= u32::MAX,
+            "I/O descriptors table overflow"
+        );
+
+        QDesc::from((index as u32) + Self::BASE_QD)
     }
 
     /// Gets the entry associated with an I/O queue descriptor.
     pub fn get(&self, qd: QDesc) -> Option<u32> {
-        let index: usize = self.get_index(qd)? as usize;
-        self.table.get(index).cloned()
+        let index: u32 = self.get_index(qd)?;
+        self.table.get(index as usize).cloned()
     }
 
     /// Releases the entry associated with an I/O queue descriptor.
     pub fn free(&mut self, qd: QDesc) -> Option<u32> {
-        let index: usize = self.get_index(qd)?;
-        Some(self.table.remove(index))
+        let index: u32 = self.get_index(qd)?;
+        Some(self.table.remove(index as usize))
     }
 
     /// Gets the index in the I/O queue descriptors table to which a given I/O queue descriptor refers to.
-    fn get_index(&self, qd: QDesc) -> Option<usize> {
-        if Into::<usize>::into(qd) < Self::BASE_QD {
+    fn get_index(&self, qd: QDesc) -> Option<u32> {
+        if Into::<u32>::into(qd) < Self::BASE_QD {
             None
         } else {
-            let rawqd: usize = Into::<usize>::into(qd) - Self::BASE_QD;
-            if !self.table.contains(rawqd) {
+            let rawqd: u32 = Into::<u32>::into(qd) - Self::BASE_QD;
+            if !self.table.contains(rawqd as usize) {
                 return None;
             }
             Some(rawqd)

--- a/src/rust/runtime/queue/qdesc.rs
+++ b/src/rust/runtime/queue/qdesc.rs
@@ -7,7 +7,7 @@
 
 /// IO Queue Descriptor
 #[derive(Debug, Eq, PartialEq, Hash, Copy, Clone)]
-pub struct QDesc(usize);
+pub struct QDesc(u32);
 
 //==============================================================================
 // Trait Implementations
@@ -23,20 +23,20 @@ impl From<QDesc> for i32 {
 impl From<i32> for QDesc {
     /// Converts a [i32] to a [QDesc].
     fn from(val: i32) -> Self {
-        QDesc(val as usize)
+        QDesc(val as u32)
     }
 }
 
-impl From<QDesc> for usize {
-    /// Converts a [QDesc] to a [usize].
+impl From<QDesc> for u32 {
+    /// Converts a [QDesc] to a [u32].
     fn from(val: QDesc) -> Self {
         val.0
     }
 }
 
-impl From<usize> for QDesc {
-    /// Converts a [usize] to a [QDesc].
-    fn from(val: usize) -> Self {
+impl From<u32> for QDesc {
+    /// Converts a [u32] to a [QDesc].
+    fn from(val: u32) -> Self {
         QDesc(val)
     }
 }


### PR DESCRIPTION
## Description

This PR closes https://github.com/demikernel/demikernel/issues/430.

## Summary of Changes

- Changed `QDesc` to use a `u32` type representation for queue descriptors.
- Fixed `IoQueueTable` accordingly.
- Fixed concerned unit tests.