### PR TITLE
[examples] `tcp-close` Testing Program

### DIFF
--- a/examples/rust/linux.mk
+++ b/examples/rust/linux.mk
@@ -21,6 +21,7 @@ all: all-examples
 	cp -f $(BUILD_DIR)/examples/tcp-ping-pong $(BINDIR)/examples/rust/tcp-ping-pong.$(EXEC_SUFFIX)
 	cp -f $(BUILD_DIR)/examples/tcp-accept $(BINDIR)/examples/rust/tcp-accept.$(EXEC_SUFFIX)
 	cp -f $(BUILD_DIR)/examples/tcp-bind $(BINDIR)/examples/rust/tcp-bind.$(EXEC_SUFFIX)
+	cp -f $(BUILD_DIR)/examples/tcp-close $(BINDIR)/examples/rust/tcp-close.$(EXEC_SUFFIX)
 	cp -f $(BUILD_DIR)/examples/pipe-open $(BINDIR)/examples/rust/pipe-open.$(EXEC_SUFFIX)
 
 all-examples:
@@ -43,4 +44,5 @@ clean:
 	@rm -rf $(BINDIR)/examples/rust/tcp-ping-pong.$(EXEC_SUFFIX)
 	@rm -rf $(BINDIR)/examples/rust/tcp-accept.$(EXEC_SUFFIX)
 	@rm -rf $(BINDIR)/examples/rust/tcp-bind.$(EXEC_SUFFIX)
+	@rm -rf $(BINDIR)/examples/rust/tcp-close.$(EXEC_SUFFIX)
 	@rm -rf $(BINDIR)/examples/rust/pipe-open.$(EXEC_SUFFIX)

--- a/examples/tcp-close/args.rs
+++ b/examples/tcp-close/args.rs
@@ -1,0 +1,133 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//======================================================================================================================
+// Imports
+//======================================================================================================================
+
+use anyhow::Result;
+use clap::{
+    Arg,
+    ArgMatches,
+    Command,
+};
+use std::{
+    net::SocketAddrV4,
+    str::FromStr,
+};
+
+//======================================================================================================================
+// Program Arguments
+//======================================================================================================================
+
+/// Program Arguments
+#[derive(Debug)]
+pub struct ProgramArguments {
+    /// Run mode.
+    run_mode: String,
+    /// Socket IPv4 address.
+    addr: SocketAddrV4,
+    /// Number of clients
+    nclients: Option<usize>,
+    /// Peer type.
+    peer_type: Option<String>,
+}
+
+impl ProgramArguments {
+    /// Parses the program arguments from the command line interface.
+    pub fn new(app_name: &'static str, app_author: &'static str, app_about: &'static str) -> Result<Self> {
+        let matches: ArgMatches = Command::new(app_name)
+            .author(app_author)
+            .about(app_about)
+            .arg(
+                Arg::new("addr")
+                    .long("address")
+                    .value_parser(clap::value_parser!(String))
+                    .required(true)
+                    .value_name("ADDRESS:PORT")
+                    .help("Sets socket address"),
+            )
+            .arg(
+                Arg::new("peer")
+                    .long("peer")
+                    .value_parser(clap::value_parser!(String))
+                    .required(false)
+                    .value_name("server|client")
+                    .help("Sets peer type"),
+            )
+            .arg(
+                Arg::new("nclients")
+                    .long("nclients")
+                    .value_parser(clap::value_parser!(usize))
+                    .required(false)
+                    .value_name("NUMBER")
+                    .help("Sets number of clients"),
+            )
+            .arg(
+                Arg::new("run-mode")
+                    .long("run-mode")
+                    .value_parser(clap::value_parser!(String))
+                    .required(true)
+                    .value_name("standalone|sequential|concurrent")
+                    .help("Sets run mode"),
+            )
+            .get_matches();
+
+        // Run mode.
+        let run_mode: String = matches
+            .get_one::<String>("run-mode")
+            .ok_or(anyhow::anyhow!("missing run mode"))?
+            .to_string();
+
+        // Socket address.
+        let addr: SocketAddrV4 = {
+            let addr: &String = matches.get_one::<String>("addr").expect("missing address");
+            SocketAddrV4::from_str(addr)?
+        };
+
+        let mut args: ProgramArguments = Self {
+            run_mode,
+            addr,
+            nclients: None,
+            peer_type: None,
+        };
+
+        // Number of clients.
+        if let Some(nclients) = matches.get_one::<usize>("nclients") {
+            if *nclients == 0 {
+                anyhow::bail!("invalid nclients");
+            }
+            args.nclients = Some(*nclients);
+        }
+
+        // Peer type.
+        if let Some(peer_type) = matches.get_one::<String>("peer") {
+            if peer_type != "server" && peer_type != "client" {
+                anyhow::bail!("invalid peer type");
+            }
+            args.peer_type = Some(peer_type.to_string());
+        }
+
+        Ok(args)
+    }
+
+    /// Returns the `addr` command line argument.
+    pub fn addr(&self) -> SocketAddrV4 {
+        self.addr
+    }
+
+    /// Returns the `nclients` command line argument.
+    pub fn nclients(&self) -> Option<usize> {
+        self.nclients
+    }
+
+    /// Returns the `peer_type` command line argument.
+    pub fn peer_type(&self) -> Option<String> {
+        self.peer_type.clone()
+    }
+
+    /// Returns the `run_mode` command line argument.
+    pub fn run_mode(&self) -> String {
+        self.run_mode.clone()
+    }
+}

