### PR TITLE
[runtime] Renaming scheduler abstractions

### DIFF
--- a/src/rust/scheduler/coroutine.rs
+++ b/src/rust/scheduler/coroutine.rs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//==============================================================================
+// Imports
+//==============================================================================
+
+use ::std::{
+    any::Any,
+    future::Future,
+};
+
+//==============================================================================
+// Traits
+//==============================================================================
+
+/// Coroutine
+///
+/// This abstraction is the basic unit of application work for Demikernel. Demikernel libOSes use coroutines to handle
+/// processing for different events (e.g. packet arriving, pushing and popping from a queue, etc.).
+pub trait Coroutine: Any + Future<Output = ()> + Unpin {
+    /// Casts the target [Coroutine] into [Any].
+    fn as_any(self: Box<Self>) -> Box<dyn Any>;
+
+    /// Gets the underlying function to run the coroutine.
+    fn get_coroutine(&self) -> &dyn Future<Output = ()>;
+}

--- a/src/rust/scheduler/demi_scheduler.rs
+++ b/src/rust/scheduler/demi_scheduler.rs
@@ -1,0 +1,336 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//! Implementation of our efficient, single-threaded task scheduler.
+//!
+//! Our scheduler uses a pinned memory slab to store tasks ([SchedulerFuture]s).
+//! As background tasks are polled, they notify task in our scheduler via the
+//! [crate::page::WakerPage]s.
+
+//==============================================================================
+// Imports
+//==============================================================================
+
+use crate::scheduler::{
+    page::{
+        WakerPageRef,
+        WakerRef,
+    },
+    pin_slab::PinSlab,
+    waker64::{
+        WAKER_BIT_LENGTH,
+        WAKER_BIT_LENGTH_SHIFT,
+    },
+    Coroutine,
+    SchedulerHandle,
+    Task,
+};
+use ::bit_iter::BitIter;
+use ::std::{
+    cell::{
+        Ref,
+        RefCell,
+        RefMut,
+    },
+    future::Future,
+    pin::Pin,
+    ptr::NonNull,
+    rc::Rc,
+    task::{
+        Context,
+        Poll,
+        Waker,
+    },
+};
+
+//==============================================================================
+// Structures
+//==============================================================================
+
+/// Actual data used by [Scheduler].
+struct Inner<F: Future<Output = ()> + Unpin> {
+    /// Stores all the tasks that are held by the scheduler.
+    slab: PinSlab<F>,
+    /// Holds the status tasks.
+    pages: Vec<WakerPageRef>,
+}
+
+/// Future Scheduler
+#[derive(Clone)]
+pub struct DemiScheduler {
+    inner: Rc<RefCell<Inner<Task>>>,
+}
+
+//==============================================================================
+// Associate Functions
+//==============================================================================
+
+/// Associate Functions for Inner
+impl<F: Future<Output = ()> + Unpin> Inner<F> {
+    /// Computes the [WakerPageRef] and offset of a given task based on its `key`.
+    fn get_page(&self, key: u64) -> (&WakerPageRef, usize) {
+        let key: usize = key as usize;
+        let (page_ix, subpage_ix): (usize, usize) = (key >> WAKER_BIT_LENGTH_SHIFT, key & (WAKER_BIT_LENGTH - 1));
+        (&self.pages[page_ix], subpage_ix)
+    }
+
+    /// Insert a task into our scheduler returning a key that may be used to drive its status.
+    fn insert(&mut self, future: F) -> Option<u64> {
+        let key: usize = self.slab.insert(future)?;
+
+        // Add a new page to hold this future's status if the current page is filled.
+        while key >= self.pages.len() << WAKER_BIT_LENGTH_SHIFT {
+            self.pages.push(WakerPageRef::default());
+        }
+        let (page, subpage_ix): (&WakerPageRef, usize) = self.get_page(key as u64);
+        page.initialize(subpage_ix);
+        Some(key as u64)
+    }
+}
+
+/// Associate Functions for Scheduler
+impl DemiScheduler {
+    /// Given a handle representing a future, remove the future from the scheduler returning it.
+    pub fn take(&self, mut handle: SchedulerHandle) -> Box<dyn Coroutine> {
+        let mut inner: RefMut<Inner<Task>> = self.inner.borrow_mut();
+        let key: u64 = handle.take_key().unwrap();
+        let (page, subpage_ix): (&WakerPageRef, usize) = inner.get_page(key);
+        assert!(!page.was_dropped(subpage_ix));
+        page.clear(subpage_ix);
+        let t: Task = inner
+            .slab
+            .remove_unpin(key as usize)
+            .expect("Task has already been removed");
+        t.get_coroutine()
+    }
+
+    /// Given the raw `key` representing this future return a proper handle.
+    pub fn from_raw_handle(&self, key: u64) -> Option<SchedulerHandle> {
+        let inner: Ref<Inner<Task>> = self.inner.borrow();
+        inner.slab.get(key as usize)?;
+        let (page, _): (&WakerPageRef, usize) = inner.get_page(key);
+        let handle: SchedulerHandle = SchedulerHandle::new(key, page.clone());
+        Some(handle)
+    }
+
+    /// Insert a new task into our scheduler returning a handle corresponding to it.
+    pub fn insert(&self, coroutine: Box<dyn Coroutine>) -> Option<SchedulerHandle> {
+        let mut inner: RefMut<Inner<Task>> = self.inner.borrow_mut();
+        let key: u64 = inner.insert(Task::new(coroutine))?;
+        let (page, _): (&WakerPageRef, usize) = inner.get_page(key);
+        Some(SchedulerHandle::new(key, page.clone()))
+    }
+
+    /// Poll all futures which are ready to run again. Tasks in our scheduler are notified when
+    /// relevant data or events happen. The relevant event have callback function (the waker) which
+    /// they can invoke to notify the scheduler that future should be polled again.
+    pub fn poll(&self) {
+        let mut inner: RefMut<Inner<Task>> = self.inner.borrow_mut();
+
+        // Iterate through pages.
+        for page_ix in 0..inner.pages.len() {
+            let (notified, dropped): (u64, u64) = {
+                let page: &mut WakerPageRef = &mut inner.pages[page_ix];
+                (page.take_notified(), page.take_dropped())
+            };
+            // There is some notified task in this page, so iterate through it.
+            if notified != 0 {
+                for subpage_ix in BitIter::from(notified) {
+                    // Handle notified tasks only.
+                    // Get future using our page indices and poll it!
+                    let ix: usize = (page_ix << WAKER_BIT_LENGTH_SHIFT) + subpage_ix;
+                    let waker: Waker = unsafe {
+                        let raw_waker: NonNull<u8> = inner.pages[page_ix].into_raw_waker_ref(subpage_ix);
+                        Waker::from_raw(WakerRef::new(raw_waker).into())
+                    };
+                    let mut sub_ctx: Context = Context::from_waker(&waker);
+
+                    let pinned_ref: Pin<&mut Task> = inner.slab.get_pin_mut(ix).unwrap();
+                    let pinned_ptr = unsafe { Pin::into_inner_unchecked(pinned_ref) as *mut _ };
+
+                    // Poll future.
+                    drop(inner);
+                    let pinned_ref = unsafe { Pin::new_unchecked(&mut *pinned_ptr) };
+                    let poll_result: Poll<()> = Future::poll(pinned_ref, &mut sub_ctx);
+                    inner = self.inner.borrow_mut();
+
+                    match poll_result {
+                        Poll::Ready(()) => inner.pages[page_ix].mark_completed(subpage_ix),
+                        Poll::Pending => (),
+                    }
+                }
+            }
+            // There is some dropped task in this page, so iterate through it.
+            if dropped != 0 {
+                // Handle dropped tasks only.
+                for subpage_ix in BitIter::from(dropped) {
+                    if subpage_ix != 0 {
+                        let ix: usize = (page_ix << WAKER_BIT_LENGTH_SHIFT) + subpage_ix;
+                        inner.slab.remove(ix);
+                        inner.pages[page_ix].clear(subpage_ix);
+                    }
+                }
+            }
+        }
+    }
+}
+
+//==============================================================================
+// Trait Implementations
+//==============================================================================
+
+/// Default Trait Implementation for Scheduler
+impl Default for DemiScheduler {
+    /// Creates a scheduler with default values.
+    fn default() -> Self {
+        let inner: Inner<Task> = Inner {
+            slab: PinSlab::new(),
+            pages: vec![],
+        };
+        Self {
+            inner: Rc::new(RefCell::new(inner)),
+        }
+    }
+}
+
+//==============================================================================
+// Unit Tests
+//==============================================================================
+
+#[cfg(test)]
+mod tests {
+    use crate::scheduler::demi_scheduler::{
+        Coroutine,
+        DemiScheduler,
+        SchedulerHandle,
+    };
+    use ::std::{
+        any::Any,
+        future::Future,
+        pin::Pin,
+        task::{
+            Context,
+            Poll,
+            Waker,
+        },
+    };
+    use ::test::{
+        black_box,
+        Bencher,
+    };
+
+    #[derive(Default)]
+    struct DummyCoroutine {
+        pub val: usize,
+    }
+
+    impl DummyCoroutine {
+        pub fn new(val: usize) -> Self {
+            let f: Self = Self { val };
+            f
+        }
+    }
+
+    impl Future for DummyCoroutine {
+        type Output = ();
+
+        fn poll(self: Pin<&mut Self>, ctx: &mut Context) -> Poll<Self::Output> {
+            match self.as_ref().val & 1 {
+                0 => Poll::Ready(()),
+                _ => {
+                    self.get_mut().val += 1;
+                    let waker: &Waker = ctx.waker();
+                    waker.wake_by_ref();
+                    Poll::Pending
+                },
+            }
+        }
+    }
+
+    impl Coroutine for DummyCoroutine {
+        fn as_any(self: Box<Self>) -> Box<dyn Any> {
+            self
+        }
+
+        fn get_coroutine(&self) -> &dyn Future<Output = ()> {
+            todo!()
+        }
+    }
+
+    #[bench]
+    fn bench_scheduler_insert(b: &mut Bencher) {
+        let scheduler: DemiScheduler = DemiScheduler::default();
+
+        b.iter(|| {
+            let future: DummyCoroutine = black_box(DummyCoroutine::default());
+            let handle: SchedulerHandle = scheduler
+                .insert(Box::new(future))
+                .expect("couldn't insert future in scheduler");
+            black_box(handle);
+        });
+    }
+
+    #[test]
+    fn scheduler_poll_once() {
+        let scheduler: DemiScheduler = DemiScheduler::default();
+
+        // Insert a single future in the scheduler. This future shall complete
+        // with a single pool operation.
+        let future: DummyCoroutine = DummyCoroutine::new(0);
+        let handle: SchedulerHandle = match scheduler.insert(Box::new(future)) {
+            Some(handle) => handle,
+            None => panic!("insert() failed"),
+        };
+
+        // All futures are inserted in the scheduler with notification flag set.
+        // By polling once, our future should complete.
+        scheduler.poll();
+
+        assert_eq!(handle.has_completed(), true);
+    }
+
+    #[test]
+    fn scheduler_poll_twice() {
+        let scheduler: DemiScheduler = DemiScheduler::default();
+
+        // Insert a single future in the scheduler. This future shall complete
+        // with two poll operations.
+        let future: DummyCoroutine = DummyCoroutine::new(1);
+        let handle: SchedulerHandle = match scheduler.insert(Box::new(future)) {
+            Some(handle) => handle,
+            None => panic!("insert() failed"),
+        };
+
+        // All futures are inserted in the scheduler with notification flag set.
+        // By polling once, this future should make a transition.
+        scheduler.poll();
+
+        assert_eq!(handle.has_completed(), false);
+
+        // This shall make the future ready.
+        scheduler.poll();
+
+        assert_eq!(handle.has_completed(), true);
+    }
+
+    #[bench]
+    fn bench_scheduler_poll(b: &mut Bencher) {
+        let scheduler: DemiScheduler = DemiScheduler::default();
+        let mut handles: Vec<SchedulerHandle> = Vec::<SchedulerHandle>::with_capacity(1024);
+
+        // Insert 1024 futures in the scheduler.
+        // Half of them will be ready.
+        for val in 0..1024 {
+            let future: DummyCoroutine = DummyCoroutine::new(val);
+            let handle: SchedulerHandle = match scheduler.insert(Box::new(future)) {
+                Some(handle) => handle,
+                None => panic!("insert() failed"),
+            };
+            handles.push(handle);
+        }
+
+        b.iter(|| {
+            black_box(scheduler.poll());
+        });
+    }
+}

