### PR TITLE
[build] Reenable MaybeUnit Feature for Windows

### DIFF
--- a/src/rust/lib.rs
+++ b/src/rust/lib.rs
@@ -11,6 +11,7 @@
 #![feature(allocator_api)]
 #![feature(slice_ptr_get)]
 #![feature(strict_provenance)]
+#![cfg_attr(target_os = "windows", feature(maybe_uninit_uninit_array))]
 
 mod collections;
 mod pal;


### PR DESCRIPTION
## Description

- This PR is related to https://github.com/demikernel/demikernel/issues/172

## Summary of Changes

- Reneabled `maybe_uninit_uninit_array` in Windows.