--- a/examples/tcp-close/client.rs
+++ b/examples/tcp-close/client.rs
@@ -1,0 +1,153 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//======================================================================================================================
+// Imports
+//======================================================================================================================
+
+use anyhow::Result;
+use demikernel::{
+    runtime::types::{
+        demi_opcode_t,
+        demi_qresult_t,
+    },
+    LibOS,
+    QDesc,
+    QToken,
+};
+use std::{
+    collections::HashMap,
+    net::SocketAddrV4,
+};
+
+//======================================================================================================================
+// Constants
+//======================================================================================================================
+
+#[cfg(target_os = "windows")]
+pub const AF_INET: i32 = windows::Win32::Networking::WinSock::AF_INET.0 as i32;
+
+#[cfg(target_os = "windows")]
+pub const SOCK_STREAM: i32 = windows::Win32::Networking::WinSock::SOCK_STREAM as i32;
+
+#[cfg(target_os = "linux")]
+pub const AF_INET: i32 = libc::AF_INET;
+
+#[cfg(target_os = "linux")]
+pub const SOCK_STREAM: i32 = libc::SOCK_STREAM;
+
+//======================================================================================================================
+// Structures
+//======================================================================================================================
+
+/// TCP Client
+pub struct TcpClient {
+    /// Underlying libOS.
+    libos: LibOS,
+    /// Address of remote peer.
+    remote: SocketAddrV4,
+    /// Number of clients that established a connection.
+    clients_connected: usize,
+    /// Number of clients that closed their connection.
+    clients_closed: usize,
+}
+
+//======================================================================================================================
+// Associated Functions
+//======================================================================================================================
+
+impl TcpClient {
+    /// Creates a new TCP client.
+    pub fn new(libos: LibOS, remote: SocketAddrV4) -> Result<Self> {
+        println!("Connecting to: {:?}", remote);
+        Ok(Self {
+            libos,
+            remote,
+            clients_connected: 0,
+            clients_closed: 0,
+        })
+    }
+
+    /// Attempts to close several connections sequentially.
+    pub fn run_sequential(&mut self, nclients: usize) -> Result<()> {
+        // Open several connections.
+        for i in 0..nclients {
+            // Create TCP socket.
+            let sockqd: QDesc = self.libos.socket(AF_INET, SOCK_STREAM, 0)?;
+
+            // Connect TCP socket.
+            let qt: QToken = self.libos.connect(sockqd, self.remote)?;
+
+            // Wait for connection to be established.
+            let qr: demi_qresult_t = self.libos.wait(qt, None)?;
+
+            // Parse result.
+            match qr.qr_opcode {
+                demi_opcode_t::DEMI_OPC_CONNECT => {
+                    println!("{} clients connected", i + 1);
+                },
+                demi_opcode_t::DEMI_OPC_FAILED => panic!("operation failed (qr_ret={:?})", qr.qr_ret),
+                qr_opcode => panic!("unexpected result (qr_opcode={:?})", qr_opcode),
+            }
+
+            // Close TCP socket.
+            self.libos.close(sockqd)?;
+        }
+
+        Ok(())
+    }
+
+    /// Attempts to close several connections concurrently.
+    pub fn run_concurrent(&mut self, nclients: usize) -> Result<()> {
+        let mut qds: Vec<QDesc> = Vec::default();
+        let mut qts: Vec<QToken> = Vec::default();
+        let mut qts_reverse: HashMap<QToken, QDesc> = HashMap::default();
+
+        // Open several connections.
+        for _ in 0..nclients {
+            // Create TCP socket.
+            let qd: QDesc = self.libos.socket(AF_INET, SOCK_STREAM, 0)?;
+            qds.push(qd);
+
+            // Connect TCP socket.
+            let qt: QToken = self.libos.connect(qd, self.remote)?;
+            qts_reverse.insert(qt, qd);
+            qts.push(qt);
+        }
+
+        // Wait for all connections to be established.
+        loop {
+            // Stop when enough connections were closed.
+            if self.clients_closed >= nclients {
+                break;
+            }
+
+            let qr: demi_qresult_t = {
+                let (index, qr): (usize, demi_qresult_t) = self.libos.wait_any(&qts, None)?;
+                let qt: QToken = qts.remove(index);
+                qts_reverse
+                    .remove(&qt)
+                    .ok_or(anyhow::anyhow!("unregistered queue token"))?;
+                qr
+            };
+
+            // Parse result.
+            match qr.qr_opcode {
+                demi_opcode_t::DEMI_OPC_CONNECT => {
+                    let qd: QDesc = qr.qr_qd.into();
+
+                    self.clients_connected += 1;
+                    println!("{} clients connected", self.clients_connected);
+
+                    // Close TCP socket.
+                    self.clients_closed += 1;
+                    self.libos.close(qd)?;
+                },
+                demi_opcode_t::DEMI_OPC_FAILED => panic!("operation failed (qr_ret={:?})", qr.qr_ret),
+                qr_opcode => panic!("unexpected result (qr_opcode={:?})", qr_opcode),
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/examples/tcp-close/main.rs
+++ b/examples/tcp-close/main.rs
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#![cfg_attr(feature = "strict", deny(warnings))]
+#![deny(clippy::all)]
+#![feature(drain_filter)]
+#![feature(hash_drain_filter)]
+
+//======================================================================================================================
+// Imports
+//======================================================================================================================
+
+mod args;
+mod client;
+mod server;
+mod standalone;
+
+use crate::{
+    args::ProgramArguments,
+    client::TcpClient,
+    server::TcpServer,
+};
+use anyhow::Result;
+use demikernel::{
+    LibOS,
+    LibOSName,
+};
+
+//======================================================================================================================
+// main
+//======================================================================================================================
+
+fn main() -> Result<()> {
+    let args: ProgramArguments = ProgramArguments::new(
+        "tcp-close",
+        "Pedro Henrique Penna <ppenna@microsoft.com>",
+        "Stress test for close() on tcp sockets.",
+    )?;
+
+    let mut libos: LibOS = {
+        let libos_name: LibOSName = LibOSName::from_env()?.into();
+        LibOS::new(libos_name)?
+    };
+
+    match args.run_mode().as_str() {
+        "sequential" | "concurrent" => match args.peer_type().expect("missing peer_type").as_str() {
+            "client" => {
+                let mut client: TcpClient = TcpClient::new(libos, args.addr())?;
+                let nclients: usize = args.nclients().expect("missing number of clients");
+                if args.run_mode().as_str() == "sequential" {
+                    client.run_sequential(nclients)
+                } else {
+                    client.run_concurrent(nclients)
+                }
+            },
+            "server" => {
+                let mut server: TcpServer = TcpServer::new(libos, args.addr())?;
+                server.run(args.nclients())
+            },
+            _ => anyhow::bail!("invalid peer type"),
+        },
+        "standalone" => standalone::run(&mut libos, &args.addr()),
+        _ => anyhow::bail!("invalid run mode"),
+    }
+}

--- a/examples/tcp-close/server.rs
+++ b/examples/tcp-close/server.rs
@@ -1,0 +1,263 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//======================================================================================================================
+// Imports
+//======================================================================================================================
+
+use anyhow::Result;
+use demikernel::{
+    demi_sgarray_t,
+    runtime::types::{
+        demi_opcode_t,
+        demi_qresult_t,
+    },
+    LibOS,
+    QDesc,
+    QToken,
+};
+use std::{
+    collections::{
+        HashMap,
+        HashSet,
+    },
+    net::SocketAddrV4,
+};
+
+//======================================================================================================================
+// Constants
+//======================================================================================================================
+
+#[cfg(target_os = "windows")]
+pub const AF_INET: i32 = windows::Win32::Networking::WinSock::AF_INET.0 as i32;
+
+#[cfg(target_os = "windows")]
+pub const SOCK_STREAM: i32 = windows::Win32::Networking::WinSock::SOCK_STREAM as i32;
+
+#[cfg(target_os = "linux")]
+pub const AF_INET: i32 = libc::AF_INET;
+
+#[cfg(target_os = "linux")]
+pub const SOCK_STREAM: i32 = libc::SOCK_STREAM;
+
+//======================================================================================================================
+// Structures
+//======================================================================================================================
+
+/// TCP Server
+pub struct TcpServer {
+    /// Underlying libOS.
+    libos: LibOS,
+    /// Local socket descriptor.
+    sockqd: QDesc,
+    /// Connected clients.
+    clients: HashSet<QDesc>,
+    /// Pending operations.
+    qts: Vec<QToken>,
+    /// Reverse mapping of pending operations.
+    qts_reverse: HashMap<QToken, QDesc>,
+    /// Number of accepted connections.
+    clients_accepted: usize,
+    /// Number of closed connections.
+    clients_closed: usize,
+}
+
+//======================================================================================================================
+// Associated Functions
+//======================================================================================================================
+
+impl TcpServer {
+    /// Creates a new TCP server.
+    pub fn new(mut libos: LibOS, local: SocketAddrV4) -> Result<Self> {
+        // Create TCP socket.
+        let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
+
+        // Bind to local address.
+        libos.bind(sockqd, local)?;
+
+        println!("Listening to: {:?}", local);
+
+        return Ok(Self {
+            libos,
+            sockqd,
+            clients: HashSet::default(),
+            qts: Vec::default(),
+            qts_reverse: HashMap::default(),
+            clients_accepted: 0,
+            clients_closed: 0,
+        });
+    }
+
+    /// Runs the target TCP server.
+    pub fn run(&mut self, nclients: Option<usize>) -> Result<()> {
+        // Mark socket as a passive one.
+        self.libos.listen(self.sockqd, nclients.unwrap_or(512))?;
+
+        // Accept first connection.
+        self.issue_accept()?;
+
+        loop {
+            // Stop when enough connections have been terminated.
+            if let Some(nclients) = nclients {
+                if self.clients_closed >= nclients {
+                    // Sanity check that all connections have been closed.
+                    assert_eq!(
+                        self.clients.len(),
+                        0,
+                        "there should be no clients connected, but there are"
+                    );
+                    break;
+                }
+            }
+
+            let qr: demi_qresult_t = {
+                let (index, qr): (usize, demi_qresult_t) = self.libos.wait_any(&self.qts, None)?;
+                self.mark_completed_operation(index)?;
+                qr
+            };
+
+            // Parse result.
+            match qr.qr_opcode {
+                // Accept completed.
+                demi_opcode_t::DEMI_OPC_ACCEPT => {
+                    let qd: QDesc = unsafe { qr.qr_value.ares.qd.into() };
+
+                    // Handles the completion of an accept() operation.
+                    self.handle_connection_establishment(qd)?;
+
+                    // Accept more connections.
+                    self.issue_accept()?;
+                },
+                // Pop completed.
+                demi_opcode_t::DEMI_OPC_POP => {
+                    let qd: QDesc = qr.qr_qd.into();
+                    let sga: demi_sgarray_t = unsafe { qr.qr_value.sga };
+
+                    // Ensure that client has closed the connection.
+                    assert_eq!(
+                        sga.sga_segs[0].sgaseg_len, 0,
+                        "client must have had closed the connection, but it has not"
+                    );
+
+                    self.libos.sgafree(sga)?;
+
+                    // Handle connection termination.
+                    let qts_cancelled: Vec<QToken> = self.handle_connection_termination(qd)?;
+
+                    // Ensure that the client has no pending operations.
+                    assert!(
+                        qts_cancelled.is_empty(),
+                        "client should not have any pending operations, but it has"
+                    );
+                },
+                demi_opcode_t::DEMI_OPC_FAILED => {
+                    let qd: QDesc = qr.qr_qd.into();
+                    let errno: i32 = qr.qr_ret;
+
+                    // Ensure that this error was triggered because
+                    // the client has terminated the connection.
+                    assert_eq!(
+                        errno,
+                        libc::ECONNRESET,
+                        "client should have had terminated the connection, but it has not"
+                    );
+
+                    // Handle connection termination.
+                    let _: Vec<QToken> = self.handle_connection_termination(qd)?;
+                },
+                _ => panic!("unexpected result"),
+            }
+        }
+
+        // Close local socket.
+        self.libos.close(self.sockqd)?;
+
+        Ok(())
+    }
+
+    /// Registers a client.
+    fn register_client(&mut self, qd: QDesc) {
+        assert_eq!(
+            self.clients.insert(qd),
+            true,
+            "client is already registered and it shouldn't be"
+        );
+    }
+
+    /// Unregisters a client.
+    fn unregister_client(&mut self, qd: QDesc) {
+        assert_eq!(
+            self.clients.remove(&qd),
+            true,
+            "client isn't registered and it should be"
+        );
+    }
+
+    /// Cancels all pending operations of a given connection.
+    fn cancel_pending_operations(&mut self, qd: QDesc) -> Vec<QToken> {
+        let qts_drained: HashMap<QToken, QDesc> = self.qts_reverse.drain_filter(|_k, v| *v == qd).collect();
+        let qts_dropped: Vec<QToken> = self.qts.drain_filter(|x| qts_drained.contains_key(x)).collect();
+        qts_dropped
+    }
+
+    /// Marks an operation as completed.
+    fn mark_completed_operation(&mut self, index: usize) -> Result<()> {
+        let qt: QToken = self.qts.remove(index);
+        self.qts_reverse
+            .remove(&qt)
+            .ok_or(anyhow::anyhow!("unregistered queue token"))?;
+        Ok(())
+    }
+
+    /// Issues an accept() operation.
+    fn issue_accept(&mut self) -> Result<()> {
+        let qt: QToken = self.libos.accept(self.sockqd)?;
+        self.qts_reverse.insert(qt, self.sockqd);
+        self.qts.push(qt);
+        Ok(())
+    }
+
+    /// Issues a pop() operation.
+    fn issue_pop(&mut self, qd: QDesc) -> Result<()> {
+        let qt: QToken = self.libos.pop(qd)?;
+        self.qts_reverse.insert(qt, qd);
+        self.qts.push(qt);
+        Ok(())
+    }
+
+    /// Issues a close() operation.
+    fn issue_close(&mut self, qd: QDesc) -> Result<()> {
+        Ok(self.libos.close(qd)?)
+    }
+
+    /// Handles the completion of an accept() operation.
+    fn handle_connection_establishment(&mut self, qd: QDesc) -> Result<()> {
+        // Register client.
+        self.register_client(qd);
+
+        // Pop first packet from this connection.
+        self.issue_pop(qd)?;
+
+        self.clients_accepted += 1;
+        println!("{} clients accepted", self.clients_accepted);
+
+        Ok(())
+    }
+
+    /// Handles a connection termination.
+    fn handle_connection_termination(&mut self, qd: QDesc) -> Result<Vec<QToken>> {
+        // Cancel any pending operations that the client has.
+        let qts_cancelled: Vec<QToken> = self.cancel_pending_operations(qd);
+
+        // Unregister client.
+        self.unregister_client(qd);
+
+        // Close TCP socket.
+        self.issue_close(qd)?;
+
+        self.clients_closed += 1;
+        println!("{} clients closed", self.clients_closed);
+
+        Ok(qts_cancelled)
+    }
+}

--- a/examples/tcp-close/standalone.rs
+++ b/examples/tcp-close/standalone.rs
@@ -1,0 +1,194 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//======================================================================================================================
+// Imports
+//======================================================================================================================
+
+use anyhow::Result;
+use demikernel::{
+    runtime::fail::Fail,
+    LibOS,
+    QDesc,
+    QToken,
+};
+use std::{
+    net::SocketAddrV4,
+    time::Duration,
+};
+
+//======================================================================================================================
+// Constants
+//======================================================================================================================
+
+#[cfg(target_os = "windows")]
+pub const AF_INET: i32 = windows::Win32::Networking::WinSock::AF_INET.0 as i32;
+
+#[cfg(target_os = "windows")]
+pub const SOCK_STREAM: i32 = windows::Win32::Networking::WinSock::SOCK_STREAM as i32;
+
+#[cfg(target_os = "linux")]
+pub const AF_INET: i32 = libc::AF_INET;
+
+#[cfg(target_os = "linux")]
+pub const SOCK_STREAM: i32 = libc::SOCK_STREAM;
+
+//======================================================================================================================
+// run_self()
+//======================================================================================================================
+
+/// Runs self tests.
+pub fn run(libos: &mut LibOS, addr: &SocketAddrV4) -> Result<()> {
+    println!("close() an invalid socket...");
+    close_invalid_socket(libos)?;
+    println!("close() a socket multiple times...");
+    close_socket_twice(libos)?;
+    println!("close() a socket that is not bound...");
+    close_unbound_socket(libos)?;
+    println!("close() a socket that is bound...");
+    close_bound_socket(libos, addr)?;
+    println!("close() a socket that is listening...");
+    close_listening_socket(libos, addr)?;
+    println!("close() a socket that is accepting...");
+    close_accepting_socket(libos, addr)?;
+    println!("close() a socket that is connecting...");
+    close_connecting_socket(libos, addr)?;
+
+    Ok(())
+}
+
+//======================================================================================================================
+// close_invalid_socket()
+//======================================================================================================================
+
+/// Attempts to close an invalid socket.
+fn close_invalid_socket(libos: &mut LibOS) -> Result<()> {
+    // Fail to close socket.
+    let e: Fail = libos
+        .close(QDesc::from(0))
+        .expect_err("close() an invalid socket should fail");
+
+    // Sanity check error code.
+    assert_eq!(e.errno, libc::EBADF, "close() failed with {}", e.cause);
+
+    Ok(())
+}
+
+//======================================================================================================================
+// close_socket_twice()
+//======================================================================================================================
+
+/// Attempts to close a socket multiple times.
+fn close_socket_twice(libos: &mut LibOS) -> Result<()> {
+    // Create an unbound socket.
+    let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
+
+    // Succeed to close socket.
+    libos.close(sockqd)?;
+
+    // Fail to close socket.
+    let e: Fail = libos
+        .close(QDesc::from(0))
+        .expect_err("close() a socket twice should fail");
+
+    // Sanity check error code.
+    assert_eq!(e.errno, libc::EBADF, "close() failed with {}", e.cause);
+
+    Ok(())
+}
+
+//======================================================================================================================
+// close_unbound_socket()
+//======================================================================================================================
+
+/// Attempts to close a socket that is not bound.
+fn close_unbound_socket(libos: &mut LibOS) -> Result<()> {
+    // Create an unbound socket.
+    let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
+
+    // Succeed to close socket.
+    libos.close(sockqd)?;
+
+    Ok(())
+}
+
+//======================================================================================================================
+// close_bound_socket()
+//======================================================================================================================
+
+/// Attempts to close a socket that is bound.
+fn close_bound_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()> {
+    // Create a bound socket.
+    let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
+    libos.bind(sockqd, *local)?;
+
+    // Succeed to close socket.
+    libos.close(sockqd)?;
+
+    Ok(())
+}
+
+//======================================================================================================================
+// close_listening_socket()
+//======================================================================================================================
+
+/// Attempts to close a socket that is listening.
+fn close_listening_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()> {
+    // Create a listening socket.
+    let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
+    libos.bind(sockqd, *local)?;
+    libos.listen(sockqd, 16)?;
+
+    // Succeed to close socket.
+    libos.close(sockqd)?;
+
+    Ok(())
+}
+
+//======================================================================================================================
+// close_accepting_socket()
+//======================================================================================================================
+
+/// Attempts to close a socket that is accepting.
+fn close_accepting_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()> {
+    // Create an accepting socket.
+    let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
+    libos.bind(sockqd, *local)?;
+    libos.listen(sockqd, 16)?;
+    let qt: QToken = libos.accept(sockqd)?;
+
+    // Poll once to ensure that the accept() co-routine runs.
+    match libos.wait(qt, Some(Duration::from_micros(0))) {
+        Err(e) if e.errno == libc::ETIMEDOUT => {},
+        Ok(_) => anyhow::bail!("wait() should not succeed"),
+        Err(_) => anyhow::bail!("wait() should timeout"),
+    }
+
+    // Succeed to close socket.
+    libos.close(sockqd)?;
+
+    Ok(())
+}
+
+//======================================================================================================================
+// close_connecting_socket()
+//======================================================================================================================
+
+/// Attempts to close a socket that is connecting.
+fn close_connecting_socket(libos: &mut LibOS, remote: &SocketAddrV4) -> Result<()> {
+    // Create a connecting socket.
+    let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
+    let qt: QToken = libos.connect(sockqd, *remote)?;
+
+    // Poll once to ensure that the connect() co-routine runs.
+    match libos.wait(qt, Some(Duration::from_micros(0))) {
+        Err(e) if e.errno == libc::ETIMEDOUT => {},
+        Ok(_) => anyhow::bail!("wait() should not succeed"),
+        Err(_) => anyhow::bail!("wait() should timeout"),
+    }
+
+    // Succeed to close socket.
+    libos.close(sockqd)?;
+
+    Ok(())
+}


### PR DESCRIPTION
## Description

This PR closes https://github.com/demikernel/demikernel/issues/526

## Summary of Changes

- Added a standalone test that attempts to close an invalid socket.
- Added a standalone test that attempts to close a TCP socket that is not bound.
- Added a standalone test that attempts to close a TCP socket that is bound.
- Added a standalone test that attempts to close a TCP socket that is listening.
- Added a standalone test that attempts to close a TCP socket that is accepting.
- Added a standalone test that attempts to close a TCP socket that is connecting.
- Added a test that attempts to close a TCP socket that is connected.

## How to Run this Test Program

```bash
export CONFIG_PATH=$HOME/config.yaml
export LIBOS=catnap|catcollar|catloop|catpowder|catnip

# Standalone
./bin/examples/rust/tcp-close.elf --address 127.0.0.1:12345 --run-mode standalone

# Sequential Mode
./bin/examples/rust/tcp-close.elf --address 10.9.1.17:12345 --run-mode sequential --peer client --nclients 128
./bin/examples/rust/tcp-close.elf --address 10.9.1.17:12345 --run-mode sequential --peer server --nclients 128

# Concurrent Mode
./bin/examples/rust/tcp-close.elf --address 10.9.1.17:12345 --run-mode concurrent --peer client --nclients 128
./bin/examples/rust/tcp-close.elf --address 10.9.1.17:12345 --run-mode concurrent --peer server --nclients 128
```

## Run Report

| LibOS     | `run-mode=standalone` | `run-mode=sequential` | `run-mode=concurrent` |
|-----------|------------|------------|------------|
| Catnap    | passed     | passed     | passed     |
| Catcollar | passed     | passed     | passed     |
| Catloop   | FAILED          | passed     | passed     |
| Catpowder | FAILED     | FAILED     | FAILED     |
| Catnip    | FAILED     | FAILED     | FAILED     |