### PR TITLE
[runtime] Add ability to set result in FutureResult

### DIFF
--- a/include/demi/types.h
+++ b/include/demi/types.h
@@ -61,6 +61,7 @@ extern "C"
         DEMI_OPC_POP,         /**< Pop operation.     */
         DEMI_OPC_ACCEPT,      /**< Accept operation.  */
         DEMI_OPC_CONNECT,     /**< Connect operation. */
+        DEMI_OPC_CLOSE,     /**< Close operation. */
         DEMI_OPC_FAILED,      /**< Operation failed.  */
     } demi_opcode_t;
 

--- a/src/rust/catcollar/futures/close.rs
+++ b/src/rust/catcollar/futures/close.rs
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//==============================================================================
+// Imports
+//==============================================================================
+
+use crate::runtime::{
+    fail::Fail,
+    QDesc,
+};
+use ::std::{
+    future::Future,
+    os::unix::prelude::RawFd,
+    pin::Pin,
+    task::{
+        Context,
+        Poll,
+    },
+};
+
+//==============================================================================
+// Structures
+//==============================================================================
+
+/// Close Operation Descriptor
+pub struct CloseFuture {
+    /// Associated queue descriptor.
+    qd: QDesc,
+    // Underlying file descriptor.
+    fd: RawFd,
+}
+
+//==============================================================================
+// Associate Functions
+//==============================================================================
+
+/// Associate Functions for Close Operation Descriptors
+impl CloseFuture {
+    /// Creates a descriptor for a close operation.
+    pub fn new(qd: QDesc, fd: RawFd) -> Self {
+        Self { qd, fd }
+    }
+
+    /// Returns the queue descriptor associated to the target [ConnectFuture].
+    pub fn get_qd(&self) -> QDesc {
+        self.qd
+    }
+}
+
+//==============================================================================
+// Trait Implementations
+//==============================================================================
+
+/// Future Trait Implementation for Close Operation Descriptors
+impl Future for CloseFuture {
+    type Output = Result<(), Fail>;
+
+    /// Polls the target [CloseFuture].
+    fn poll(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Self::Output> {
+        let self_: &mut CloseFuture = self.get_mut();
+        match unsafe { libc::close(self_.fd) } {
+            // Operation completed.
+            stats if stats == 0 => {
+                trace!("socket closed fd={:?}", self_.fd);
+                Poll::Ready(Ok(()))
+            },
+            // Operation not completed, thus parse errno to find out what happened.
+            _ => {
+                let errno: libc::c_int = unsafe { *libc::__errno_location() };
+
+                // Operation was interrupted, retry?
+                if errno == libc::EINTR {
+                    ctx.waker().wake_by_ref();
+                    return Poll::Pending;
+                }
+                // Operation failed.
+                else {
+                    let cause: String = format!("close(): operation failed (errno={:?})", errno);
+                    error!("{}", cause);
+                    return Poll::Ready(Err(Fail::new(errno, &cause)));
+                }
+            },
+        }
+    }
+}

--- a/src/rust/catcollar/mod.rs
+++ b/src/rust/catcollar/mod.rs
@@ -499,6 +499,7 @@ fn pack_result(rt: &IoUringRuntime, result: OperationResult, qd: QDesc, qt: u64)
                 }
             },
         },
