### PR TITLE
[catnap] Do not Allow Multiple `bind()` to Same Address

### DIFF
--- a/src/rust/catnap/mod.rs
+++ b/src/rust/catnap/mod.rs
@@ -136,30 +136,60 @@ impl CatnapLibOS {
     pub fn bind(&mut self, qd: QDesc, local: SocketAddrV4) -> Result<(), Fail> {
         trace!("bind() qd={:?}, local={:?}", qd, local);
 
-        // Issue bind operation.
-        match self.qtable.get(&qd) {
-            Some(queue) => match queue.get_fd() {
-                Some(fd) => {
-                    let sockaddr: libc::sockaddr_in = linux::socketaddrv4_to_sockaddr_in(&local);
-                    match unsafe {
-                        libc::bind(
-                            fd,
-                            (&sockaddr as *const libc::sockaddr_in) as *const libc::sockaddr,
-                            mem::size_of_val(&sockaddr) as u32,
-                        )
-                    } {
-                        stats if stats == 0 => Ok(()),
-                        _ => {
-                            let errno: libc::c_int = unsafe { *libc::__errno_location() };
-                            error!("failed to bind socket (errno={:?})", errno);
-                            Err(Fail::new(errno, "operation failed"))
-                        },
-                    }
-                },
-                None => unreachable!("CatnapQueue has invalid underlying file descriptor"),
+        // Check if we are binding to the wildcard port.
+        if local.port() == 0 {
+            let cause: String = format!("cannot bind to port 0 (qd={:?})", qd);
+            error!("bind(): {}", cause);
+            return Err(Fail::new(libc::ENOTSUP, &cause));
+        }
+
+        // Check if queue descriptor is valid.
+        if self.qtable.get(&qd).is_none() {
+            let cause: String = format!("invalid queue descriptor {:?}", qd);
+            error!("bind(): {}", &cause);
+            return Err(Fail::new(libc::EBADF, &cause));
+        }
+
+        // Check wether the address is in use.
+        for (_, queue) in self.qtable.get_values() {
+            if let Some(addr) = queue.get_addr() {
+                if addr == local {
+                    let cause: String = format!("address is already bound to a socket (qd={:?}", qd);
+                    error!("bind(): {}", &cause);
+                    return Err(Fail::new(libc::EADDRINUSE, &cause));
+                }
+            }
+        }
+
+        // Get a mutable reference to the queue table.
+        // It is safe to unwrap because we checked before that the queue descriptor is valid.
+        let queue: &mut CatnapQueue = self
+            .qtable
+            .get_mut(&qd)
+            .expect("queue descriptor should be in queue table");
+
+        // Get reference to the underlying file descriptor.
+        // It is safe to unwrap because when creating a queue we assigned it a valid file descritor.
+        let fd: RawFd = queue.get_fd().expect("queue should have a file descriptor");
+
+        // Bind underlying socket.
+        let sockaddr: libc::sockaddr_in = linux::socketaddrv4_to_sockaddr_in(&local);
+        match unsafe {
+            libc::bind(
+                fd,
+                (&sockaddr as *const libc::sockaddr_in) as *const libc::sockaddr,
+                mem::size_of_val(&sockaddr) as u32,
+            )
+        } {
+            stats if stats == 0 => {
+                queue.set_addr(local);
+                Ok(())
             },
-            // TODO: Return the queue descriptor
-            None => Err(Fail::new(libc::EBADF, "invalid queue descriptor")),
+            _ => {
+                let errno: libc::c_int = unsafe { *libc::__errno_location() };
+                error!("failed to bind socket (errno={:?})", errno);
+                Err(Fail::new(errno, "operation failed"))
+            },
         }
     }
 
@@ -369,8 +399,14 @@ impl CatnapLibOS {
             // Associate raw file descriptor with queue descriptor.
             if let Some(new_fd) = new_fd {
                 match self.qtable.get_mut(&new_qd) {
-                    Some(queue) => queue.set_fd(new_fd),
-                    None => unreachable!("queue descriptor not inserted"),
+                    Some(queue) => match qr {
+                        OperationResult::Accept((_, addr)) => {
+                            queue.set_fd(new_fd);
+                            queue.set_addr(addr);
+                        },
+                        _ => unreachable!("invalid operation result"),
+                    },
+                    None => unreachable!("queue descriptor not registered"),
                 }
             } else {
                 // Release entry in queue table.

--- a/src/rust/catnap/queue.rs
+++ b/src/rust/catnap/queue.rs
@@ -9,7 +9,10 @@ use crate::runtime::{
     queue::IoQueue,
     QType,
 };
-use ::std::os::unix::prelude::RawFd;
+use ::std::{
+    net::SocketAddrV4,
+    os::unix::prelude::RawFd,
+};
 
 //======================================================================================================================
 // Structures
@@ -19,6 +22,7 @@ use ::std::os::unix::prelude::RawFd;
 pub struct CatnapQueue {
     qtype: QType,
     fd: Option<RawFd>,
+    addr: Option<SocketAddrV4>,
 }
 
 //======================================================================================================================
@@ -27,7 +31,7 @@ pub struct CatnapQueue {
 
 impl CatnapQueue {
     pub fn new(qtype: QType, fd: Option<RawFd>) -> Self {
-        Self { qtype, fd }
+        Self { qtype, fd, addr: None }
     }
 
     /// Get underlying POSIX file descriptor.
@@ -38,6 +42,16 @@ impl CatnapQueue {
     /// Set underlying POSIX file descriptor.
     pub fn set_fd(&mut self, fd: RawFd) {
         self.fd = Some(fd);
+    }
+
+    /// Gets underlying socket address.
+    pub fn get_addr(&self) -> Option<SocketAddrV4> {
+        self.addr
+    }
+
+    /// Sets underlying socket address.
+    pub fn set_addr(&mut self, addr: SocketAddrV4) {
+        self.addr = Some(addr);
     }
 }
 


### PR DESCRIPTION
## Description

This PR fixes https://github.com/demikernel/demikernel/issues/508

## Summary of Changes

- Added extra check for whether the bind address is already in use.
- Fixed error value when trying to bind a bound socket to a different address from `EBADF` to `EINVAL`.

## Additional Information

This PR takes dependency on https://github.com/demikernel/demikernel/pull/513