### PR TITLE
[inetstack] Implement async_close

### DIFF
--- a/src/rust/inetstack/protocols/tcp/established/ctrlblk.rs
+++ b/src/rust/inetstack/protocols/tcp/established/ctrlblk.rs
@@ -632,10 +632,8 @@ impl ControlBlock {
                             // is, we can delete our state (we maintained it in case we needed to retransmit something,
                             // but we had already sent everything we're ever going to send (incl. FIN) at least once).
                             self.state.set(State::Closed);
-
-                            // ToDo: Delete the ControlBlock.
                         },
-
+                        // TODO: Handle TimeWait to Closed transition.
                         _ => (),
                     }
                 } else {
@@ -735,6 +733,7 @@ impl ControlBlock {
             }
 
             // Push empty buffer.
+            // TODO: set err bit and wake
             self.receiver.push(DemiBuffer::new(0));
             if let Some(w) = self.waker.borrow_mut().take() {
                 w.wake()
@@ -785,10 +784,24 @@ impl ControlBlock {
         let fin_buf: DemiBuffer = DemiBuffer::new(0);
         self.send(fin_buf).expect("send failed");
 
+        // TODO: Set state to FIN-WAIT1 if currently establisehd or set to LASTACK if CloseWait.
+
         // Remember that the user has called close.
         self.user_is_done_sending.set(true);
 
         Ok(())
+    }
+
+    /// Handle moving the connection to the closed state.
+    ///
+    /// This function runs the TCP state machine once it has either sent or received a FIN. This function is only for
+    /// closing estabilished connections.
+    ///
+    pub fn poll_close(&self) -> Poll<Result<(), Fail>> {
+        // TODO: Retry FIN if not successful.
+        // TODO: Check if we have reached the CLOSED state, otherwise continue polling.
+        // For now, just immediately return with ok.
+        Poll::Ready(Ok(()))
     }
 
     /// Fetch a TCP header filling out various values based on our current state.

--- a/src/rust/inetstack/protocols/tcp/established/mod.rs
+++ b/src/rust/inetstack/protocols/tcp/established/mod.rs
@@ -78,6 +78,10 @@ impl EstablishedSocket {
         self.cb.close()
     }
 
+    pub fn poll_close(&self) -> Poll<Result<(), Fail>> {
+        self.cb.poll_close()
+    }
+
     pub fn remote_mss(&self) -> usize {
         self.cb.remote_mss()
     }

--- a/src/rust/inetstack/protocols/udp/futures/operation.rs
+++ b/src/rust/inetstack/protocols/udp/futures/operation.rs
@@ -33,6 +33,8 @@ pub enum UdpOperation {
     Pushto(QDesc, Result<(), Fail>),
     /// Pop operation.
     Pop(FutureResult<UdpPopFuture>),
+    /// Close operation
+    Close(QDesc, Result<(), Fail>),
 }
 
 //==============================================================================
@@ -57,6 +59,10 @@ impl UdpOperation {
                 done: Some(Err(e)),
             }) => (future.get_qd(), OperationResult::Failed(e)),
 
+            // Close operation.
+            UdpOperation::Close(fd, Ok(())) => (fd, OperationResult::Close),
+            UdpOperation::Close(fd, Err(e)) => (fd, OperationResult::Failed(e)),
+
             _ => panic!("UDP Operation not ready"),
         }
     }
@@ -75,6 +81,7 @@ impl Future for UdpOperation {
         match self.get_mut() {
             UdpOperation::Pop(ref mut f) => Future::poll(Pin::new(f), ctx),
             UdpOperation::Pushto(..) => Poll::Ready(()),
+            UdpOperation::Close(..) => Poll::Ready(()),
         }
     }
 }


### PR DESCRIPTION
This PR implements asynchronous close for the inet stack. Importantly, this PR creates a future/coroutine for driving the TCP connection to the close state and then freeing resources associated with the queue/socket. This PR leaves TODOs for actually implementing the TCP close state transitions for a later PR. Currently, the future immediately returns without being yielding, so there is no need to wake up the future. We will need to store a waker in the established socket, separate from the one for receiving data for close operations. Note that there is no need to free any of the socket data structures or control blocks explicitly because they are now all owned by the IoQueueTable, so when we free the queue descriptor, all associated metadata should be correctly freed as well. This means that it is important for us to not free the queue descriptor or SocketIds in the addresses backmap until we are sure that we will not continue to receive any more packets for the connection.