### PR TITLE
[runtime] Unify Queue Table Abstraction

### DIFF
--- a/src/rust/catcollar/queue.rs
+++ b/src/rust/catcollar/queue.rs
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//======================================================================================================================
+// Imports
+//======================================================================================================================
+
+use crate::runtime::{
+    queue::IoQueue,
+    QType,
+};
+use ::std::os::unix::prelude::RawFd;
+
+//======================================================================================================================
+// Structures
+//======================================================================================================================
+
+/// Catcollar control block: meta data stored per queue.
+#[derive(Copy, Clone)]
+pub struct CatcollarQueue {
+    qtype: QType,
+    fd: Option<RawFd>,
+}
+
+//======================================================================================================================
+// Associated Functions
+//======================================================================================================================
+
+impl CatcollarQueue {
+    /// Creates a new metadata structure for a queue.
+    pub fn new(qtype: QType) -> Self {
+        Self { qtype: qtype, fd: None }
+    }
+
+    /// Get the underlying Linux raw socket.
+    pub fn get_fd(&self) -> Option<RawFd> {
+        self.fd
+    }
+
+    /// Set the underlying Linux raw socket.
+    pub fn set_fd(&mut self, fd: RawFd) {
+        self.fd = Some(fd);
+    }
+}
+
+//======================================================================================================================
+// Trait implementation
+//======================================================================================================================
+
+impl IoQueue for CatcollarQueue {
+    fn get_qtype(&self) -> QType {
+        self.qtype
+    }
+}

--- a/src/rust/catloop/queue.rs
+++ b/src/rust/catloop/queue.rs
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//======================================================================================================================
+// Imports
+//======================================================================================================================
+
+use super::{
+    duplex_pipe::DuplexPipe,
+    Socket,
+};
+use crate::runtime::{
+    queue::IoQueue,
+    QType,
+};
+use ::std::rc::Rc;
+
+//======================================================================================================================
+// Structures
+//======================================================================================================================
+
+/// Per-queue meta-data: address and pipe for data transfer
+pub struct CatloopQueue {
+    qtype: QType,
+    socket: Socket,
+    pipe: Option<Rc<DuplexPipe>>,
+}
+
+//======================================================================================================================
+// Associated Functions
+//======================================================================================================================
+
+impl CatloopQueue {
+    pub fn new(qtype: QType) -> Self {
+        Self {
+            qtype: qtype,
+            socket: Socket::Active(None),
+            pipe: None,
+        }
+    }
+
+    /// Get socket type and address associated with this queue.
+    pub fn get_socket(&self) -> Socket {
+        self.socket
+    }
+
+    /// Set socket type and address for this queue.
+    pub fn set_socket(&mut self, socket: Socket) {
+        self.socket = socket;
+    }
+
+    /// Get underlying bi-directional pipe.
+    pub fn get_pipe(&self) -> Option<Rc<DuplexPipe>> {
+        match &self.pipe {
+            Some(pipe) => Some(pipe.clone()),
+            None => None,
+        }
+    }
+
+    /// Set underlying bi-directional pipe.
+    pub fn set_pipe(&mut self, pipe: Rc<DuplexPipe>) {
+        self.pipe = Some(pipe.clone());
+    }
+}
+
+//======================================================================================================================
+// Trait implementation
+//======================================================================================================================
+
+impl IoQueue for CatloopQueue {
+    fn get_qtype(&self) -> QType {
+        self.qtype
+    }
+}

--- a/src/rust/catmem/queue.rs
+++ b/src/rust/catmem/queue.rs
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//======================================================================================================================
+// Imports
+//======================================================================================================================
+
+use super::pipe::Pipe;
+use crate::{
+    collections::shared_ring::SharedRingBuffer,
+    runtime::{
+        queue::IoQueue,
+        QType,
+    },
+};
+
+//======================================================================================================================
+// Structures
+//======================================================================================================================
+
+/// Per-queue metadata: reference to the shared pipe.
+pub struct CatmemQueue {
+    pipe: Pipe,
+}
+
+//======================================================================================================================
+// Associated Functions
+//======================================================================================================================
+
+impl CatmemQueue {
+    pub fn new(ring: SharedRingBuffer<u16>) -> Self {
+        Self { pipe: Pipe::new(ring) }
+    }
+
+    /// Get underlying uni-directional pipe.
+    pub fn get_pipe(&self) -> &Pipe {
+        &self.pipe
+    }
+
+    /// Set underlying uni-directional pipe.
+    pub fn get_mut_pipe(&mut self) -> &mut Pipe {
+        &mut self.pipe
+    }
+}
+
+//======================================================================================================================
+// Trait implementation
+//======================================================================================================================
+
+impl IoQueue for CatmemQueue {
+    fn get_qtype(&self) -> QType {
+        QType::MemoryQueue
+    }
+}

