### PR TITLE
[catloop] Several Bug Fixes for Connection Establishment / Shutdown

### DIFF
--- a/src/rust/catloop/duplex_pipe.rs
+++ b/src/rust/catloop/duplex_pipe.rs
@@ -65,7 +65,7 @@ impl DuplexPipe {
 
     /// Closes a duplex pipe.
     pub fn close(&self) -> Result<(), Fail> {
-        self.catmem.borrow_mut().close(self.rx)?;
+        self.catmem.borrow_mut().shutdown(self.rx)?;
         self.catmem.borrow_mut().close(self.tx)?;
         Ok(())
     }

--- a/src/rust/catloop/duplex_pipe.rs
+++ b/src/rust/catloop/duplex_pipe.rs
@@ -101,4 +101,12 @@ impl DuplexPipe {
 
         Ok(Some(handle))
     }
+
+    /// Drops a pending operation on a duplex pipe.
+    pub fn drop(catmem: &Rc<RefCell<CatmemLibOS>>, qt: QToken) -> Result<(), Fail> {
+        // Retrieve a handle to the concerned co-routine and execute its destructor.
+        let handle: SchedulerHandle = catmem.borrow_mut().schedule(qt)?;
+        drop(handle);
+        Ok(())
+    }
 }

--- a/src/rust/catloop/duplex_pipe.rs
+++ b/src/rust/catloop/duplex_pipe.rs
@@ -70,6 +70,14 @@ impl DuplexPipe {
         Ok(())
     }
 
+    /// Disallows further operations on a duplex pipe. The underlying queue
+    /// descriptors are released, but EoF is not pushed to the remote end.
+    pub fn shutdown(&self) -> Result<(), Fail> {
+        self.catmem.borrow_mut().shutdown(self.rx)?;
+        self.catmem.borrow_mut().shutdown(self.tx)?;
+        Ok(())
+    }
+
     /// Pushes a scatter-gather array to a duplex pipe.
     pub fn push(&self, sga: &demi_sgarray_t) -> Result<QToken, Fail> {
         self.catmem.borrow_mut().push(self.tx, &sga)

--- a/src/rust/catloop/futures/connect.rs
+++ b/src/rust/catloop/futures/connect.rs
@@ -192,6 +192,10 @@ fn connect_ack_received(
 
         // Transition to the next state in the connection establishment protocol.
         self_.state = ClientState::Connected(remote, duplex_pipe);
+    } else {
+        // Connection timeout, retry.
+        DuplexPipe::drop(&self_.catmem, qt_rx)?;
+        self_.state = ClientState::InitiateConnectRequest;
     }
 
     // Re-schedule co-routine for later execution.

--- a/src/rust/catloop/futures/connect.rs
+++ b/src/rust/catloop/futures/connect.rs
@@ -169,11 +169,7 @@ fn connect_ack_received(
 
         let sga: demi_sgarray_t = match qr.qr_opcode {
             demi_opcode_t::DEMI_OPC_POP => unsafe { qr.qr_value.sga },
-            _ => {
-                let e: Fail = Fail::new(libc::EAGAIN, "hashsake failed");
-                error!("failed to establish connection ({:?})", e);
-                return Poll::Ready(Err(e));
-            },
+            _ => panic!("unexpected operation on control duplex pipe"),
         };
 
         // Extract port number.

--- a/src/rust/catmem/mod.rs
+++ b/src/rust/catmem/mod.rs
@@ -61,7 +61,12 @@ pub struct CatmemLibOS {
     scheduler: Scheduler,
 }
 
+//======================================================================================================================
+// Trait Implementations
+//======================================================================================================================
+
 impl MemoryRuntime for CatmemLibOS {}
+
 //======================================================================================================================
 // Associated Functions
 //======================================================================================================================
@@ -112,6 +117,24 @@ impl CatmemLibOS {
         Ok(())
     }
 
+    /// Disallows further operations on a memory queue.
+    /// This causes the queue descriptor to be freed and the underlying ring
+    /// buffer to be released, but it does not push an EoF message to the other end.
+    pub fn shutdown(&mut self, qd: QDesc) -> Result<(), Fail> {
+        trace!("shutdown() qd={:?}", qd);
+        match self.qtable.get(&qd) {
+            Some(_) => {
+                self.qtable.free(&qd);
+            },
+            None => {
+                let cause: String = format!("invalid queue descriptor (qd={:?})", qd);
+                error!("shutdown(): {}", cause);
+                return Err(Fail::new(libc::EBADF, &cause));
+            },
+        };
+        Ok(())
+    }
+
     /// Closes a memory queue.
     pub fn close(&mut self, qd: QDesc) -> Result<(), Fail> {
         trace!("close() qd={:?}", qd);
@@ -124,6 +147,7 @@ impl CatmemLibOS {
     }
 
     /// Pushes a scatter-gather array to a socket.
+    /// TODO: Enforce semantics on the pipe.
     pub fn push(&mut self, qd: QDesc, sga: &demi_sgarray_t) -> Result<QToken, Fail> {
         trace!("push() qd={:?}", qd);
 
@@ -160,6 +184,7 @@ impl CatmemLibOS {
     }
 
     /// Pops data from a socket.
+    /// TODO: Enforce semantics on the pipe.
     pub fn pop(&mut self, qd: QDesc) -> Result<QToken, Fail> {
         trace!("pop() qd={:?}", qd);
 

--- a/src/rust/catmem/mod.rs
+++ b/src/rust/catmem/mod.rs
@@ -140,7 +140,7 @@ impl CatmemLibOS {
                         // Handle end of file.
                         if pipe.eof() {
                             let cause: String = format!("end of file (qd={:?})", qd);
-                            error!("pop(): {:?}", cause);
+                            error!("push(): {:?}", cause);
                             return Err(Fail::new(libc::ECONNRESET, &cause));
                         }
                         let future: Operation = Operation::from(PushFuture::new(qd, pipe.buffer(), buf));


### PR DESCRIPTION
## Description

This PR fixes several bug fixes that were exposed by the `tcp-accept` program https://github.com/demikernel/demikernel/issues/478.

## Summary of Changes

- When closing duplex pipe, half-close underlying receiving pipe.
- Re-issue accept operation on bad connect request.
- Re-try on connection timeout.
- Half-Close duplex pipe when connecting.
- Wait for connect ACK when accepting a connection.