### PR TITLE
[catnap] Free queue descriptor on `close()`

### DIFF
--- a/src/rust/catnap/mod.rs
+++ b/src/rust/catnap/mod.rs
@@ -225,11 +225,15 @@ impl CatnapLibOS {
         trace!("close() qd={:?}", qd);
         match self.sockets.get(&qd) {
             Some(&fd) => match unsafe { libc::close(fd) } {
-                stats if stats == 0 => Ok(()),
-                _ => Err(Fail::new(libc::EBADF, "invalid queue descriptor")),
+                stats if stats == 0 => (),
+                _ => return Err(Fail::new(libc::EBADF, "invalid queue descriptor")),
             },
-            _ => Err(Fail::new(libc::EBADF, "invalid queue descriptor")),
-        }
+            None => return Err(Fail::new(libc::EBADF, "invalid queue descriptor")),
+        };
+
+        self.sockets.remove(&qd);
+        self.qtable.free(qd);
+        Ok(())
     }
 
     /// Pushes a scatter-gather array to a socket.


### PR DESCRIPTION
This commit fixes issue #491.