+        OperationResult::Close => unimplemented!("Async close not implemented yet"),
         OperationResult::Failed(e) => {
             warn!("Operation Failed: {:?}", e);
             demi_qresult_t {

--- a/src/rust/catnap/futures/close.rs
+++ b/src/rust/catnap/futures/close.rs
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//==============================================================================
+// Imports
+//==============================================================================
+
+use crate::runtime::{
+    fail::Fail,
+    QDesc,
+};
+use ::std::{
+    future::Future,
+    os::unix::prelude::RawFd,
+    pin::Pin,
+    task::{
+        Context,
+        Poll,
+    },
+};
+
+//==============================================================================
+// Structures
+//==============================================================================
+
+/// Close Operation Descriptor
+pub struct CloseFuture {
+    /// Associated queue descriptor.
+    qd: QDesc,
+    // Underlying file descriptor.
+    fd: RawFd,
+}
+
+//==============================================================================
+// Associate Functions
+//==============================================================================
+
+/// Associate Functions for Close Operation Descriptors
+impl CloseFuture {
+    /// Creates a descriptor for a close operation.
+    pub fn new(qd: QDesc, fd: RawFd) -> Self {
+        Self { qd, fd }
+    }
+
+    /// Returns the queue descriptor associated to the target [ConnectFuture].
+    pub fn get_qd(&self) -> QDesc {
+        self.qd
+    }
+}
+
+//==============================================================================
+// Trait Implementations
+//==============================================================================
+
+/// Future Trait Implementation for Close Operation Descriptors
+impl Future for CloseFuture {
+    type Output = Result<(), Fail>;
+
+    /// Polls the target [CloseFuture].
+    fn poll(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Self::Output> {
+        let self_: &mut CloseFuture = self.get_mut();
+        match unsafe { libc::close(self_.fd) } {
+            // Operation completed.
+            stats if stats == 0 => {
+                trace!("socket closed fd={:?}", self_.fd);
+                Poll::Ready(Ok(()))
+            },
+            // Operation not completed, thus parse errno to find out what happened.
+            _ => {
+                let errno: libc::c_int = unsafe { *libc::__errno_location() };
+
+                // Operation was interrupted, retry?
+                if errno == libc::EINTR {
+                    ctx.waker().wake_by_ref();
+                    return Poll::Pending;
+                }
+                // Operation failed.
+                else {
+                    let message: String = format!("close(): operation failed (errno={:?})", errno);
+                    error!("{}", message);
+                    return Poll::Ready(Err(Fail::new(errno, &message)));
+                }
+            },
+        }
+    }
+}

--- a/src/rust/catnap/mod.rs
+++ b/src/rust/catnap/mod.rs
@@ -488,5 +488,6 @@ fn pack_result(rt: &PosixRuntime, result: OperationResult, qd: QDesc, qt: u64) -
                 qr_value: unsafe { mem::zeroed() },
             }
         },
+        OperationResult::Close => unimplemented!("Async close not supported yet"),
     }
 }

--- a/src/rust/catnip/interop.rs
+++ b/src/rust/catnip/interop.rs
@@ -98,6 +98,7 @@ pub fn pack_result(rt: Rc<DPDKRuntime>, result: OperationResult, qd: QDesc, qt: 
                 }
             },
         },
+        OperationResult::Close => unimplemented!("Async close not implemented yet"),
         OperationResult::Failed(e) => {
             warn!("Operation Failed: {:?}", e);
             demi_qresult_t {

--- a/src/rust/catnip/interop.rs
+++ b/src/rust/catnip/interop.rs
@@ -98,7 +98,12 @@ pub fn pack_result(rt: Rc<DPDKRuntime>, result: OperationResult, qd: QDesc, qt: 
                 }
             },
         },
-        OperationResult::Close => unimplemented!("Async close not implemented yet"),
+        OperationResult::Close => demi_qresult_t {
+            qr_opcode: demi_opcode_t::DEMI_OPC_CLOSE,
+            qr_qd: qd.into(),
+            qr_qt: qt,
+            qr_value: unsafe { mem::zeroed() },
+        },
         OperationResult::Failed(e) => {
             warn!("Operation Failed: {:?}", e);
             demi_qresult_t {

--- a/src/rust/catpowder/interop.rs
+++ b/src/rust/catpowder/interop.rs
@@ -77,7 +77,12 @@ pub fn pack_result(rt: Rc<LinuxRuntime>, result: OperationResult, qd: QDesc, qt:
                 }
             },
         },
-        OperationResult::Close => unimplemented!("Async close not implemented yet"),
+        OperationResult::Close => demi_qresult_t {
+            qr_opcode: demi_opcode_t::DEMI_OPC_CLOSE,
+            qr_qd: qd.into(),
+            qr_qt: qt,
+            qr_value: unsafe { mem::zeroed() },
+        },
         OperationResult::Failed(e) => {
             warn!("Operation Failed: {:?}", e);
             demi_qresult_t {

--- a/src/rust/catpowder/interop.rs
+++ b/src/rust/catpowder/interop.rs
@@ -77,6 +77,7 @@ pub fn pack_result(rt: Rc<LinuxRuntime>, result: OperationResult, qd: QDesc, qt:
                 }
             },
         },
