### PR TITLE
[build] Copy `default.yaml` When Installing Artifacts

### DIFF
--- a/linux.mk
+++ b/linux.mk
@@ -81,6 +81,7 @@ install:
 	mkdir -p $(INSTALL_PREFIX)/include $(INSTALL_PREFIX)/lib
 	cp -rf $(INCDIR)/* $(INSTALL_PREFIX)/include/
 	cp -f  $(DEMIKERNEL_LIB) $(INSTALL_PREFIX)/lib/
+	cp -f $(CURDIR)/scripts/config/default.yaml $(INSTALL_PREFIX)/config.yaml
 
 #=======================================================================================================================
 # Libs


### PR DESCRIPTION
## Description

This PR closes https://github.com/demikernel/demikernel/issues/451

## Summary of Changes

- Changed `install` rule to copy `default.yaml` when install artifacts as well.