### PR TITLE
[catnip, catpowder] Move to newly renamed scheduler

### DIFF
--- a/src/rust/catnip/mod.rs
+++ b/src/rust/catnip/mod.rs
@@ -33,7 +33,7 @@ use crate::{
         QToken,
     },
     scheduler::{
-        Scheduler,
+        DemiScheduler,
         SchedulerHandle,
     },
 };
@@ -56,7 +56,7 @@ use crate::timer;
 
 /// Catnip LibOS
 pub struct CatnipLibOS {
-    scheduler: Scheduler,
+    scheduler: DemiScheduler,
     inetstack: InetStack,
     rt: Rc<DPDKRuntime>,
 }
@@ -82,7 +82,7 @@ impl CatnipLibOS {
         ));
         let now: Instant = Instant::now();
         let clock: TimerRc = TimerRc(Rc::new(Timer::new(now)));
-        let scheduler: Scheduler = Scheduler::default();
+        let scheduler: DemiScheduler = DemiScheduler::default();
         let rng_seed: [u8; 32] = [0; 32];
         let inetstack: InetStack = InetStack::new(
             rt.clone(),
@@ -116,7 +116,7 @@ impl CatnipLibOS {
                     return Err(Fail::new(libc::EINVAL, "zero-length buffer"));
                 }
                 let future = self.do_push(qd, buf)?;
-                let handle: SchedulerHandle = match self.scheduler.insert(future) {
+                let handle: SchedulerHandle = match self.scheduler.insert(Box::new(future)) {
                     Some(handle) => handle,
                     None => return Err(Fail::new(libc::EAGAIN, "cannot schedule co-routine")),
                 };
@@ -137,7 +137,7 @@ impl CatnipLibOS {
                     return Err(Fail::new(libc::EINVAL, "zero-length buffer"));
                 }
                 let future = self.do_pushto(qd, buf, to)?;
-                let handle: SchedulerHandle = match self.scheduler.insert(future) {
+                let handle: SchedulerHandle = match self.scheduler.insert(Box::new(future)) {
                     Some(handle) => handle,
                     None => return Err(Fail::new(libc::EAGAIN, "cannot schedule co-routine")),
                 };

--- a/src/rust/catpowder/mod.rs
+++ b/src/rust/catpowder/mod.rs
@@ -32,7 +32,7 @@ use crate::{
         QToken,
     },
     scheduler::{
-        Scheduler,
+        DemiScheduler,
         SchedulerHandle,
     },
 };
@@ -56,7 +56,7 @@ use crate::timer;
 
 /// Catpowder LibOS
 pub struct CatpowderLibOS {
-    scheduler: Scheduler,
+    scheduler: DemiScheduler,
     inetstack: InetStack,
     rt: Rc<LinuxRuntime>,
 }
@@ -76,7 +76,7 @@ impl CatpowderLibOS {
             HashMap::default(),
         ));
         let now: Instant = Instant::now();
-        let scheduler: Scheduler = Scheduler::default();
+        let scheduler: DemiScheduler = DemiScheduler::default();
         let clock: TimerRc = TimerRc(Rc::new(Timer::new(now)));
         let rng_seed: [u8; 32] = [0; 32];
         let inetstack: InetStack = InetStack::new(
@@ -111,7 +111,7 @@ impl CatpowderLibOS {
                     return Err(Fail::new(libc::EINVAL, "zero-length buffer"));
                 }
                 let future = self.do_push(qd, buf)?;
-                let handle: SchedulerHandle = match self.scheduler.insert(future) {
+                let handle: SchedulerHandle = match self.scheduler.insert(Box::new(future)) {
                     Some(handle) => handle,
                     None => return Err(Fail::new(libc::EAGAIN, "cannot schedule co-routine")),
                 };
@@ -132,7 +132,7 @@ impl CatpowderLibOS {
                     return Err(Fail::new(libc::EINVAL, "zero-length buffer"));
                 }
                 let future = self.do_pushto(qd, buf, to)?;
-                let handle: SchedulerHandle = match self.scheduler.insert(future) {
+                let handle: SchedulerHandle = match self.scheduler.insert(Box::new(future)) {
                     Some(handle) => handle,
                     None => return Err(Fail::new(libc::EAGAIN, "cannot schedule co-routine")),
                 };

--- a/src/rust/inetstack/futures/operation/mod.rs
+++ b/src/rust/inetstack/futures/operation/mod.rs
@@ -6,7 +6,7 @@ use crate::{
         tcp::operations::TcpOperation,
         udp::UdpOperation,
     },
-    scheduler::SchedulerFuture,
+    scheduler::Coroutine,
 };
 use ::futures::Future;
 use ::std::{
@@ -40,12 +40,12 @@ pub enum FutureOperation {
     Background(Pin<Box<dyn Future<Output = ()>>>),
 }
 
-impl SchedulerFuture for FutureOperation {
+impl Coroutine for FutureOperation {
     fn as_any(self: Box<Self>) -> Box<dyn Any> {
         self
     }
 
-    fn get_future(&self) -> &dyn Future<Output = ()> {
+    fn get_coroutine(&self) -> &dyn Future<Output = ()> {
         todo!()
     }
 }

--- a/src/rust/inetstack/protocols/arp/peer.rs
+++ b/src/rust/inetstack/protocols/arp/peer.rs
@@ -31,7 +31,7 @@ use crate::{
         timer::TimerRc,
     },
     scheduler::{
-        Scheduler,
+        DemiScheduler,
         SchedulerHandle,
     },
 };
@@ -92,7 +92,7 @@ pub struct ArpPeer {
 impl ArpPeer {
     pub fn new(
         rt: Rc<dyn NetworkRuntime>,
-        scheduler: Scheduler,
+        scheduler: DemiScheduler,
         clock: TimerRc,
         local_link_addr: MacAddress,
         local_ipv4_addr: Ipv4Addr,
@@ -105,8 +105,8 @@ impl ArpPeer {
             arp_config.get_disable_arp(),
         )));
 
-        let future = Self::background(clock.clone(), cache.clone());
-        let handle: SchedulerHandle = match scheduler.insert(FutureOperation::Background(future.boxed_local())) {
+        let future = FutureOperation::Background(Self::background(clock.clone(), cache.clone()).boxed_local());
+        let handle: SchedulerHandle = match scheduler.insert(Box::new(future)) {
             Some(handle) => handle,
             None => {
                 return Err(Fail::new(

--- a/src/rust/inetstack/protocols/peer.rs
+++ b/src/rust/inetstack/protocols/peer.rs
@@ -25,7 +25,7 @@ use crate::{
         queue::IoQueueTable,
         timer::TimerRc,
     },
-    scheduler::scheduler::Scheduler,
+    scheduler::demi_scheduler::DemiScheduler,
 };
 use ::libc::ENOTCONN;
 use ::std::{
@@ -49,7 +49,7 @@ pub struct Peer {
 impl Peer {
     pub fn new(
         rt: Rc<dyn NetworkRuntime>,
-        scheduler: Scheduler,
+        scheduler: DemiScheduler,
         qtable: Rc<RefCell<IoQueueTable<InetQueue>>>,
         clock: TimerRc,
         local_link_addr: MacAddress,

--- a/src/rust/inetstack/protocols/tcp/active_open.rs
+++ b/src/rust/inetstack/protocols/tcp/active_open.rs
@@ -40,7 +40,7 @@ use crate::{
         timer::TimerRc,
     },
     scheduler::{
-        Scheduler,
+        DemiScheduler,
         SchedulerHandle,
     },
 };
@@ -74,7 +74,7 @@ pub struct ActiveOpenSocket {
     remote: SocketAddrV4,
 
     rt: Rc<dyn NetworkRuntime>,
-    scheduler: Scheduler,
+    scheduler: DemiScheduler,
     clock: TimerRc,
     local_link_addr: MacAddress,
     tcp_config: TcpConfig,
@@ -87,7 +87,7 @@ pub struct ActiveOpenSocket {
 
 impl ActiveOpenSocket {
     pub fn new(
-        scheduler: Scheduler,
+        scheduler: DemiScheduler,
         local_isn: SeqNumber,
         local: SocketAddrV4,
         remote: SocketAddrV4,
@@ -114,7 +114,8 @@ impl ActiveOpenSocket {
             arp.clone(),
             result.clone(),
         );
-        let handle: SchedulerHandle = match scheduler.insert(FutureOperation::Background(future.boxed_local())) {
+        let future: FutureOperation = FutureOperation::Background(future.boxed_local());
+        let handle: SchedulerHandle = match scheduler.insert(Box::new(future)) {
             Some(handle) => handle,
             None => panic!("failed to insert task in the scheduler"),
         };

--- a/src/rust/inetstack/protocols/tcp/established/ctrlblk.rs
+++ b/src/rust/inetstack/protocols/tcp/established/ctrlblk.rs
@@ -43,7 +43,7 @@ use crate::{
             WatchedValue,
         },
     },
-    scheduler::scheduler::Scheduler,
+    scheduler::demi_scheduler::DemiScheduler,
 };
 use ::std::{
     cell::{
@@ -149,7 +149,7 @@ pub struct ControlBlock {
     remote: SocketAddrV4,
 
     rt: Rc<dyn NetworkRuntime>,
-    pub scheduler: Scheduler,
+    pub scheduler: DemiScheduler,
     pub clock: TimerRc,
     local_link_addr: MacAddress,
     tcp_config: TcpConfig,
@@ -216,7 +216,7 @@ impl ControlBlock {
         local: SocketAddrV4,
         remote: SocketAddrV4,
         rt: Rc<dyn NetworkRuntime>,
-        scheduler: Scheduler,
+        scheduler: DemiScheduler,
         clock: TimerRc,
         local_link_addr: MacAddress,
         tcp_config: TcpConfig,

--- a/src/rust/inetstack/protocols/tcp/established/mod.rs
+++ b/src/rust/inetstack/protocols/tcp/established/mod.rs
@@ -51,8 +51,8 @@ pub struct EstablishedSocket {
 impl EstablishedSocket {
     pub fn new(cb: ControlBlock, fd: QDesc, dead_socket_tx: mpsc::UnboundedSender<QDesc>) -> Self {
         let cb = Rc::new(cb);
-        let future = background(cb.clone(), fd, dead_socket_tx);
-        let handle: Rc<SchedulerHandle> = match cb.scheduler.insert(FutureOperation::Background(future.boxed_local())) {
+        let future = FutureOperation::Background(background(cb.clone(), fd, dead_socket_tx).boxed_local());
+        let handle: Rc<SchedulerHandle> = match cb.scheduler.insert(Box::new(future)) {
             Some(handle) => Rc::<SchedulerHandle>::new(handle),
             None => panic!("failed to insert task in the scheduler"),
         };

--- a/src/rust/inetstack/protocols/tcp/passive_open.rs
+++ b/src/rust/inetstack/protocols/tcp/passive_open.rs
@@ -41,7 +41,7 @@ use crate::{
         timer::TimerRc,
     },
     scheduler::{
-        Scheduler,
+        DemiScheduler,
         SchedulerHandle,
     },
 };
@@ -131,7 +131,7 @@ pub struct PassiveSocket {
 
     local: SocketAddrV4,
     rt: Rc<dyn NetworkRuntime>,
-    scheduler: Scheduler,
+    scheduler: DemiScheduler,
     clock: TimerRc,
     tcp_config: TcpConfig,
     local_link_addr: MacAddress,
@@ -143,7 +143,7 @@ impl PassiveSocket {
         local: SocketAddrV4,
         max_backlog: usize,
         rt: Rc<dyn NetworkRuntime>,
-        scheduler: Scheduler,
+        scheduler: DemiScheduler,
         clock: TimerRc,
         tcp_config: TcpConfig,
         local_link_addr: MacAddress,
@@ -275,7 +275,8 @@ impl PassiveSocket {
             self.arp.clone(),
             self.ready.clone(),
         );
-        let handle: SchedulerHandle = match self.scheduler.insert(FutureOperation::Background(future.boxed_local())) {
+        let future: FutureOperation = FutureOperation::Background(future.boxed_local());
+        let handle: SchedulerHandle = match self.scheduler.insert(Box::new(future)) {
             Some(handle) => handle,
             None => panic!("failed to insert task in the scheduler"),
         };

--- a/src/rust/inetstack/protocols/tcp/peer.rs
+++ b/src/rust/inetstack/protocols/tcp/peer.rs
@@ -52,7 +52,7 @@ use crate::{
         timer::TimerRc,
         QDesc,
     },
-    scheduler::scheduler::Scheduler,
+    scheduler::demi_scheduler::DemiScheduler,
 };
 use ::futures::channel::mpsc;
 use ::rand::{
@@ -113,7 +113,7 @@ pub struct Inner {
     // Connection or socket identifier for mapping incoming packets to the Demikernel queue
     addresses: HashMap<SocketId, QDesc>,
     rt: Rc<dyn NetworkRuntime>,
-    scheduler: Scheduler,
+    scheduler: DemiScheduler,
     clock: TimerRc,
     local_link_addr: MacAddress,
     local_ipv4_addr: Ipv4Addr,
@@ -134,7 +134,7 @@ pub struct TcpPeer {
 impl TcpPeer {
     pub fn new(
         rt: Rc<dyn NetworkRuntime>,
-        scheduler: Scheduler,
+        scheduler: DemiScheduler,
         qtable: Rc<RefCell<IoQueueTable<InetQueue>>>,
         clock: TimerRc,
         local_link_addr: MacAddress,
@@ -516,7 +516,7 @@ impl TcpPeer {
 impl Inner {
     fn new(
         rt: Rc<dyn NetworkRuntime>,
-        scheduler: Scheduler,
+        scheduler: DemiScheduler,
         qtable: Rc<RefCell<IoQueueTable<InetQueue>>>,
         clock: TimerRc,
         local_link_addr: MacAddress,

--- a/src/rust/inetstack/test_helpers/engine.rs
+++ b/src/rust/inetstack/test_helpers/engine.rs
@@ -26,7 +26,7 @@ use crate::{
         timer::TimerRc,
         QDesc,
     },
-    scheduler::scheduler::Scheduler,
+    scheduler::demi_scheduler::DemiScheduler,
 };
 use ::libc::EBADMSG;
 use ::std::{
@@ -52,7 +52,7 @@ pub struct Engine {
 }
 
 impl Engine {
-    pub fn new(rt: TestRuntime, scheduler: Scheduler, clock: TimerRc) -> Result<Self, Fail> {
+    pub fn new(rt: TestRuntime, scheduler: DemiScheduler, clock: TimerRc) -> Result<Self, Fail> {
         let rt = Rc::new(rt);
         let link_addr = rt.link_addr;
         let ipv4_addr = rt.ipv4_addr;

--- a/src/rust/inetstack/test_helpers/mod.rs
+++ b/src/rust/inetstack/test_helpers/mod.rs
@@ -19,7 +19,7 @@ use crate::{
         },
         timer::TimerRc,
     },
-    scheduler::scheduler::Scheduler,
+    scheduler::demi_scheduler::DemiScheduler,
 };
 use ::std::{
     collections::HashMap,
@@ -57,7 +57,7 @@ pub fn new_alice(now: Instant) -> Engine {
     let udp_config = UdpConfig::default();
     let tcp_config = TcpConfig::default();
     let rt = TestRuntime::new(now, arp_options, udp_config, tcp_config, ALICE_MAC, ALICE_IPV4);
-    let scheduler: Scheduler = rt.scheduler.clone();
+    let scheduler: DemiScheduler = rt.scheduler.clone();
     let clock: TimerRc = rt.clock.clone();
     Engine::new(rt, scheduler, clock).unwrap()
 }
@@ -73,7 +73,7 @@ pub fn new_bob(now: Instant) -> Engine {
     let udp_config = UdpConfig::default();
     let tcp_config = TcpConfig::default();
     let rt = TestRuntime::new(now, arp_options, udp_config, tcp_config, BOB_MAC, BOB_IPV4);
-    let scheduler: Scheduler = rt.scheduler.clone();
+    let scheduler: DemiScheduler = rt.scheduler.clone();
     let clock: TimerRc = rt.clock.clone();
     Engine::new(rt, scheduler, clock).unwrap()
 }
@@ -92,7 +92,7 @@ pub fn new_alice2(now: Instant) -> Engine {
     let udp_config = UdpConfig::default();
     let tcp_config = TcpConfig::default();
     let rt = TestRuntime::new(now, arp_options, udp_config, tcp_config, ALICE_MAC, ALICE_IPV4);
-    let scheduler: Scheduler = rt.scheduler.clone();
+    let scheduler: DemiScheduler = rt.scheduler.clone();
     let clock: TimerRc = rt.clock.clone();
     Engine::new(rt, scheduler, clock).unwrap()
 }
@@ -111,7 +111,7 @@ pub fn new_bob2(now: Instant) -> Engine {
     let udp_config = UdpConfig::default();
     let tcp_config = TcpConfig::default();
     let rt = TestRuntime::new(now, arp_options, udp_config, tcp_config, BOB_MAC, BOB_IPV4);
-    let scheduler: Scheduler = rt.scheduler.clone();
+    let scheduler: DemiScheduler = rt.scheduler.clone();
     let clock: TimerRc = rt.clock.clone();
     Engine::new(rt, scheduler, clock).unwrap()
 }
@@ -128,7 +128,7 @@ pub fn new_carrie(now: Instant) -> Engine {
     let tcp_config = TcpConfig::default();
 
     let rt = TestRuntime::new(now, arp_options, udp_config, tcp_config, CARRIE_MAC, CARRIE_IPV4);
-    let scheduler: Scheduler = rt.scheduler.clone();
+    let scheduler: DemiScheduler = rt.scheduler.clone();
     let clock: TimerRc = rt.clock.clone();
     Engine::new(rt, scheduler, clock).unwrap()
 }

--- a/src/rust/inetstack/test_helpers/runtime.rs
+++ b/src/rust/inetstack/test_helpers/runtime.rs
@@ -21,7 +21,7 @@ use crate::{
             TimerRc,
         },
     },
-    scheduler::scheduler::Scheduler,
+    scheduler::demi_scheduler::DemiScheduler,
 };
 use ::arrayvec::ArrayVec;
 use ::std::{
@@ -52,7 +52,7 @@ pub struct TestRuntime {
     pub udp_config: UdpConfig,
     pub tcp_config: TcpConfig,
     inner: Rc<RefCell<Inner>>,
-    pub scheduler: Scheduler,
+    pub scheduler: DemiScheduler,
     pub clock: TimerRc,
 }
 
@@ -80,7 +80,7 @@ impl TestRuntime {
             link_addr,
             ipv4_addr,
             inner: Rc::new(RefCell::new(inner)),
-            scheduler: Scheduler::default(),
+            scheduler: DemiScheduler::default(),
             clock: TimerRc(Rc::new(Timer::new(now))),
             arp_options,
             udp_config,

--- a/src/rust/scheduler/coroutine.rs
+++ b/src/rust/scheduler/coroutine.rs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//==============================================================================
+// Imports
+//==============================================================================
+
+use ::std::{
+    any::Any,
+    future::Future,
+};
+
+//==============================================================================
+// Traits
+//==============================================================================
+
+/// Coroutine
+///
+/// This abstraction is the basic unit of application work for Demikernel. Demikernel libOSes use coroutines to handle
+/// processing for different events (e.g. packet arriving, pushing and popping from a queue, etc.).
+pub trait Coroutine: Any + Future<Output = ()> + Unpin {
+    /// Casts the target [Coroutine] into [Any].
+    fn as_any(self: Box<Self>) -> Box<dyn Any>;
+
+    /// Gets the underlying function to run the coroutine.
+    fn get_coroutine(&self) -> &dyn Future<Output = ()>;
+}

--- a/src/rust/scheduler/demi_scheduler.rs
+++ b/src/rust/scheduler/demi_scheduler.rs
@@ -1,0 +1,336 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//! Implementation of our efficient, single-threaded task scheduler.
+//!
+//! Our scheduler uses a pinned memory slab to store tasks ([SchedulerFuture]s).
+//! As background tasks are polled, they notify task in our scheduler via the
+//! [crate::page::WakerPage]s.
+
+//==============================================================================
+// Imports
+//==============================================================================
+
+use crate::scheduler::{
+    page::{
+        WakerPageRef,
+        WakerRef,
+    },
+    pin_slab::PinSlab,
+    waker64::{
+        WAKER_BIT_LENGTH,
+        WAKER_BIT_LENGTH_SHIFT,
+    },
+    Coroutine,
+    SchedulerHandle,
+    Task,
+};
+use ::bit_iter::BitIter;
+use ::std::{
+    cell::{
+        Ref,
+        RefCell,
+        RefMut,
+    },
+    future::Future,
+    pin::Pin,
+    ptr::NonNull,
+    rc::Rc,
+    task::{
+        Context,
+        Poll,
+        Waker,
+    },
+};
+
+//==============================================================================
+// Structures
+//==============================================================================
+
+/// Actual data used by [Scheduler].
+struct Inner<F: Future<Output = ()> + Unpin> {
+    /// Stores all the tasks that are held by the scheduler.
+    slab: PinSlab<F>,
+    /// Holds the status tasks.
+    pages: Vec<WakerPageRef>,
+}
+
+/// Future Scheduler
+#[derive(Clone)]
+pub struct DemiScheduler {
+    inner: Rc<RefCell<Inner<Task>>>,
+}
+
+//==============================================================================
+// Associate Functions
+//==============================================================================
+
+/// Associate Functions for Inner
+impl<F: Future<Output = ()> + Unpin> Inner<F> {
+    /// Computes the [WakerPageRef] and offset of a given task based on its `key`.
+    fn get_page(&self, key: u64) -> (&WakerPageRef, usize) {
+        let key: usize = key as usize;
+        let (page_ix, subpage_ix): (usize, usize) = (key >> WAKER_BIT_LENGTH_SHIFT, key & (WAKER_BIT_LENGTH - 1));
+        (&self.pages[page_ix], subpage_ix)
+    }
+
+    /// Insert a task into our scheduler returning a key that may be used to drive its status.
+    fn insert(&mut self, future: F) -> Option<u64> {
+        let key: usize = self.slab.insert(future)?;
+
+        // Add a new page to hold this future's status if the current page is filled.
+        while key >= self.pages.len() << WAKER_BIT_LENGTH_SHIFT {
+            self.pages.push(WakerPageRef::default());
+        }
+        let (page, subpage_ix): (&WakerPageRef, usize) = self.get_page(key as u64);
+        page.initialize(subpage_ix);
+        Some(key as u64)
+    }
+}
+
+/// Associate Functions for Scheduler
+impl DemiScheduler {
+    /// Given a handle representing a future, remove the future from the scheduler returning it.
+    pub fn take(&self, mut handle: SchedulerHandle) -> Box<dyn Coroutine> {
+        let mut inner: RefMut<Inner<Task>> = self.inner.borrow_mut();
+        let key: u64 = handle.take_key().unwrap();
+        let (page, subpage_ix): (&WakerPageRef, usize) = inner.get_page(key);
+        assert!(!page.was_dropped(subpage_ix));
+        page.clear(subpage_ix);
+        let t: Task = inner
+            .slab
+            .remove_unpin(key as usize)
+            .expect("Task has already been removed");
+        t.get_coroutine()
+    }
+
+    /// Given the raw `key` representing this future return a proper handle.
+    pub fn from_raw_handle(&self, key: u64) -> Option<SchedulerHandle> {
+        let inner: Ref<Inner<Task>> = self.inner.borrow();
+        inner.slab.get(key as usize)?;
+        let (page, _): (&WakerPageRef, usize) = inner.get_page(key);
+        let handle: SchedulerHandle = SchedulerHandle::new(key, page.clone());
+        Some(handle)
+    }
+
+    /// Insert a new task into our scheduler returning a handle corresponding to it.
+    pub fn insert(&self, coroutine: Box<dyn Coroutine>) -> Option<SchedulerHandle> {
+        let mut inner: RefMut<Inner<Task>> = self.inner.borrow_mut();
+        let key: u64 = inner.insert(Task::new(coroutine))?;
+        let (page, _): (&WakerPageRef, usize) = inner.get_page(key);
+        Some(SchedulerHandle::new(key, page.clone()))
+    }
+
+    /// Poll all futures which are ready to run again. Tasks in our scheduler are notified when
+    /// relevant data or events happen. The relevant event have callback function (the waker) which
+    /// they can invoke to notify the scheduler that future should be polled again.
+    pub fn poll(&self) {
+        let mut inner: RefMut<Inner<Task>> = self.inner.borrow_mut();
+
+        // Iterate through pages.
+        for page_ix in 0..inner.pages.len() {
+            let (notified, dropped): (u64, u64) = {
+                let page: &mut WakerPageRef = &mut inner.pages[page_ix];
+                (page.take_notified(), page.take_dropped())
+            };
+            // There is some notified task in this page, so iterate through it.
+            if notified != 0 {
+                for subpage_ix in BitIter::from(notified) {
+                    // Handle notified tasks only.
+                    // Get future using our page indices and poll it!
+                    let ix: usize = (page_ix << WAKER_BIT_LENGTH_SHIFT) + subpage_ix;
+                    let waker: Waker = unsafe {
+                        let raw_waker: NonNull<u8> = inner.pages[page_ix].into_raw_waker_ref(subpage_ix);
+                        Waker::from_raw(WakerRef::new(raw_waker).into())
+                    };
+                    let mut sub_ctx: Context = Context::from_waker(&waker);
+
+                    let pinned_ref: Pin<&mut Task> = inner.slab.get_pin_mut(ix).unwrap();
+                    let pinned_ptr = unsafe { Pin::into_inner_unchecked(pinned_ref) as *mut _ };
+
+                    // Poll future.
+                    drop(inner);
+                    let pinned_ref = unsafe { Pin::new_unchecked(&mut *pinned_ptr) };
+                    let poll_result: Poll<()> = Future::poll(pinned_ref, &mut sub_ctx);
+                    inner = self.inner.borrow_mut();
+
+                    match poll_result {
+                        Poll::Ready(()) => inner.pages[page_ix].mark_completed(subpage_ix),
+                        Poll::Pending => (),
+                    }
+                }
+            }
+            // There is some dropped task in this page, so iterate through it.
+            if dropped != 0 {
+                // Handle dropped tasks only.
+                for subpage_ix in BitIter::from(dropped) {
+                    if subpage_ix != 0 {
+                        let ix: usize = (page_ix << WAKER_BIT_LENGTH_SHIFT) + subpage_ix;
+                        inner.slab.remove(ix);
+                        inner.pages[page_ix].clear(subpage_ix);
+                    }
+                }
+            }
+        }
+    }
+}
+
+//==============================================================================
+// Trait Implementations
+//==============================================================================
+
+/// Default Trait Implementation for Scheduler
+impl Default for DemiScheduler {
+    /// Creates a scheduler with default values.
+    fn default() -> Self {
+        let inner: Inner<Task> = Inner {
+            slab: PinSlab::new(),
+            pages: vec![],
+        };
+        Self {
+            inner: Rc::new(RefCell::new(inner)),
+        }
+    }
+}
+
+//==============================================================================
+// Unit Tests
+//==============================================================================
+
+#[cfg(test)]
+mod tests {
+    use crate::scheduler::demi_scheduler::{
+        Coroutine,
+        DemiScheduler,
+        SchedulerHandle,
+    };
+    use ::std::{
+        any::Any,
+        future::Future,
+        pin::Pin,
+        task::{
+            Context,
+            Poll,
+            Waker,
+        },
+    };
+    use ::test::{
+        black_box,
+        Bencher,
+    };
+
+    #[derive(Default)]
+    struct DummyCoroutine {
+        pub val: usize,
+    }
+
+    impl DummyCoroutine {
+        pub fn new(val: usize) -> Self {
+            let f: Self = Self { val };
+            f
+        }
+    }
+
+    impl Future for DummyCoroutine {
+        type Output = ();
+
+        fn poll(self: Pin<&mut Self>, ctx: &mut Context) -> Poll<Self::Output> {
+            match self.as_ref().val & 1 {
+                0 => Poll::Ready(()),
+                _ => {
+                    self.get_mut().val += 1;
+                    let waker: &Waker = ctx.waker();
+                    waker.wake_by_ref();
+                    Poll::Pending
+                },
+            }
+        }
+    }
+
+    impl Coroutine for DummyCoroutine {
+        fn as_any(self: Box<Self>) -> Box<dyn Any> {
+            self
+        }
+
+        fn get_coroutine(&self) -> &dyn Future<Output = ()> {
+            todo!()
+        }
+    }
+
+    #[bench]
+    fn bench_scheduler_insert(b: &mut Bencher) {
+        let scheduler: DemiScheduler = DemiScheduler::default();
+
+        b.iter(|| {
+            let future: DummyCoroutine = black_box(DummyCoroutine::default());
+            let handle: SchedulerHandle = scheduler
+                .insert(Box::new(future))
+                .expect("couldn't insert future in scheduler");
+            black_box(handle);
+        });
+    }
+
+    #[test]
+    fn scheduler_poll_once() {
+        let scheduler: DemiScheduler = DemiScheduler::default();
+
+        // Insert a single future in the scheduler. This future shall complete
+        // with a single pool operation.
+        let future: DummyCoroutine = DummyCoroutine::new(0);
+        let handle: SchedulerHandle = match scheduler.insert(Box::new(future)) {
+            Some(handle) => handle,
+            None => panic!("insert() failed"),
+        };
+
+        // All futures are inserted in the scheduler with notification flag set.
+        // By polling once, our future should complete.
+        scheduler.poll();
+
+        assert_eq!(handle.has_completed(), true);
+    }
+
+    #[test]
+    fn scheduler_poll_twice() {
+        let scheduler: DemiScheduler = DemiScheduler::default();
+
+        // Insert a single future in the scheduler. This future shall complete
+        // with two poll operations.
+        let future: DummyCoroutine = DummyCoroutine::new(1);
+        let handle: SchedulerHandle = match scheduler.insert(Box::new(future)) {
+            Some(handle) => handle,
+            None => panic!("insert() failed"),
+        };
+
+        // All futures are inserted in the scheduler with notification flag set.
+        // By polling once, this future should make a transition.
+        scheduler.poll();
+
+        assert_eq!(handle.has_completed(), false);
+
+        // This shall make the future ready.
+        scheduler.poll();
+
+        assert_eq!(handle.has_completed(), true);
+    }
+
+    #[bench]
+    fn bench_scheduler_poll(b: &mut Bencher) {
+        let scheduler: DemiScheduler = DemiScheduler::default();
+        let mut handles: Vec<SchedulerHandle> = Vec::<SchedulerHandle>::with_capacity(1024);
+
+        // Insert 1024 futures in the scheduler.
+        // Half of them will be ready.
+        for val in 0..1024 {
+            let future: DummyCoroutine = DummyCoroutine::new(val);
+            let handle: SchedulerHandle = match scheduler.insert(Box::new(future)) {
+                Some(handle) => handle,
+                None => panic!("insert() failed"),
+            };
+            handles.push(handle);
+        }
+
+        b.iter(|| {
+            black_box(scheduler.poll());
+        });
+    }
+}

--- a/src/rust/scheduler/mod.rs
+++ b/src/rust/scheduler/mod.rs
@@ -1,12 +1,18 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+// TODO: Replace with coroutine eventually.
+pub mod coroutine;
 mod future;
+// TODO: Replace with task handle
 mod handle;
 mod page;
 mod pin_slab;
+// TODO: Replace with task
+pub mod demi_scheduler;
 mod result;
 pub mod scheduler;
+mod task;
 mod waker64;
 
 //==============================================================================
@@ -14,8 +20,11 @@ mod waker64;
 //==============================================================================
 
 pub use self::{
+    coroutine::Coroutine,
+    demi_scheduler::DemiScheduler,
     future::SchedulerFuture,
     handle::SchedulerHandle,
     result::FutureResult,
     scheduler::Scheduler,
+    task::Task,
 };

--- a/src/rust/scheduler/task.rs
+++ b/src/rust/scheduler/task.rs
@@ -1,0 +1,93 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//==============================================================================
+// Imports
+//==============================================================================
+
+use ::std::{
+    future::Future,
+    pin::Pin,
+    task::{
+        Context,
+        Poll,
+    },
+};
+
+use crate::scheduler::Coroutine;
+
+//==============================================================================
+// Structures
+//==============================================================================
+
+/// This abstraction represents a unit of scheduling in Demikernel. A task takes a coroutine and runs the coroutine until the coroutine completes (indicated by a Poll::Ready return value) and produces a result.
+pub struct Task {
+    /// Application coroutine
+    pub coroutine: Box<dyn Coroutine>,
+    /// Output value of the underlying future.
+    pub done: Option<<dyn Coroutine as Future>::Output>,
+}
+
+//==============================================================================
+// Associate Functions
+//==============================================================================
+
+/// Associate Functions for Future Results
+impl Task {
+    /// Instantiates a new future result.
+    pub fn new(coroutine: Box<dyn Coroutine>) -> Self {
+        Self {
+            coroutine: coroutine,
+            done: None,
+        }
+    }
+
+    /// Pre-empts this task and returns (generally due to error).
+    pub fn cancel(&mut self, cause: <dyn Coroutine as Future>::Output) {
+        self.done = Some(cause);
+    }
+
+    /// Check if the coroutine has completed.
+    pub fn has_completed(self) -> bool {
+        self.done.is_some()
+    }
+
+    /// Use this function to get the result of this Future. Should only be called once future has completed.
+    pub fn get_coroutine_and_result(self) -> (Box<dyn Coroutine>, Box<<dyn Coroutine as Future>::Output>) {
+        (self.coroutine, Box::new(self.done.expect("Future not complete")))
+    }
+
+    /// Use this to get the application coroutine.
+    pub fn get_coroutine(self) -> Box<dyn Coroutine> {
+        self.coroutine
+    }
+}
+
+//==============================================================================
+// Trait Implementations
+//==============================================================================
+
+/// Future Trait Implementation for Future Results
+impl Future for Task {
+    type Output = ();
+
+    /// Runs the task.
+    fn poll(self: Pin<&mut Self>, ctx: &mut Context) -> Poll<()> {
+        let self_: &mut Task = self.get_mut();
+
+        // Check whether the coroutine already completed.
+        if self_.done.is_some() {
+            return Poll::Ready(());
+        }
+
+        // Otherwise, run the coroutine.
+        match Future::poll(Pin::new(&mut self_.coroutine), ctx) {
+            Poll::Pending => return Poll::Pending,
+            Poll::Ready(result) => {
+                // If the coroutine is done and produced a result, set the result.
+                self_.done = Some(result);
+                Poll::Ready(())
+            },
+        }
+    }
+}

--- a/tests/rust/common/libos.rs
+++ b/tests/rust/common/libos.rs
@@ -26,7 +26,7 @@ use crossbeam_channel::{
     Receiver,
     Sender,
 };
-use demikernel::scheduler::scheduler::Scheduler;
+use demikernel::scheduler::demi_scheduler::DemiScheduler;
 use std::{
     collections::HashMap,
     net::Ipv4Addr,
@@ -67,7 +67,7 @@ impl DummyLibOS {
         );
         let udp_config: UdpConfig = UdpConfig::default();
         let tcp_config: TcpConfig = TcpConfig::default();
-        let scheduler: Scheduler = rt.scheduler.clone();
+        let scheduler: DemiScheduler = rt.scheduler.clone();
         let clock: TimerRc = rt.clock.clone();
         let rng_seed: [u8; 32] = [0; 32];
         logging::initialize();

--- a/tests/rust/common/runtime.rs
+++ b/tests/rust/common/runtime.rs
@@ -20,7 +20,7 @@ use ::demikernel::{
             TimerRc,
         },
     },
-    scheduler::scheduler::Scheduler,
+    scheduler::demi_scheduler::DemiScheduler,
 };
 use ::std::{
     cell::RefCell,
@@ -46,7 +46,7 @@ struct SharedDummyRuntime {
 pub struct DummyRuntime {
     /// Shared Member Fields
     inner: Rc<RefCell<SharedDummyRuntime>>,
-    pub scheduler: Scheduler,
+    pub scheduler: DemiScheduler,
     pub clock: TimerRc,
 }
 
@@ -65,7 +65,7 @@ impl DummyRuntime {
         let inner = SharedDummyRuntime { incoming, outgoing };
         Self {
             inner: Rc::new(RefCell::new(inner)),
-            scheduler: Scheduler::default(),
+            scheduler: DemiScheduler::default(),
             clock: TimerRc(Rc::new(Timer::new(now))),
         }
     }


### PR DESCRIPTION
This PR moves the inetstack, catnip and catpowder to our newly renamed scheduler. It requires us to box all of our futures for dynamic dispatch later. 