### PR TITLE
[catnip] Append an empty string at eal_init args to be skipped

### DIFF
--- a/scripts/config/default.yaml
+++ b/scripts/config/default.yaml
@@ -23,6 +23,6 @@ catnip:
     "ff:ff:ff:ff:ff:ff": "XX.XX.XX.XX"
     "ff:ff:ff:ff:ff:ff": "YY.YY.YY.YY"
 dpdk:
-  eal_init: ["-c", "0xff", "-n", "4", "-a", "WW:WW.W","--proc-type=auto"]
+  eal_init: ["", "-c", "0xff", "-n", "4", "-a", "WW:WW.W","--proc-type=auto"]
 
 # vim: set tabstop=2 shiftwidth=2


### PR DESCRIPTION
# Description
This PR solves https://github.com/demikernel/demikernel/issues/536

# Summary of Changes
Just append an empty string to `eal_init` in the `default.yaml` configuration file.