--- a/src/rust/catnap/queue.rs
+++ b/src/rust/catnap/queue.rs
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//======================================================================================================================
+// Imports
+//======================================================================================================================
+
+use crate::runtime::{
+    queue::IoQueue,
+    QType,
+};
+use ::std::os::unix::prelude::RawFd;
+
+//======================================================================================================================
+// Structures
+//======================================================================================================================
+
+/// Per-queue metadata: Catnap control block
+pub struct CatnapQueue {
+    qtype: QType,
+    fd: Option<RawFd>,
+}
+
+//======================================================================================================================
+// Associated Functions
+//======================================================================================================================
+
+impl CatnapQueue {
+    pub fn new(qtype: QType, fd: Option<RawFd>) -> Self {
+        Self { qtype, fd }
+    }
+
+    /// Get underlying POSIX file descriptor.
+    pub fn get_fd(&self) -> Option<RawFd> {
+        self.fd
+    }
+
+    /// Set underlying POSIX file descriptor.
+    pub fn set_fd(&mut self, fd: RawFd) {
+        self.fd = Some(fd);
+    }
+}
+
+//======================================================================================================================
+// Trait implementation
+//======================================================================================================================
+
+impl IoQueue for CatnapQueue {
+    fn get_qtype(&self) -> QType {
+        self.qtype
+    }
+}

--- a/src/rust/inetstack/protocols/mod.rs
+++ b/src/rust/inetstack/protocols/mod.rs
@@ -7,6 +7,7 @@ pub mod icmpv4;
 pub mod ip;
 pub mod ipv4;
 mod peer;
+pub mod queue;
 pub mod tcp;
 pub mod udp;
 

--- a/src/rust/inetstack/protocols/peer.rs
+++ b/src/rust/inetstack/protocols/peer.rs
@@ -7,6 +7,7 @@ use crate::{
         icmpv4::Icmpv4Peer,
         ip::IpProtocol,
         ipv4::Ipv4Header,
+        queue::InetQueue,
         tcp::TcpPeer,
         udp::UdpPeer,
     },
@@ -21,12 +22,14 @@ use crate::{
             types::MacAddress,
             NetworkRuntime,
         },