--- a/src/rust/scheduler/mod.rs
+++ b/src/rust/scheduler/mod.rs
@@ -1,12 +1,18 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+// TODO: Replace with coroutine eventually.
+pub mod coroutine;
 mod future;
+// TODO: Replace with task handle
 mod handle;
 mod page;
 mod pin_slab;
+// TODO: Replace with task
+pub mod demi_scheduler;
 mod result;
 pub mod scheduler;
+mod task;
 mod waker64;
 
 //==============================================================================
@@ -14,8 +20,11 @@ mod waker64;
 //==============================================================================
 
 pub use self::{
+    coroutine::Coroutine,
+    demi_scheduler::DemiScheduler,
     future::SchedulerFuture,
     handle::SchedulerHandle,
     result::FutureResult,
     scheduler::Scheduler,
+    task::Task,
 };

--- a/src/rust/scheduler/task.rs
+++ b/src/rust/scheduler/task.rs
@@ -1,0 +1,93 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//==============================================================================
+// Imports
+//==============================================================================
+
+use ::std::{
+    future::Future,
+    pin::Pin,
+    task::{
+        Context,
+        Poll,
+    },
+};
+
+use crate::scheduler::Coroutine;
+
+//==============================================================================
+// Structures
+//==============================================================================
+
+/// This abstraction represents a unit of scheduling in Demikernel. A task takes a coroutine and runs the coroutine until the coroutine completes (indicated by a Poll::Ready return value) and produces a result.
+pub struct Task {
+    /// Application coroutine
+    pub coroutine: Box<dyn Coroutine>,
+    /// Output value of the underlying future.
+    pub done: Option<<dyn Coroutine as Future>::Output>,
+}
+
+//==============================================================================
+// Associate Functions
+//==============================================================================
+
+/// Associate Functions for Future Results
+impl Task {
+    /// Instantiates a new future result.
+    pub fn new(coroutine: Box<dyn Coroutine>) -> Self {
+        Self {
+            coroutine: coroutine,
+            done: None,
+        }
+    }
+
+    /// Pre-empts this task and returns (generally due to error).
+    pub fn cancel(&mut self, cause: <dyn Coroutine as Future>::Output) {
+        self.done = Some(cause);
+    }
+
+    /// Check if the coroutine has completed.
+    pub fn has_completed(self) -> bool {
+        self.done.is_some()
+    }
+
+    /// Use this function to get the result of this Future. Should only be called once future has completed.
+    pub fn get_coroutine_and_result(self) -> (Box<dyn Coroutine>, Box<<dyn Coroutine as Future>::Output>) {
+        (self.coroutine, Box::new(self.done.expect("Future not complete")))
+    }
+
+    /// Use this to get the application coroutine.
+    pub fn get_coroutine(self) -> Box<dyn Coroutine> {
+        self.coroutine
+    }
+}
+
+//==============================================================================
+// Trait Implementations
+//==============================================================================
+
+/// Future Trait Implementation for Future Results
+impl Future for Task {
+    type Output = ();
+
+    /// Runs the task.
+    fn poll(self: Pin<&mut Self>, ctx: &mut Context) -> Poll<()> {
+        let self_: &mut Task = self.get_mut();
+
+        // Check whether the coroutine already completed.
+        if self_.done.is_some() {
+            return Poll::Ready(());
+        }
+
+        // Otherwise, run the coroutine.
+        match Future::poll(Pin::new(&mut self_.coroutine), ctx) {
+            Poll::Pending => return Poll::Pending,
+            Poll::Ready(result) => {
+                // If the coroutine is done and produced a result, set the result.
+                self_.done = Some(result);
+                Poll::Ready(())
+            },
+        }
+    }
+}


### PR DESCRIPTION
This is the first of several PRs to move our scheduler to new abstractions. The new names are more reflective of the abstractions and what they are used for. In addition, tasks have the ability to be cancelled while our FutureResult abstraction does not. After we move all of our libOSes, I will remove the old scheduler implementation