+        OperationResult::Close => unimplemented!("Async close not implemented yet"),
         OperationResult::Failed(e) => {
             warn!("Operation Failed: {:?}", e);
             demi_qresult_t {

--- a/src/rust/demikernel/libos/mod.rs
+++ b/src/rust/demikernel/libos/mod.rs
@@ -185,6 +185,13 @@ impl LibOS {
         }
     }
 
+    pub fn async_close(&mut self, qd: QDesc) -> Result<QToken, Fail> {
+        match self {
+            LibOS::NetworkLibOS(libos) => libos.async_close(qd),
+            _ => unimplemented!("No async close for memory libOSes"),
+        }
+    }
+
     /// Pushes a scatter-gather array to an I/O queue.
     pub fn push(&mut self, qd: QDesc, sga: &demi_sgarray_t) -> Result<QToken, Fail> {
         match self {

--- a/src/rust/demikernel/libos/network.rs
+++ b/src/rust/demikernel/libos/network.rs
@@ -176,7 +176,7 @@ impl NetworkLibOS {
             #[cfg(feature = "catpowder-libos")]
             NetworkLibOS::Catpowder(libos) => unimplemented!("Async close not supported yet"),
             #[cfg(all(feature = "catnap-libos", target_os = "linux"))]
-            NetworkLibOS::Catnap(libos) => unimplemented!("Async close not supported yet"),
+            NetworkLibOS::Catnap(libos) => libos.async_close(sockqd),
             #[cfg(all(feature = "catnapw-libos", target_os = "windows"))]
             NetworkLibOS::CatnapW(libos) => unimplemented!("Async close not supported yet"),
             #[cfg(feature = "catcollar-libos")]

--- a/src/rust/demikernel/libos/network.rs
+++ b/src/rust/demikernel/libos/network.rs
@@ -180,7 +180,7 @@ impl NetworkLibOS {
             #[cfg(all(feature = "catnapw-libos", target_os = "windows"))]
             NetworkLibOS::CatnapW(libos) => unimplemented!("Async close not supported yet"),
             #[cfg(feature = "catcollar-libos")]
-            NetworkLibOS::Catcollar(libos) => unimplemented!("Async close not supported yet"),
+            NetworkLibOS::Catcollar(libos) => libos.async_close(sockqd),
             #[cfg(feature = "catnip-libos")]
             NetworkLibOS::Catnip(libos) => libos.async_close(sockqd),
             #[cfg(feature = "catloop-libos")]

--- a/src/rust/demikernel/libos/network.rs
+++ b/src/rust/demikernel/libos/network.rs
@@ -171,6 +171,23 @@ impl NetworkLibOS {
         }
     }
 
+    pub fn async_close(&mut self, sockqd: QDesc) -> Result<QToken, Fail> {
+        match self {
+            #[cfg(feature = "catpowder-libos")]
+            NetworkLibOS::Catpowder(libos) => unimplemented!("Async close not supported yet"),
+            #[cfg(all(feature = "catnap-libos", target_os = "linux"))]
+            NetworkLibOS::Catnap(libos) => unimplemented!("Async close not supported yet"),
+            #[cfg(all(feature = "catnapw-libos", target_os = "windows"))]
+            NetworkLibOS::CatnapW(libos) => unimplemented!("Async close not supported yet"),
+            #[cfg(feature = "catcollar-libos")]
+            NetworkLibOS::Catcollar(libos) => unimplemented!("Async close not supported yet"),
+            #[cfg(feature = "catnip-libos")]
+            NetworkLibOS::Catnip(libos) => unimplemented!("Async close not supported yet"),
+            #[cfg(feature = "catloop-libos")]
+            NetworkLibOS::Catloop(libos) => unimplemented!("Async close not supported yet"),
+        }
+    }
+
     /// Pushes a scatter-gather array to a TCP socket.
     pub fn push(&mut self, sockqd: QDesc, sga: &demi_sgarray_t) -> Result<QToken, Fail> {
         match self {

--- a/src/rust/demikernel/libos/network.rs
+++ b/src/rust/demikernel/libos/network.rs
@@ -182,7 +182,7 @@ impl NetworkLibOS {
             #[cfg(feature = "catcollar-libos")]
             NetworkLibOS::Catcollar(libos) => unimplemented!("Async close not supported yet"),
             #[cfg(feature = "catnip-libos")]
-            NetworkLibOS::Catnip(libos) => unimplemented!("Async close not supported yet"),
+            NetworkLibOS::Catnip(libos) => libos.async_close(sockqd),
             #[cfg(feature = "catloop-libos")]
             NetworkLibOS::Catloop(libos) => unimplemented!("Async close not supported yet"),
         }

--- a/src/rust/demikernel/libos/network.rs
+++ b/src/rust/demikernel/libos/network.rs
@@ -174,7 +174,7 @@ impl NetworkLibOS {
     pub fn async_close(&mut self, sockqd: QDesc) -> Result<QToken, Fail> {
         match self {
             #[cfg(feature = "catpowder-libos")]
-            NetworkLibOS::Catpowder(libos) => unimplemented!("Async close not supported yet"),
+            NetworkLibOS::Catpowder(libos) => libos.async_close(sockqd),
             #[cfg(all(feature = "catnap-libos", target_os = "linux"))]
             NetworkLibOS::Catnap(libos) => libos.async_close(sockqd),
             #[cfg(all(feature = "catnapw-libos", target_os = "windows"))]

--- a/src/rust/inetstack/mod.rs
+++ b/src/rust/inetstack/mod.rs
@@ -339,6 +339,43 @@ impl InetStack {
         }
     }
 
+    ///
+    /// **Brief**
+    ///
+    /// Asynchronously closes a connection referred to by `qd`.
+    ///
+    /// **Return Value**
+    ///
+    /// Upon successful completion, `Ok(())` is returned. This qtoken can be used to wait until the close
+    /// completes shutting down the connection. Upon failure, `Fail` is returned instead.
+    ///
+    pub fn async_close(&mut self, qd: QDesc) -> Result<QToken, Fail> {
+        #[cfg(feature = "profiler")]
+        timer!("inetstack::async_close");
+        trace!("async_close(): qd={:?}", qd);
+
+        let future: FutureOperation = match self.lookup_qtype(&qd) {
+            Some(QType::TcpSocket) => {
+                let fut = self.ipv4.tcp.do_async_close(qd)?;
+                FutureOperation::from(fut)
+            },
+            Some(QType::UdpSocket) => {
+                let udp_op = UdpOperation::Pushto(qd, self.ipv4.udp.do_close(qd));
+                FutureOperation::Udp(udp_op)
+            },
+            Some(_) => return Err(Fail::new(libc::EINVAL, "invalid queue type")),
+            None => return Err(Fail::new(libc::EBADF, "bad queue descriptor")),
+        };
+
+        let handle: SchedulerHandle = match self.scheduler.insert(future) {
+            Some(handle) => handle,
+            None => return Err(Fail::new(libc::EAGAIN, "cannot schedule co-routine")),
+        };
+        let qt: QToken = handle.into_raw().into();
+        trace!("async_close() qt={:?}", qt);
+        Ok(qt)
+    }
+
     /// Pushes a buffer to a TCP socket.
     /// TODO: Rename this function to push() once we have a common representation across all libOSes.
     pub fn do_push(&mut self, qd: QDesc, buf: DemiBuffer) -> Result<FutureOperation, Fail> {

--- a/src/rust/inetstack/protocols/tcp/established/ctrlblk.rs
+++ b/src/rust/inetstack/protocols/tcp/established/ctrlblk.rs
@@ -632,10 +632,8 @@ impl ControlBlock {
                             // is, we can delete our state (we maintained it in case we needed to retransmit something,
                             // but we had already sent everything we're ever going to send (incl. FIN) at least once).
                             self.state.set(State::Closed);
-
-                            // ToDo: Delete the ControlBlock.
                         },
-
+                        // TODO: Handle TimeWait to Closed transition.
                         _ => (),
                     }
                 } else {
@@ -735,6 +733,7 @@ impl ControlBlock {
             }
 
             // Push empty buffer.
+            // TODO: set err bit and wake
             self.receiver.push(DemiBuffer::new(0));
             if let Some(w) = self.waker.borrow_mut().take() {
                 w.wake()
@@ -785,10 +784,24 @@ impl ControlBlock {
         let fin_buf: DemiBuffer = DemiBuffer::new(0);
         self.send(fin_buf).expect("send failed");
 
+        // TODO: Set state to FIN-WAIT1 if currently establisehd or set to LASTACK if CloseWait.
+
         // Remember that the user has called close.
         self.user_is_done_sending.set(true);
 
         Ok(())
+    }
+
+    /// Handle moving the connection to the closed state.
+    ///
+    /// This function runs the TCP state machine once it has either sent or received a FIN. This function is only for
+    /// closing estabilished connections.
+    ///
+    pub fn poll_close(&self) -> Poll<Result<(), Fail>> {
+        // TODO: Retry FIN if not successful.
+        // TODO: Check if we have reached the CLOSED state, otherwise continue polling.
+        // For now, just immediately return with ok.
+        Poll::Ready(Ok(()))
     }
 
     /// Fetch a TCP header filling out various values based on our current state.

--- a/src/rust/inetstack/protocols/tcp/established/mod.rs
+++ b/src/rust/inetstack/protocols/tcp/established/mod.rs
@@ -78,6 +78,10 @@ impl EstablishedSocket {
         self.cb.close()
     }
 
+    pub fn poll_close(&self) -> Poll<Result<(), Fail>> {
+        self.cb.poll_close()
+    }
+
     pub fn remote_mss(&self) -> usize {
         self.cb.remote_mss()
     }

--- a/src/rust/inetstack/protocols/udp/futures/operation.rs
+++ b/src/rust/inetstack/protocols/udp/futures/operation.rs
@@ -33,6 +33,8 @@ pub enum UdpOperation {
     Pushto(QDesc, Result<(), Fail>),
     /// Pop operation.
     Pop(FutureResult<UdpPopFuture>),
+    /// Close operation
+    Close(QDesc, Result<(), Fail>),
 }
 
 //==============================================================================
@@ -57,6 +59,10 @@ impl UdpOperation {
                 done: Some(Err(e)),
             }) => (future.get_qd(), OperationResult::Failed(e)),
 
+            // Close operation.
+            UdpOperation::Close(fd, Ok(())) => (fd, OperationResult::Close),
+            UdpOperation::Close(fd, Err(e)) => (fd, OperationResult::Failed(e)),
+
             _ => panic!("UDP Operation not ready"),
         }
     }
@@ -75,6 +81,7 @@ impl Future for UdpOperation {
         match self.get_mut() {
             UdpOperation::Pop(ref mut f) => Future::poll(Pin::new(f), ctx),
             UdpOperation::Pushto(..) => Poll::Ready(()),
+            UdpOperation::Close(..) => Poll::Ready(()),
         }
     }
 }

--- a/src/rust/runtime/queue/qresult.rs
+++ b/src/rust/runtime/queue/qresult.rs
@@ -28,6 +28,7 @@ pub enum OperationResult {
     Accept((QDesc, SocketAddrV4)),
     Push,
     Pop(Option<SocketAddrV4>, DemiBuffer),
+    Close,
     Failed(Fail),
 }
 
@@ -51,6 +52,7 @@ impl fmt::Debug for OperationResult {
             OperationResult::Accept(..) => write!(f, "Accept"),
             OperationResult::Push => write!(f, "Push"),
             OperationResult::Pop(..) => write!(f, "Pop"),
+            OperationResult::Close => write!(f, "Close"),
             OperationResult::Failed(ref e) => write!(f, "Failed({:?})", e),
         }
     }

--- a/src/rust/runtime/queue/qtoken.rs
+++ b/src/rust/runtime/queue/qtoken.rs
@@ -16,7 +16,7 @@ pub struct QToken(u64);
 //======================================================================================================================
 
 impl From<u64> for QToken {
-    /// Converts a [QToken] to a [u64].
+    /// Converts a [u64] to a [QToken].
     fn from(value: u64) -> Self {
         QToken(value)
     }

--- a/src/rust/runtime/types/ops.rs
+++ b/src/rust/runtime/types/ops.rs
@@ -29,6 +29,7 @@ pub enum demi_opcode_t {
     DEMI_OPC_POP,
     DEMI_OPC_ACCEPT,
     DEMI_OPC_CONNECT,
+    DEMI_OPC_CLOSE,
     DEMI_OPC_FAILED,
 }
 

--- a/src/rust/scheduler/handle.rs
+++ b/src/rust/scheduler/handle.rs
@@ -53,6 +53,11 @@ impl SchedulerHandle {
     pub fn into_raw(mut self) -> u64 {
         self.key.take().unwrap()
     }
+
+    /// Returns the raw key without taking it.
+    pub fn lookup_key(&self) -> u64 {
+        self.key.unwrap()
+    }
 }
 
 //==============================================================================


### PR DESCRIPTION
Currently, the only way for a FutureResult to complete is for the Future to complete with a ready and a result. This PR adds the ability to externally trigger the completion of the FutureResult (e.g., because the socket was closed). The code that sets the result should also wake the Future to ensure that the scheduler runs it on the next iteration and returns the set result the next time that the application waits on the qtoken.