+        queue::IoQueueTable,
         timer::TimerRc,
     },
     scheduler::scheduler::Scheduler,
 };
 use ::libc::ENOTCONN;
 use ::std::{
+    cell::RefCell,
     future::Future,
     net::Ipv4Addr,
     rc::Rc,
@@ -47,6 +50,7 @@ impl Peer {
     pub fn new(
         rt: Rc<dyn NetworkRuntime>,
         scheduler: Scheduler,
+        qtable: Rc<RefCell<IoQueueTable<InetQueue>>>,
         clock: TimerRc,
         local_link_addr: MacAddress,
         local_ipv4_addr: Ipv4Addr,
@@ -59,6 +63,7 @@ impl Peer {
         let udp: UdpPeer = UdpPeer::new(
             rt.clone(),
             scheduler.clone(),
+            qtable.clone(),
             rng_seed,
             local_link_addr,
             local_ipv4_addr,
@@ -77,6 +82,7 @@ impl Peer {
         let tcp: TcpPeer = TcpPeer::new(
             rt.clone(),
             scheduler.clone(),
+            qtable.clone(),
             clock.clone(),
             local_link_addr,
             local_ipv4_addr,

--- a/src/rust/inetstack/protocols/queue.rs
+++ b/src/rust/inetstack/protocols/queue.rs
@@ -1,0 +1,23 @@
+use super::{
+    tcp::queue::TcpQueue,
+    udp::queue::UdpQueue,
+};
+use crate::runtime::queue::{
+    IoQueue,
+    QType,
+};
+
+/// Per-queue metadata: Inet stack Control Block
+pub enum InetQueue {
+    Udp(UdpQueue),
+    Tcp(TcpQueue),
+}
+
+impl IoQueue for InetQueue {
+    fn get_qtype(&self) -> QType {
+        match self {
+            Self::Udp(_) => QType::UdpSocket,
+            Self::Tcp(_) => QType::TcpSocket,
+        }
+    }
+}

--- a/src/rust/inetstack/protocols/tcp/active_open.rs
+++ b/src/rust/inetstack/protocols/tcp/active_open.rs
@@ -317,4 +317,9 @@ impl ActiveOpenSocket {
             r.result.replace(Err(Fail::new(ETIMEDOUT, "handshake timeout")));
         }
     }
+
+    /// Returns the addresses of the two ends of this connection.
+    pub fn endpoints(&self) -> (SocketAddrV4, SocketAddrV4) {
+        (self.local, self.remote)
+    }
 }

--- a/src/rust/inetstack/protocols/tcp/mod.rs
+++ b/src/rust/inetstack/protocols/tcp/mod.rs
@@ -8,6 +8,7 @@ mod isn_generator;
 pub mod operations;
 mod passive_open;
 pub mod peer;
+pub mod queue;
 pub mod segment;
 mod sequence_number;
 

--- a/src/rust/inetstack/protocols/tcp/passive_open.rs
+++ b/src/rust/inetstack/protocols/tcp/passive_open.rs
@@ -171,6 +171,11 @@ impl PassiveSocket {
         }
     }
 
+    /// Returns the address that the socket is bound to.
+    pub fn endpoint(&self) -> SocketAddrV4 {
+        self.local
+    }
+
     pub fn poll_accept(&mut self, ctx: &mut Context) -> Poll<Result<ControlBlock, Fail>> {
         self.ready.borrow_mut().poll(ctx)
     }

--- a/src/rust/inetstack/protocols/tcp/queue.rs
+++ b/src/rust/inetstack/protocols/tcp/queue.rs
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//======================================================================================================================
+// Imports
+//======================================================================================================================
+
+use super::peer::Socket;
+use crate::runtime::{
+    queue::IoQueue,
+    QType,
+};
+
+//======================================================================================================================
+// Structures
+//======================================================================================================================
+
+/// Per-queue metadata for the TCP socket.
+pub struct TcpQueue {
+    socket: Socket,
+}
+
+//======================================================================================================================
+// Associated Functions
+//======================================================================================================================
+
+impl TcpQueue {
+    pub fn new() -> Self {
+        Self {
+            socket: Socket::Inactive(None),
+        }
+    }
+
+    /// Get/borrow reference to underlying TCP socket data structure.
+    pub fn get_socket(&self) -> &Socket {
+        &self.socket
+    }
+
+    /// Get/borrow mutable reference to underlying TCP socket data structure.
+    pub fn get_mut_socket(&mut self) -> &mut Socket {
+        &mut self.socket
+    }
+
+    /// Set underlying TCP socket data structure.
+    pub fn set_socket(&mut self, s: Socket) {
+        self.socket = s;
+    }
+}
+
+//======================================================================================================================
+// Trait implementation
+//======================================================================================================================
+
+impl IoQueue for TcpQueue {
+    fn get_qtype(&self) -> QType {
+        QType::TcpSocket
+    }
+}

--- a/src/rust/inetstack/protocols/udp/mod.rs
+++ b/src/rust/inetstack/protocols/udp/mod.rs
@@ -9,8 +9,8 @@
 
 mod datagram;
 mod futures;
-mod peer;
-mod queue;
+pub mod peer;
+pub mod queue;
 
 #[cfg(test)]
 mod tests;

--- a/src/rust/runtime/queue/mod.rs
+++ b/src/rust/runtime/queue/mod.rs
@@ -27,10 +27,13 @@ pub use self::{
 // Structures
 //======================================================================================================================
 
+pub trait IoQueue {
+    fn get_qtype(&self) -> QType;
+}
+
 /// I/O queue descriptors table.
-pub struct IoQueueTable {
-    // TODO: Store a QType in the slab.
-    table: Slab<u32>,
+pub struct IoQueueTable<T: IoQueue> {
+    table: Slab<T>,
 }
 
 //======================================================================================================================
@@ -38,7 +41,7 @@ pub struct IoQueueTable {
 //======================================================================================================================
 
 /// Associated functions for I/O queue descriptors tables.
-impl IoQueueTable {
+impl<T: IoQueue> IoQueueTable<T> {
     /// Offset for I/O queue descriptors.
     ///
     /// When Demikernel is interposing system calls of the underlying OS
@@ -50,12 +53,14 @@ impl IoQueueTable {
 
     /// Creates an I/O queue descriptors table.
     pub fn new() -> Self {
-        Self { table: Slab::new() }
+        Self {
+            table: Slab::<T>::new(),
+        }
     }
 
     /// Allocates a new entry in the target I/O queue descriptors table.
-    pub fn alloc(&mut self, qtype: u32) -> QDesc {
-        let index: usize = self.table.insert(qtype);
+    pub fn alloc(&mut self, queue: T) -> QDesc {
+        let index: usize = self.table.insert(queue);
 
         // Ensure that the allocation would yield to a safe conversion between usize to u32.
         // Note: This imposes a limit on the number of open queue descriptors in u32::MAX.
@@ -67,24 +72,30 @@ impl IoQueueTable {
         QDesc::from((index as u32) + Self::BASE_QD)
     }
 
-    /// Gets the entry associated with an I/O queue descriptor.
-    pub fn get(&self, qd: QDesc) -> Option<u32> {
+    /// Gets/borrows a reference to the queue metadata associated with an I/O queue descriptor.
+    pub fn get(&self, qd: &QDesc) -> Option<&T> {
         let index: u32 = self.get_index(qd)?;
-        self.table.get(index as usize).cloned()
+        self.table.get(index as usize)
+    }
+
+    /// Gets/borrows a mutable reference to the queue metadata associated with an I/O queue descriptor
+    pub fn get_mut(&mut self, qd: &QDesc) -> Option<&mut T> {
+        let index: u32 = self.get_index(qd)?;
+        self.table.get_mut(index as usize)
     }
 
     /// Releases the entry associated with an I/O queue descriptor.
-    pub fn free(&mut self, qd: QDesc) -> Option<u32> {
+    pub fn free(&mut self, qd: &QDesc) -> Option<T> {
         let index: u32 = self.get_index(qd)?;
         Some(self.table.remove(index as usize))
     }
 
     /// Gets the index in the I/O queue descriptors table to which a given I/O queue descriptor refers to.
-    fn get_index(&self, qd: QDesc) -> Option<u32> {
-        if Into::<u32>::into(qd) < Self::BASE_QD {
+    fn get_index(&self, qd: &QDesc) -> Option<u32> {
+        if Into::<u32>::into(*qd) < Self::BASE_QD {
             None
         } else {
-            let rawqd: u32 = Into::<u32>::into(qd) - Self::BASE_QD;
+            let rawqd: u32 = Into::<u32>::into(*qd) - Self::BASE_QD;
             if !self.table.contains(rawqd as usize) {
                 return None;
             }
@@ -99,7 +110,10 @@ impl IoQueueTable {
 
 #[cfg(test)]
 mod tests {
-    use super::IoQueueTable;
+    use super::{
+        IoQueue,
+        IoQueueTable,
+    };
     use crate::{
         QDesc,
         QType,
@@ -109,14 +123,22 @@ mod tests {
         Bencher,
     };
 
+    pub struct TestQueue {}
+
+    impl IoQueue for TestQueue {
+        fn get_qtype(&self) -> QType {
+            QType::TestQueue
+        }
+    }
+
     #[bench]
     fn bench_alloc_free(b: &mut Bencher) {
-        let mut ioqueue_table: IoQueueTable = IoQueueTable::new();
+        let mut ioqueue_table: IoQueueTable<TestQueue> = IoQueueTable::<TestQueue>::new();
 
         b.iter(|| {
-            let qd: QDesc = ioqueue_table.alloc(QType::TcpSocket.into());
+            let qd: QDesc = ioqueue_table.alloc(TestQueue {});
             black_box(qd);
-            let qtype: Option<u32> = ioqueue_table.free(qd);
+            let qtype: Option<TestQueue> = ioqueue_table.free(&qd);
             black_box(qtype);
         });
     }

--- a/src/rust/runtime/queue/qtype.rs
+++ b/src/rust/runtime/queue/qtype.rs
@@ -14,6 +14,7 @@ pub enum QType {
     UdpSocket = 0x0001,
     TcpSocket = 0x0002,
     MemoryQueue = 0x003,
+    TestQueue = 0x004,
 }
 
 //==============================================================================
@@ -27,6 +28,7 @@ impl From<QType> for u32 {
             QType::UdpSocket => 0x0001,
             QType::TcpSocket => 0x0002,
             QType::MemoryQueue => 0x0003,
+            QType::TestQueue => 0x0004,
         }
     }
 }
@@ -40,6 +42,7 @@ impl TryFrom<u32> for QType {
             0x0001 => Ok(QType::UdpSocket),
             0x0002 => Ok(QType::TcpSocket),
             0x0003 => Ok(QType::MemoryQueue),
+            0x0004 => Ok(QType::TestQueue),
             _ => Err("invalid qtype"),
         }
     }


### PR DESCRIPTION
This change unifies all of the per-queue metadata for all libOSes into one IoQueueTable abstraction. The IoQueueTable is generic over the queue type, which is based on and implemented by the libOS. For libOSes with multiple queue types, an enum can be used to dispatch Demikernel calls to the appropriate queue type. Eventually, we expect this queue table to be shared across multiple libOSes, although right now, each libOS keeps it's own queue table.