### PR TITLE
[doc] Updating Build Instructions and Manual Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 [![Catmem LibOS](https://github.com/demikernel/demikernel/actions/workflows/catmem.yml/badge.svg)](https://github.com/demikernel/demikernel/actions/workflows/catmem.yml)
 [![Catpowder LibOS](https://github.com/demikernel/demikernel/actions/workflows/catpowder.yml/badge.svg)](https://github.com/demikernel/demikernel/actions/workflows/catpowder.yml)
 [![Catcollar LibOS](https://github.com/demikernel/demikernel/actions/workflows/catcollar.yml/badge.svg)](https://github.com/demikernel/demikernel/actions/workflows/catcollar.yml)
+[![Catloop LibOS](https://github.com/demikernel/demikernel/actions/workflows/catloop.yml/badge.svg)](https://github.com/demikernel/demikernel/actions/workflows/catloop.yml)
+[![Catnapw LibOS](https://github.com/demikernel/demikernel/actions/workflows/catnapw.yml/badge.svg)](https://github.com/demikernel/demikernel/actions/workflows/catnapw.yml)
 
 _Demikernel_ is a library operating system (LibOS) architecture designed for use
 with kernel-bypass I/O devices. This architecture offers a uniform system call

--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ To get details about the system, read our paper in [SOSP '21](https://doi.org/10
 
 > To read more about Demikernel check out <https://aka.ms/demikernel>.
 
+## Codename for LibOSes
+
+- `catcollar` -- I/O Uring LibOS
+- `catloop` -- TCP Socket Loopback LibOS
+- `catmem` -- Shared Memory LibOS
+- `catnap` -- Linux Sockets LibOS
+- `catnip` -- DPDK LibOS
+- `catpowder` -- Linux Raw Sockets
+- `catnapw` -- Windows Sockets LibOS
+
 ## Documentation
 
 - For instructions on development environment setup, see [doc/setup.md](./doc/setup.md).

--- a/doc/building.md
+++ b/doc/building.md
@@ -36,7 +36,7 @@ make LIBOS=catloop
 # Build Demikernel with Shared Memory LibOS.
 make LIBOS=catmem
 
-# Build Demikernel with Sockets LibOS.
+# Build Demikernel with Linux Sockets LibOS.
 make LIBOS=catnap
 
 # Build Demikernel with DPDK LibOS.

--- a/doc/building.md
+++ b/doc/building.md
@@ -30,6 +30,9 @@ make
 # Build Demikernel with I/O Uring LibOS.
 make LIBOS=catcollar
 
+# Build Demikernel with TCP Socket Loopback LibOS.
+make LIBOS=catloop
+
 # Build Demikernel with Shared Memory LibOS.
 make LIBOS=catmem
 

--- a/man/demi_init.md
+++ b/man/demi_init.md
@@ -26,15 +26,15 @@ turned on.
 
 All arguments supported by Demikernel are listed in the table bellow. Arguments that are not listed therein are ignored.
 
-| ID      | Argument      | Description             | Supported OS |
-| ------- | ------------- | ----------------------- | ------------ |
-| `ARG-1` | `--catcollar` | Enables Catcollar LibOS | Linux        |
-| `ARG-2` | `--catloop`   | Enables Catloop LibOS   | Linux        |
-| `ARG-3` | `--catmem`    | Enables Catmem LibOS    | Linux        |
-| `ARG-4` | `--catnap`    | Enables Catnap LibOS    | Linux        |
-| `ARG-5` | `--catnip`    | Enables Catnip LibOS    | Linux        |
-| `ARG-6` | `--catpowder` | Enables Catpowder LibOS | Linux        |
-| `ARG-7` | `--catnapw`   | Enables Catnap LibOS    | Windows      |
+| ID      | Argument      | Description                       | Supported OS |
+| ------- | ------------- | --------------------------------- | ------------ |
+| `ARG-1` | `--catcollar` | Enables I/O Uring LibOS           | Linux        |
+| `ARG-2` | `--catloop`   | Enables TCP Socket Loopback LibOS | Linux        |
+| `ARG-3` | `--catmem`    | Enables Shared Memory LibOS       | Linux        |
+| `ARG-4` | `--catnap`    | Enables Linux Sockets LibOS       | Linux        |
+| `ARG-5` | `--catnip`    | Enables DPDK LibOS                | Linux        |
+| `ARG-6` | `--catpowder` | Enables Linux Raw Sockets LibOS   | Linux        |
+| `ARG-7` | `--catnapw`   | Enables Windows Sockets LibOS     | Windows      |
 
 These arguments are mutually exclusive. Demikernel currently does not support multiple LibOSes to co-exist.
 [Issue #158](https://github.com/demikernel/demikernel/issues/158) tracks progress of this feature.

--- a/man/demi_init.md
+++ b/man/demi_init.md
@@ -29,18 +29,20 @@ All arguments supported by Demikernel are listed in the table bellow. Arguments 
 |ID       | Argument      | Description             |
 |---------|---------------|-------------------------|
 | `ARG-1` | `--catcollar` | Enables Catcollar LibOS |
-| `ARG-2` | `--catnap`    | Enables Catnap LibOS    |
-| `ARG-3` | `--catnip`    | Enables Catnip LibOS    |
-| `ARG-4` | `--catpowder` | Enables Catpowder LibOS |
-| `ARG-5` | `--catmem`    | Enables Catmem LibOS    |
+| `ARG-2` | `--catloop`   | Enables Catloop LibOS   |
+| `ARG-3` | `--catnap`    | Enables Catnap LibOS    |
+| `ARG-4` | `--catnip`    | Enables Catnip LibOS    |
+| `ARG-5` | `--catpowder` | Enables Catpowder LibOS |
+| `ARG-6` | `--catmem`    | Enables Catmem LibOS    |
 
  Any constraints/restrictions of arguments are detailed next:
 
 - `ARG-1` takes effect only on Linux hosts. If one is attempts to initialize Catcollar on a non-Linux host and `ARG-1`
 is the only parameter passed to Demikernel, `demi_init()` will fail.
 
-- `ARG-1`, `ARG-2`, `ARG-3`, `ARG-4` and `ARG-5` are mutually exclusive. Demikernel currently does not support multiple
-LibOSes to co-exist. [Issue #158](https://github.com/demikernel/demikernel/issues/158) tracks progress of this feature.
+- `ARG-1`, `ARG-2`, `ARG-3`, `ARG-4`, `ARG-5` and `ARG-6` are mutually exclusive. Demikernel currently does not support
+multiple LibOSes to co-exist. [Issue #158](https://github.com/demikernel/demikernel/issues/158) tracks progress of this
+feature.
 
 ## Return Value
 

--- a/man/demi_init.md
+++ b/man/demi_init.md
@@ -26,8 +26,8 @@ turned on.
 
 All arguments supported by Demikernel are listed in the table bellow. Arguments that are not listed therein are ignored.
 
-|ID       | Argument      | Description             |
-|---------|---------------|-------------------------|
+| ID      | Argument      | Description             |
+| ------- | ------------- | ----------------------- |
 | `ARG-1` | `--catcollar` | Enables Catcollar LibOS |
 | `ARG-2` | `--catloop`   | Enables Catloop LibOS   |
 | `ARG-3` | `--catnap`    | Enables Catnap LibOS    |

--- a/man/demi_init.md
+++ b/man/demi_init.md
@@ -34,10 +34,10 @@ All arguments supported by Demikernel are listed in the table bellow. Arguments 
 | `ARG-4` | `--catnap`    | Enables Catnap LibOS    | Linux        |
 | `ARG-5` | `--catnip`    | Enables Catnip LibOS    | Linux        |
 | `ARG-6` | `--catpowder` | Enables Catpowder LibOS | Linux        |
+| `ARG-7` | `--catnapw`   | Enables Catnap LibOS    | Windows      |
 
-`ARG-1`, `ARG-2`, `ARG-3`, `ARG-4`, `ARG-5` and `ARG-6` are mutually exclusive. Demikernel currently does not support
-multiple LibOSes to co-exist. [Issue #158](https://github.com/demikernel/demikernel/issues/158) tracks progress of this
-feature.
+These arguments are mutually exclusive. Demikernel currently does not support multiple LibOSes to co-exist.
+[Issue #158](https://github.com/demikernel/demikernel/issues/158) tracks progress of this feature.
 
 ## Return Value
 

--- a/man/demi_init.md
+++ b/man/demi_init.md
@@ -26,21 +26,16 @@ turned on.
 
 All arguments supported by Demikernel are listed in the table bellow. Arguments that are not listed therein are ignored.
 
-| ID      | Argument      | Description             |
-| ------- | ------------- | ----------------------- |
-| `ARG-1` | `--catcollar` | Enables Catcollar LibOS |
-| `ARG-2` | `--catloop`   | Enables Catloop LibOS   |
-| `ARG-3` | `--catnap`    | Enables Catnap LibOS    |
-| `ARG-4` | `--catnip`    | Enables Catnip LibOS    |
-| `ARG-5` | `--catpowder` | Enables Catpowder LibOS |
-| `ARG-6` | `--catmem`    | Enables Catmem LibOS    |
+| ID      | Argument      | Description             | Supported OS |
+| ------- | ------------- | ----------------------- | ------------ |
+| `ARG-1` | `--catcollar` | Enables Catcollar LibOS | Linux        |
+| `ARG-2` | `--catloop`   | Enables Catloop LibOS   | Linux        |
+| `ARG-3` | `--catmem`    | Enables Catmem LibOS    | Linux        |
+| `ARG-4` | `--catnap`    | Enables Catnap LibOS    | Linux        |
+| `ARG-5` | `--catnip`    | Enables Catnip LibOS    | Linux        |
+| `ARG-6` | `--catpowder` | Enables Catpowder LibOS | Linux        |
 
- Any constraints/restrictions of arguments are detailed next:
-
-- `ARG-1` takes effect only on Linux hosts. If one is attempts to initialize Catcollar on a non-Linux host and `ARG-1`
-is the only parameter passed to Demikernel, `demi_init()` will fail.
-
-- `ARG-1`, `ARG-2`, `ARG-3`, `ARG-4`, `ARG-5` and `ARG-6` are mutually exclusive. Demikernel currently does not support
+`ARG-1`, `ARG-2`, `ARG-3`, `ARG-4`, `ARG-5` and `ARG-6` are mutually exclusive. Demikernel currently does not support
 multiple LibOSes to co-exist. [Issue #158](https://github.com/demikernel/demikernel/issues/158) tracks progress of this
 feature.
 


### PR DESCRIPTION
## Description

- This PR closes https://github.com/demikernel/demikernel/issues/455

## Summary of Changes

- Updated documentation to include `Catloop` and `Catnapw`.
- Added information on LibOS codenames.