### PR TITLE
[pal] Retrieve `errno` and Propagate It in `SharedMemory`

### DIFF
--- a/src/rust/pal/linux/shm.rs
+++ b/src/rust/pal/linux/shm.rs
@@ -96,8 +96,13 @@ impl SharedMemory {
 
             // Check for failure return value.
             if ret == -1 {
-                // TODO: get cause for errno variable.
-                return Err(Fail::new(libc::EAGAIN, "failed to create shared memory region"));
+                let errno: libc::c_int = *libc::__errno_location();
+                let cause: String = format!(
+                    "failed to create shared memory region (name={:?}, size={}, errno={})",
+                    name, size, errno
+                );
+                error!("create(): {}", cause);
+                return Err(Fail::new(errno, &cause));
             }
             ret
         };

--- a/src/rust/pal/linux/shm.rs
+++ b/src/rust/pal/linux/shm.rs
@@ -55,8 +55,13 @@ impl SharedMemory {
 
             // Check for failure return value.
             if ret == -1 {
-                // TODO: get cause for errno variable.
-                return Err(Fail::new(libc::EAGAIN, "failed to open shared memory region"));
+                let errno: libc::c_int = *libc::__errno_location();
+                let cause: String = format!(
+                    "failed to open shared memory region (name={:?}, len={}, errno={})",
+                    name, len, errno
+                );
+                error!("open(): {}", cause);
+                return Err(Fail::new(errno, &cause));
             }
 
             ret


### PR DESCRIPTION
## Description

- This PR closes https://github.com/demikernel/demikernel/issues/504
- This PR closes https://github.com/demikernel/demikernel/issues/505

## Summary of Changes

- Changed `SharedMemory::open()` to retrieve `errno` and propagate it on fail.
- Changed `SharedMemory:create()` to retrieve `errno` and propagate it on fail.