### PR TITLE
[ipv4] Removed extraneous Parenthesis to Avoid Compiler Warning

### DIFF
--- a/src/rust/inetstack/protocols/ipv4/datagram.rs
+++ b/src/rust/inetstack/protocols/ipv4/datagram.rs
@@ -256,7 +256,9 @@ impl Ipv4Header {
 
     /// Serializes the target IPv4 header.
     pub fn serialize(&self, buf: &mut [u8], payload_len: usize) {
-        let buf: &mut [u8; (IPV4_HEADER_MIN_SIZE as usize)] = buf.try_into().expect("buffer to small");
+        let buf: &mut [u8; IPV4_HEADER_MIN_SIZE as usize] = buf
+            .try_into()
+            .expect("buffer should be large enough to hold an IPv4 header");
 
         // Version + IHL.
         buf[0] = (self.version << 4) | self.ihl;


### PR DESCRIPTION
This PR removes some unnecessary parentheses that were causing a compiler warning.
