### PR TITLE
[test] Integration Tests for TCP

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,11 @@ crate-type = ["cdylib", "rlib"]
 path = "src/rust/lib.rs"
 
 [[test]]
+name = "tcp-test"
+path = "tests/rust/tcp-test/main.rs"
+harness = false
+
+[[test]]
 name = "tcp"
 path = "tests/rust/tcp.rs"
 

--- a/linux.mk
+++ b/linux.mk
@@ -209,3 +209,7 @@ test-unit-rust:
 	$(CARGO) test --test sga $(BUILD) $(CARGO_FEATURES) -- --nocapture --test-threads=1 test_unit_sga_alloc_free_single_big
 	$(CARGO) test --test sga $(BUILD) $(CARGO_FEATURES) -- --nocapture --test-threads=1 test_unit_sga_alloc_free_loop_tight_big
 	$(CARGO) test --test sga $(BUILD) $(CARGO_FEATURES) -- --nocapture --test-threads=1 test_unit_sga_alloc_free_loop_decoupled_big
+
+# Runs Rust integration tests.
+test-integration-rust:
+	$(CARGO) test --test tcp-test $(CARGO_FLAGS) $(CARGO_FEATURES) -- $(ARGS)

--- a/tests/rust/tcp-test/accept/mod.rs
+++ b/tests/rust/tcp-test/accept/mod.rs
@@ -1,0 +1,193 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//======================================================================================================================
+// Imports
+//======================================================================================================================
+
+use anyhow::Result;
+use demikernel::{
+    runtime::fail::Fail,
+    LibOS,
+    QDesc,
+    QToken,
+};
+use std::{
+    net::SocketAddrV4,
+    time::Duration,
+};
+
+//======================================================================================================================
+// Constants
+//======================================================================================================================
+
+#[cfg(target_os = "windows")]
+pub const AF_INET: i32 = windows::Win32::Networking::WinSock::AF_INET.0 as i32;
+
+#[cfg(target_os = "windows")]
+pub const SOCK_STREAM: i32 = windows::Win32::Networking::WinSock::SOCK_STREAM as i32;
+
+#[cfg(target_os = "linux")]
+pub const AF_INET: i32 = libc::AF_INET;
+
+#[cfg(target_os = "linux")]
+pub const SOCK_STREAM: i32 = libc::SOCK_STREAM;
+
+//======================================================================================================================
+// Standalone Functions
+//======================================================================================================================
+
+/// Runs standalone tests.
+pub fn run(libos: &mut LibOS, addr: &SocketAddrV4) -> Result<()> {
+    accept_invalid_queue_descriptor(libos)?;
+    accept_unbound_socket(libos)?;
+    accept_active_socket(libos, addr)?;
+    accept_listening_socket(libos, addr)?;
+    accept_connecting_socket(libos, addr)?;
+    accept_accepting_socket(libos, addr)?;
+
+    Ok(())
+}
+
+/// Attempts to accept connections on an invalid queue descriptor.
+fn accept_invalid_queue_descriptor(libos: &mut LibOS) -> Result<()> {
+    println!("{}", stringify!(accept_invalid_socket));
+
+    // Fail to accept() connections.
+    let e: Fail = libos
+        .accept(QDesc::from(0))
+        .expect_err("accept() connections on an invalid socket should fail");
+
+    // Sanity check error code.
+    assert_eq!(e.errno, libc::EBADF, "accept() failed with {}", e.cause);
+
+    Ok(())
+}
+
+/// Attempts to accept connections on a TCP socket that is not bound.
+fn accept_unbound_socket(libos: &mut LibOS) -> Result<()> {
+    println!("{}", stringify!(accept_unbound_socket));
+
+    // Create an unbound socket.
+    let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
+
+    // Fail to accept() connections.
+    let e: Fail = libos
+        .accept(sockqd)
+        .expect_err("accept() connections on a socket that is not bound should fail");
+
+    // Sanity check error code.
+    assert_eq!(e.errno, libc::EINVAL, "accept() failed with {}", e.cause);
+
+    // Succeed to close socket.
+    libos.close(sockqd)?;
+
+    Ok(())
+}
+
+/// Attempts to accept connections on a TCP socket that is not listening.
+fn accept_active_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()> {
+    println!("{}", stringify!(accept_active_socket));
+
+    // Create a bound socket.
+    let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
+    libos.bind(sockqd, local.to_owned())?;
+
+    // Fail to accept() connections.
+    let e: Fail = libos
+        .accept(sockqd)
+        .expect_err("accept() connections on a socket that is not listening should fail");
+
+    // Sanity check error code.
+    assert_eq!(e.errno, libc::EINVAL, "accept() failed with {}", e.cause);
+
+    // Succeed to close socket.
+    libos.close(sockqd)?;
+
+    Ok(())
+}
+
+/// Attempts to accept connections on a TCP socket that is listening.
+fn accept_listening_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()> {
+    println!("{}", stringify!(accept_listening_socket));
+
+    // Create an accepting socket.
+    let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
+    libos.bind(sockqd, local.to_owned())?;
+    libos.listen(sockqd, 16)?;
+
+    // Succeed to accept() connections.
+    let qt: QToken = libos.accept(sockqd)?;
+
+    // Poll once to ensure that the accept() co-routine runs.
+    match libos.wait(qt, Some(Duration::from_micros(0))) {
+        Err(e) if e.errno == libc::ETIMEDOUT => {},
+        Ok(_) => anyhow::bail!("wait() should not succeed"),
+        Err(_) => anyhow::bail!("wait() should timeout"),
+    }
+
+    // Succeed to close socket.
+    libos.close(sockqd)?;
+
+    Ok(())
+}
+
+/// Attempts to accept connections on a TCP socket that is connecting.
+fn accept_connecting_socket(libos: &mut LibOS, remote: &SocketAddrV4) -> Result<()> {
+    println!("{}", stringify!(accept_connecting_socket));
+
+    // Create a connecting socket.
+    let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
+    let qt: QToken = libos.connect(sockqd, remote.to_owned())?;
+
+    // Poll once to ensure that the connect() co-routine runs.
+    match libos.wait(qt, Some(Duration::from_micros(0))) {
+        Err(e) if e.errno == libc::ETIMEDOUT => {},
+        Ok(_) => anyhow::bail!("wait() should not succeed"),
+        Err(_) => anyhow::bail!("wait() should timeout"),
+    }
+
+    // Fail to accept() connections.
+    let e: Fail = libos
+        .accept(sockqd)
+        .expect_err("accept() connections on a socket that is connecting should fail");
+
+    // Sanity check error code.
+    assert_eq!(e.errno, libc::EINVAL, "accept() failed with {}", e.cause);
+
+    // Succeed to close socket.
+    libos.close(sockqd)?;
+
+    Ok(())
+}
+
+/// Attempts to accept connections on a TCP socket that is already accepting connections.
+fn accept_accepting_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()> {
+    println!("{}", stringify!(accept_accepting_socket));
+
+    // Create an accepting socket.
+    let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
+    libos.bind(sockqd, local.to_owned())?;
+    libos.listen(sockqd, 16)?;
+    let qt: QToken = libos.accept(sockqd)?;
+
+    // Poll once to ensure that the accept() co-routine runs.
+    match libos.wait(qt, Some(Duration::from_micros(0))) {
+        Err(e) if e.errno == libc::ETIMEDOUT => {},
+        Ok(_) => anyhow::bail!("wait() should not succeed"),
+        Err(_) => anyhow::bail!("wait() should timeout"),
+    }
+
+    // Fail to accept() connections.
+    let e: Fail = libos
+        .accept(sockqd)
+        .expect_err("accept() connections on a socket that is accepting connections should fail");
+
+    // Sanity check error code.
+    assert_eq!(e.errno, libc::EINPROGRESS, "accept() failed with {}", e.cause);
+
+    // Succeed to close socket.
+    libos.close(sockqd)?;
+
+    Ok(())
+}

--- a/tests/rust/tcp-test/args.rs
+++ b/tests/rust/tcp-test/args.rs
@@ -6,7 +6,15 @@
 //======================================================================================================================
 
 use anyhow::Result;
-use clap::Command;
+use clap::{
+    Arg,
+    ArgMatches,
+    Command,
+};
+use std::{
+    net::SocketAddrV4,
+    str::FromStr,
+};
 
 //======================================================================================================================
 // Program Arguments
@@ -14,13 +22,38 @@ use clap::Command;
 
 /// Program Arguments
 #[derive(Debug)]
-pub struct ProgramArguments {}
+pub struct ProgramArguments {
+    /// Address of local.
+    local: SocketAddrV4,
+}
 
 impl ProgramArguments {
     /// Parses the program arguments from the command line interface.
     pub fn new(app_name: &'static str, app_author: &'static str, app_about: &'static str) -> Result<Self> {
-        Command::new(app_name).author(app_author).about(app_about).get_matches();
+        let matches: ArgMatches = Command::new(app_name)
+            .author(app_author)
+            .about(app_about)
+            .arg(
+                Arg::new("local")
+                    .long("local-address")
+                    .value_parser(clap::value_parser!(String))
+                    .required(true)
+                    .value_name("ADDRESS:PORT")
+                    .help("Sets the address of local socket"),
+            )
+            .get_matches();
 
-        Ok(Self {})
+        // Address of local socket.
+        let local: SocketAddrV4 = {
+            let local: &String = matches.get_one::<String>("local").expect("missing address");
+            SocketAddrV4::from_str(local)?
+        };
+
+        Ok(Self { local})
+    }
+
+    /// Returns the `local` command line argument.
+    pub fn local(&self) -> SocketAddrV4 {
+        self.local
     }
 }

--- a/tests/rust/tcp-test/args.rs
+++ b/tests/rust/tcp-test/args.rs
@@ -25,6 +25,8 @@ use std::{
 pub struct ProgramArguments {
     /// Address of local.
     local: SocketAddrV4,
+    /// Address of remote socket.
+    remote: SocketAddrV4,
 }
 
 impl ProgramArguments {
@@ -41,6 +43,14 @@ impl ProgramArguments {
                     .value_name("ADDRESS:PORT")
                     .help("Sets the address of local socket"),
             )
+            .arg(
+                Arg::new("remote")
+                    .long("remote-address")
+                    .value_parser(clap::value_parser!(String))
+                    .required(true)
+                    .value_name("ADDRESS:PORT")
+                    .help("Sets the address of remote socket"),
+            )
             .get_matches();
 
         // Address of local socket.
@@ -49,11 +59,22 @@ impl ProgramArguments {
             SocketAddrV4::from_str(local)?
         };
 
-        Ok(Self { local})
+        // Address of remote socket.
+        let remote: SocketAddrV4 = {
+            let remote: &String = matches.get_one::<String>("remote").expect("missing address");
+            SocketAddrV4::from_str(remote)?
+        };
+
+        Ok(Self { local, remote })
     }
 
     /// Returns the `local` command line argument.
     pub fn local(&self) -> SocketAddrV4 {
         self.local
+    }
+
+    /// Returns the `remote` command line argument.
+    pub fn remote(&self) -> SocketAddrV4 {
+        self.remote
     }
 }

--- a/tests/rust/tcp-test/args.rs
+++ b/tests/rust/tcp-test/args.rs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//======================================================================================================================
+// Imports
+//======================================================================================================================
+
+use anyhow::Result;
+use clap::Command;
+
+//======================================================================================================================
+// Program Arguments
+//======================================================================================================================
+
+/// Program Arguments
+#[derive(Debug)]
+pub struct ProgramArguments {}
+
+impl ProgramArguments {
+    /// Parses the program arguments from the command line interface.
+    pub fn new(app_name: &'static str, app_author: &'static str, app_about: &'static str) -> Result<Self> {
+        Command::new(app_name).author(app_author).about(app_about).get_matches();
+
+        Ok(Self {})
+    }
+}

--- a/tests/rust/tcp-test/bind/mod.rs
+++ b/tests/rust/tcp-test/bind/mod.rs
@@ -1,0 +1,162 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//======================================================================================================================
+// Imports
+//======================================================================================================================
+
+use anyhow::Result;
+use demikernel::{
+    runtime::fail::Fail,
+    LibOS,
+    QDesc,
+};
+use std::net::{
+    Ipv4Addr,
+    SocketAddrV4,
+};
+
+//======================================================================================================================
+// Constants
+//======================================================================================================================
+
+#[cfg(target_os = "windows")]
+pub const AF_INET: i32 = windows::Win32::Networking::WinSock::AF_INET.0 as i32;
+
+#[cfg(target_os = "windows")]
+pub const SOCK_STREAM: i32 = windows::Win32::Networking::WinSock::SOCK_STREAM as i32;
+
+#[cfg(target_os = "linux")]
+pub const AF_INET: i32 = libc::AF_INET;
+
+#[cfg(target_os = "linux")]
+pub const SOCK_STREAM: i32 = libc::SOCK_STREAM;
+
+//======================================================================================================================
+// Standalone Functions
+//======================================================================================================================
+
+/// Drives integration tests for bind() on TCP sockets.
+pub fn run(libos: &mut LibOS, ipv4: &Ipv4Addr) -> Result<()> {
+    bind_addr_to_invalid_queue_descriptor(libos, ipv4)?;
+    bind_multiple_addresses_to_same_socket(libos, ipv4)?;
+    bind_same_address_to_two_sockets(libos, ipv4)?;
+    bind_to_private_ports(libos, ipv4)?;
+
+    Ok(())
+}
+
+/// Attempts to bind an address to an invalid queue_descriptor.
+fn bind_addr_to_invalid_queue_descriptor(libos: &mut LibOS, ipv4: &Ipv4Addr) -> Result<()> {
+    println!("{}", stringify!(bind_addr_to_invalid_queue_descriptor));
+
+    // Bind address.
+    let addr: SocketAddrV4 = {
+        let http_port: u16 = 6379;
+        SocketAddrV4::new(*ipv4, http_port)
+    };
+
+    // Fail to bind socket.
+    let e: Fail = libos
+        .bind(QDesc::from(0), addr)
+        .expect_err("bind() an address to an invalid queue descriptor should fail");
+
+    // Sanity check error code.
+    assert_eq!(e.errno, libc::EBADF, "bind() failed with {}", e.cause);
+
+    Ok(())
+}
+
+/// Attempts to bind multiple addresses to the same socket.
+fn bind_multiple_addresses_to_same_socket(libos: &mut LibOS, ipv4: &Ipv4Addr) -> Result<()> {
+    println!("{}", stringify!(bind_multiple_addresses_to_same_socket));
+
+    // Create a TCP socket.
+    let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
+
+    // Bind address.
+    let addr: SocketAddrV4 = {
+        let any_port: u16 = 6739;
+        SocketAddrV4::new(*ipv4, any_port)
+    };
+
+    // Bind socket.
+    libos.bind(sockqd, addr)?;
+
+    // Bind address.
+    let addr: SocketAddrV4 = {
+        let any_port: u16 = 6780;
+        SocketAddrV4::new(*ipv4, any_port)
+    };
+
+    // Fail to bind socket.
+    let e: Fail = libos
+        .bind(sockqd, addr)
+        .expect_err("bind() a socket multiple times should fail");
+
+    // Sanity check error code.
+    assert_eq!(e.errno, libc::EINVAL, "bind() failed with {}", e.cause);
+
+    // Close socket.
+    libos.close(sockqd)?;
+
+    Ok(())
+}
+
+/// Attempts to bind the same address to two sockets.
+fn bind_same_address_to_two_sockets(libos: &mut LibOS, ipv4: &Ipv4Addr) -> Result<()> {
+    println!("{}", stringify!(bind_same_address_to_two_sockets));
+
+    // Create two TCP sockets.
+    let sockqd1: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
+    let sockqd2: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
+
+    // Bind address.
+    let addr: SocketAddrV4 = {
+        let http_port: u16 = 8080;
+        SocketAddrV4::new(*ipv4, http_port)
+    };
+
+    // Bind first socket.
+    libos.bind(sockqd1, addr)?;
+
+    // Fail to bind second socket.
+    let e: Fail = libos
+        .bind(sockqd2, addr)
+        .expect_err("bind() the same address to two sockets should fail");
+
+    // Sanity check error code.
+    assert_eq!(e.errno, libc::EADDRINUSE, "bind() failed with {}", e.cause);
+
+    // Close sockets.
+    libos.close(sockqd1)?;
+    libos.close(sockqd2)?;
+
+    Ok(())
+}
+
+/// Attempts to bind to all private ports.
+fn bind_to_private_ports(libos: &mut LibOS, ipv4: &Ipv4Addr) -> Result<()> {
+    println!("{}", stringify!(bind_to_private_ports));
+
+    // Traverse all ports in the private range.
+    for port in 49152..65535 {
+        // Create a TCP socket.
+        let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
+
+        // Bind socket.
+        let addr: SocketAddrV4 = SocketAddrV4::new(*ipv4, port);
+        match libos.bind(sockqd, addr) {
+            Ok(()) => {},
+            Err(e) => {
+                // Sanity check error code.
+                assert_eq!(e.errno, libc::EADDRINUSE, "bind() failed with {}", e.cause);
+            },
+        };
+
+        // Close socket.
+        libos.close(sockqd)?;
+    }
+
+    Ok(())
+}

--- a/tests/rust/tcp-test/close/mod.rs
+++ b/tests/rust/tcp-test/close/mod.rs
@@ -1,0 +1,173 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//======================================================================================================================
+// Imports
+//======================================================================================================================
+
+use anyhow::Result;
+use demikernel::{
+    runtime::fail::Fail,
+    LibOS,
+    QDesc,
+    QToken,
+};
+use std::{
+    net::SocketAddrV4,
+    time::Duration,
+};
+
+//======================================================================================================================
+// Constants
+//======================================================================================================================
+
+#[cfg(target_os = "windows")]
+pub const AF_INET: i32 = windows::Win32::Networking::WinSock::AF_INET.0 as i32;
+
+#[cfg(target_os = "windows")]
+pub const SOCK_STREAM: i32 = windows::Win32::Networking::WinSock::SOCK_STREAM as i32;
+
+#[cfg(target_os = "linux")]
+pub const AF_INET: i32 = libc::AF_INET;
+
+#[cfg(target_os = "linux")]
+pub const SOCK_STREAM: i32 = libc::SOCK_STREAM;
+
+//======================================================================================================================
+// Standalone Functions
+//======================================================================================================================
+
+/// Drives integration tests for close() on TCP sockets.
+pub fn run(libos: &mut LibOS, addr: &SocketAddrV4) -> Result<()> {
+    close_invalid_queue_descriptor(libos)?;
+    close_socket_twice(libos)?;
+    close_unbound_socket(libos)?;
+    close_bound_socket(libos, addr)?;
+    close_listening_socket(libos, addr)?;
+    close_accepting_socket(libos, addr)?;
+    close_connecting_socket(libos, addr)?;
+
+    Ok(())
+}
+
+/// Attempts to close an invalid queue descriptor.
+fn close_invalid_queue_descriptor(libos: &mut LibOS) -> Result<()> {
+    println!("{}", stringify!(close_invalid_queue_descriptor));
+
+    // Fail to close socket.
+    let e: Fail = libos
+        .close(QDesc::from(0))
+        .expect_err("close() an invalid socket should fail");
+
+    // Sanity check error code.
+    assert_eq!(e.errno, libc::EBADF, "close() failed with {}", e.cause);
+
+    Ok(())
+}
+
+/// Attempts to close a TCP socket multiple times.
+fn close_socket_twice(libos: &mut LibOS) -> Result<()> {
+    println!("{}", stringify!(close_socket_twice));
+
+    // Create an unbound socket.
+    let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
+
+    // Succeed to close socket.
+    libos.close(sockqd)?;
+
+    // Fail to close socket.
+    let e: Fail = libos
+        .close(QDesc::from(0))
+        .expect_err("close() a socket twice should fail");
+
+    // Sanity check error code.
+    assert_eq!(e.errno, libc::EBADF, "close() failed with {}", e.cause);
+
+    Ok(())
+}
+
+/// Attempts to close a TCP socket that is not bound.
+fn close_unbound_socket(libos: &mut LibOS) -> Result<()> {
+    println!("{}", stringify!(close_unbound_socket));
+
+    // Create an unbound socket.
+    let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
+
+    // Succeed to close socket.
+    libos.close(sockqd)?;
+
+    Ok(())
+}
+
+/// Attempts to close a TCP socket that is bound.
+fn close_bound_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()> {
+    println!("{}", stringify!(close_bound_socket));
+
+    // Create a bound socket.
+    let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
+    libos.bind(sockqd, *local)?;
+
+    // Succeed to close socket.
+    libos.close(sockqd)?;
+
+    Ok(())
+}
+
+/// Attempts to close a TCP socket that is listening.
+fn close_listening_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()> {
+    println!("{}", stringify!(close_listening_socket));
+
+    // Create a listening socket.
+    let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
+    libos.bind(sockqd, *local)?;
+    libos.listen(sockqd, 16)?;
+
+    // Succeed to close socket.
+    libos.close(sockqd)?;
+
+    Ok(())
+}
+
+/// Attempts to close a TCP socket that is accepting.
+fn close_accepting_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()> {
+    println!("{}", stringify!(close_accepting_socket));
+
+    // Create an accepting socket.
+    let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
+    libos.bind(sockqd, *local)?;
+    libos.listen(sockqd, 16)?;
+    let qt: QToken = libos.accept(sockqd)?;
+
+    // Poll once to ensure that the accept() co-routine runs.
+    match libos.wait(qt, Some(Duration::from_micros(0))) {
+        Err(e) if e.errno == libc::ETIMEDOUT => {},
+        Ok(_) => anyhow::bail!("wait() should not succeed"),
+        Err(_) => anyhow::bail!("wait() should timeout"),
+    }
+
+    // Succeed to close socket.
+    libos.close(sockqd)?;
+
+    Ok(())
+}
+
+/// Attempts to close a TCP socket that is connecting.
+fn close_connecting_socket(libos: &mut LibOS, remote: &SocketAddrV4) -> Result<()> {
+    println!("{}", stringify!(close_connecting_socket));
+
+    // Create a connecting socket.
+    let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
+    let qt: QToken = libos.connect(sockqd, *remote)?;
+
+    // Poll once to ensure that the connect() co-routine runs.
+    match libos.wait(qt, Some(Duration::from_micros(0))) {
+        Err(e) if e.errno == libc::ETIMEDOUT => {},
+        Ok(_) => anyhow::bail!("wait() should not succeed"),
+        Err(_) => anyhow::bail!("wait() should timeout"),
+    }
+
+    // Succeed to close socket.
+    libos.close(sockqd)?;
+
+    Ok(())
+}

--- a/tests/rust/tcp-test/connect/mod.rs
+++ b/tests/rust/tcp-test/connect/mod.rs
@@ -1,0 +1,170 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//======================================================================================================================
+// Imports
+//======================================================================================================================
+
+use anyhow::Result;
+use demikernel::{
+    runtime::fail::Fail,
+    LibOS,
+    QDesc,
+    QToken,
+};
+use std::{
+    net::SocketAddrV4,
+    time::Duration,
+};
+
+//======================================================================================================================
+// Constants
+//======================================================================================================================
+
+#[cfg(target_os = "windows")]
+pub const AF_INET: i32 = windows::Win32::Networking::WinSock::AF_INET.0 as i32;
+
+#[cfg(target_os = "windows")]
+pub const SOCK_STREAM: i32 = windows::Win32::Networking::WinSock::SOCK_STREAM as i32;
+
+#[cfg(target_os = "linux")]
+pub const AF_INET: i32 = libc::AF_INET;
+
+#[cfg(target_os = "linux")]
+pub const SOCK_STREAM: i32 = libc::SOCK_STREAM;
+
+//======================================================================================================================
+// Standalone Functions
+//======================================================================================================================
+
+/// Drives integration tests for connect() on TCP sockets.
+pub fn run(libos: &mut LibOS, local: &SocketAddrV4, remote: &SocketAddrV4) -> Result<()> {
+    connect_invalid_queue_descriptor(libos, remote)?;
+    connect_unbound_socket(libos, remote)?;
+    connect_listening_socket(libos, local, remote)?;
+    connect_connecting_socket(libos, remote)?;
+    connect_accepting_socket(libos, local, remote)?;
+
+    Ok(())
+}
+
+/// Attempts to connect an invalid queue descriptor.
+fn connect_invalid_queue_descriptor(libos: &mut LibOS, remote: &SocketAddrV4) -> Result<()> {
+    println!("{}", stringify!(connect_invalid_queue_descriptor));
+
+    // Fail to connect().
+    let e: Fail = libos
+        .connect(QDesc::from(0), remote.to_owned())
+        .expect_err("connect() an invalid socket should fail");
+
+    // Sanity check error code.
+    assert_eq!(e.errno, libc::EBADF, "connect() failed with {}", e.cause);
+
+    Ok(())
+}
+
+/// Attempts to connect a TCP socket that is not bound.
+fn connect_unbound_socket(libos: &mut LibOS, remote: &SocketAddrV4) -> Result<()> {
+    println!("{}", stringify!(connect_unbound_socket));
+
+    // Create an unbound socket.
+    let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
+
+    // Succeed to connect socket.
+    let qt: QToken = libos.connect(sockqd, remote.to_owned())?;
+
+    // Poll once to ensure that the connect() co-routine runs.
+    match libos.wait(qt, Some(Duration::from_micros(0))) {
+        Err(e) if e.errno == libc::ETIMEDOUT => {},
+        Ok(_) => anyhow::bail!("wait() should not succeed"),
+        Err(_) => anyhow::bail!("wait() should timeout"),
+    }
+
+    // Succeed to close socket.
+    libos.close(sockqd)?;
+
+    Ok(())
+}
+
+/// Attempts to connect a TCP socket that is listening.
+fn connect_listening_socket(libos: &mut LibOS, local: &SocketAddrV4, remote: &SocketAddrV4) -> Result<()> {
+    println!("{}", stringify!(connect_listening_socket));
+
+    // Create a listening socket.
+    let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
+    libos.bind(sockqd, local.to_owned())?;
+    libos.listen(sockqd, 16)?;
+
+    // Fail to connect().
+    let e: Fail = libos
+        .connect(sockqd, remote.to_owned())
+        .expect_err("connect() a socket that is listening should fail");
+
+    // Sanity check error code.
+    assert_eq!(e.errno, libc::EOPNOTSUPP, "connect() failed with {}", e.cause);
+
+    // Succeed to close socket.
+    libos.close(sockqd)?;
+
+    Ok(())
+}
+
+/// Attempts to connect a TCP socket that is already connecting.
+fn connect_connecting_socket(libos: &mut LibOS, remote: &SocketAddrV4) -> Result<()> {
+    println!("{}", stringify!(connect_connecting_socket));
+
+    // Create a connecting socket.
+    let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
+    let qt: QToken = libos.connect(sockqd, remote.to_owned())?;
+
+    // Poll once to ensure that the connect() co-routine runs.
+    match libos.wait(qt, Some(Duration::from_micros(0))) {
+        Err(e) if e.errno == libc::ETIMEDOUT => {},
+        Ok(_) => anyhow::bail!("wait() should not succeed"),
+        Err(_) => anyhow::bail!("wait() should timeout"),
+    }
+
+    // Fail to connect().
+    let e: Fail = libos
+        .connect(sockqd, remote.to_owned())
+        .expect_err("connect() a socket that is connecting should fail");
+
+    // Sanity check error code.
+    assert_eq!(e.errno, libc::EINPROGRESS, "connect() failed with {}", e.cause);
+
+    // Succeed to close socket.
+    libos.close(sockqd)?;
+
+    Ok(())
+}
+
+/// Attempts to connect a TCP socket that is accepting connections.
+fn connect_accepting_socket(libos: &mut LibOS, local: &SocketAddrV4, remote: &SocketAddrV4) -> Result<()> {
+    println!("{}", stringify!(connect_accepting_socket));
+
+    // Create an accepting socket.
+    let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
+    libos.bind(sockqd, local.to_owned())?;
+    libos.listen(sockqd, 16)?;
+    let qt: QToken = libos.accept(sockqd)?;
+
+    // Poll once to ensure that the accept() co-routine runs.
+    match libos.wait(qt, Some(Duration::from_micros(0))) {
+        Err(e) if e.errno == libc::ETIMEDOUT => {},
+        Ok(_) => anyhow::bail!("wait() should not succeed"),
+        Err(_) => anyhow::bail!("wait() should timeout"),
+    }
+
+    // Fail to connect().
+    let e: Fail = libos
+        .connect(sockqd, remote.to_owned())
+        .expect_err("connect() a socket that is accepting should fail");
+
+    // Sanity check error code.
+    assert_eq!(e.errno, libc::EOPNOTSUPP, "connect() failed with {}", e.cause);
+
+    // Succeed to close socket.
+    libos.close(sockqd)?;
+
+    Ok(())
+}

--- a/tests/rust/tcp-test/listen/mod.rs
+++ b/tests/rust/tcp-test/listen/mod.rs
@@ -1,0 +1,186 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//======================================================================================================================
+// Imports
+//======================================================================================================================
+
+use anyhow::Result;
+use demikernel::{
+    runtime::fail::Fail,
+    LibOS,
+    QDesc,
+    QToken,
+};
+use std::{
+    net::SocketAddrV4,
+    time::Duration,
+};
+
+//======================================================================================================================
+// Constants
+//======================================================================================================================
+
+#[cfg(target_os = "windows")]
+pub const AF_INET: i32 = windows::Win32::Networking::WinSock::AF_INET.0 as i32;
+
+#[cfg(target_os = "windows")]
+pub const SOCK_STREAM: i32 = windows::Win32::Networking::WinSock::SOCK_STREAM as i32;
+
+#[cfg(target_os = "linux")]
+pub const AF_INET: i32 = libc::AF_INET;
+
+#[cfg(target_os = "linux")]
+pub const SOCK_STREAM: i32 = libc::SOCK_STREAM;
+
+//======================================================================================================================
+// Standalone Functions
+//======================================================================================================================
+
+/// Drives integration tests for listen() on TCP sockets.
+pub fn run(libos: &mut LibOS, addr: &SocketAddrV4) -> Result<()> {
+    listen_invalid_queue_descriptor(libos)?;
+    listen_unbound_socket(libos)?;
+    listen_bound_socket(libos, addr)?;
+    listen_listening_socket(libos, addr)?;
+    listen_connecting_socket(libos, addr)?;
+    listen_accepting_socket(libos, addr)?;
+
+    Ok(())
+}
+
+/// Attempts to listen for connections on an invalid queue descriptor.
+fn listen_invalid_queue_descriptor(libos: &mut LibOS) -> Result<()> {
+    println!("{}", stringify!(listen_invalid_queue_descriptor));
+
+    // Fail to listen().
+    let e: Fail = libos
+        .listen(QDesc::from(0), 8)
+        .expect_err("listen() on an invalid queue descriptor should fail");
+
+    // Sanity check error code.
+    assert_eq!(e.errno, libc::EBADF, "listen() failed with {}", e.cause);
+
+    Ok(())
+}
+
+/// Attempts to listen for connections on a TCP socket that is not bound.
+fn listen_unbound_socket(libos: &mut LibOS) -> Result<()> {
+    println!("{}", stringify!(listen_unbound_socket));
+
+    // Create an unbound socket.
+    let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
+
+    // Fail to listen().
+    let e: Fail = libos
+        .listen(sockqd, 16)
+        .expect_err("listen() on a socket that is not bound should fail");
+
+    // Sanity check error code.
+    assert_eq!(e.errno, libc::EDESTADDRREQ, "listen() failed with {}", e.cause);
+
+    // Succeed to close socket.
+    libos.close(sockqd)?;
+
+    Ok(())
+}
+
+/// Attempts to listen for connections on a TCP socket that is bound.
+fn listen_bound_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()> {
+    println!("{}", stringify!(listen_bound_socket));
+
+    // Create a bound socket.
+    let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
+    libos.bind(sockqd, local.to_owned())?;
+
+    // Succeed to listen().
+    libos.listen(sockqd, 16)?;
+
+    // Succeed to close socket.
+    libos.close(sockqd)?;
+
+    Ok(())
+}
+
+/// Attempts to listen for connections on a TCP socket that is already listening for connections.
+fn listen_listening_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()> {
+    println!("{}", stringify!(listen_listening_socket));
+
+    // Create a bound socket.
+    let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
+    libos.bind(sockqd, local.to_owned())?;
+
+    // Succeed to listen().
+    libos.listen(sockqd, 16)?;
+
+    // Fail to listen().
+    let e: Fail = libos
+        .listen(sockqd, 16)
+        .expect_err("listen() on a socket that is already listening should fail");
+
+    // Sanity check error code.
+    assert_eq!(e.errno, libc::EADDRINUSE, "listen() failed with {}", e.cause);
+
+    // Succeed to close socket.
+    libos.close(sockqd)?;
+
+    Ok(())
+}
+
+/// Attempts to listen for connections on a TCP socket that is connecting.
+fn listen_connecting_socket(libos: &mut LibOS, remote: &SocketAddrV4) -> Result<()> {
+    println!("{}", stringify!(listen_connecting_socket));
+
+    // Create a connecting socket.
+    let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
+    let qt: QToken = libos.connect(sockqd, remote.to_owned())?;
+
+    // Poll once to ensure that the connect() co-routine runs.
+    match libos.wait(qt, Some(Duration::from_micros(0))) {
+        Err(e) if e.errno == libc::ETIMEDOUT => {},
+        Ok(_) => anyhow::bail!("wait() should not succeed"),
+        Err(_) => anyhow::bail!("wait() should timeout"),
+    }
+
+    // Fail to listen().
+    let e: Fail = libos
+        .listen(sockqd, 16)
+        .expect_err("listen() on a socket that is connecting should fail");
+
+    // Sanity check error code.
+    assert_eq!(e.errno, libc::EADDRINUSE, "listen() failed with {}", e.cause);
+
+    // Succeed to close socket.
+    libos.close(sockqd)?;
+
+    Ok(())
+}
+
+/// Attempts to listen for connections on a TCP socket that is accepting connections.
+fn listen_accepting_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()> {
+    // Create an accepting socket.
+    let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
+    libos.bind(sockqd, local.to_owned())?;
+    libos.listen(sockqd, 16)?;
+    let qt: QToken = libos.accept(sockqd)?;
+
+    // Poll once to ensure that the accept() co-routine runs.
+    match libos.wait(qt, Some(Duration::from_micros(0))) {
+        Err(e) if e.errno == libc::ETIMEDOUT => {},
+        Ok(_) => anyhow::bail!("wait() should not succeed"),
+        Err(_) => anyhow::bail!("wait() should timeout"),
+    }
+
+    // Fail to listen().
+    let e: Fail = libos
+        .listen(sockqd, 16)
+        .expect_err("listen() on a socket that is accepting connections should fail");
+
+    // Sanity check error code.
+    assert_eq!(e.errno, libc::EADDRINUSE, "listen() failed with {}", e.cause);
+
+    // Succeed to close socket.
+    libos.close(sockqd)?;
+
+    Ok(())
+}

--- a/tests/rust/tcp-test/main.rs
+++ b/tests/rust/tcp-test/main.rs
@@ -11,6 +11,7 @@
 mod accept;
 mod args;
 mod bind;
+mod close;
 mod connect;
 mod listen;
 mod socket;
@@ -43,5 +44,7 @@ fn main() -> Result<()> {
     listen::run(&mut libos, &args.local())?;
     accept::run(&mut libos, &args.local())?;
     connect::run(&mut libos, &args.local(), &args.remote())?;
+    close::run(&mut libos, &args.local())?;
+
     Ok(())
 }

--- a/tests/rust/tcp-test/main.rs
+++ b/tests/rust/tcp-test/main.rs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#![cfg_attr(feature = "strict", deny(warnings))]
+#![deny(clippy::all)]
+
+//======================================================================================================================
+// Modules
+//======================================================================================================================
+
+mod args;
+//======================================================================================================================
+// Imports
+//======================================================================================================================
+
+use anyhow::Result;
+use args::ProgramArguments;
+
+fn main() -> Result<()> {
+    ProgramArguments::new(
+        "tcp",
+        "Pedro Henrique Penna <ppenna@microsoft.com>",
+        "Integration test for TCP queues.",
+    )?;
+
+    Ok(())
+}

--- a/tests/rust/tcp-test/main.rs
+++ b/tests/rust/tcp-test/main.rs
@@ -9,12 +9,18 @@
 //======================================================================================================================
 
 mod args;
+mod socket;
+
 //======================================================================================================================
 // Imports
 //======================================================================================================================
 
 use anyhow::Result;
 use args::ProgramArguments;
+use demikernel::{
+    LibOS,
+    LibOSName,
+};
 
 fn main() -> Result<()> {
     ProgramArguments::new(
@@ -23,5 +29,11 @@ fn main() -> Result<()> {
         "Integration test for TCP queues.",
     )?;
 
+    let mut libos: LibOS = {
+        let libos_name: LibOSName = LibOSName::from_env()?.into();
+        LibOS::new(libos_name)?
+    };
+
+    socket::run(&mut libos)?;
     Ok(())
 }

--- a/tests/rust/tcp-test/main.rs
+++ b/tests/rust/tcp-test/main.rs
@@ -11,6 +11,7 @@
 mod accept;
 mod args;
 mod bind;
+mod connect;
 mod listen;
 mod socket;
 
@@ -41,5 +42,6 @@ fn main() -> Result<()> {
     bind::run(&mut libos, &args.local().ip())?;
     listen::run(&mut libos, &args.local())?;
     accept::run(&mut libos, &args.local())?;
+    connect::run(&mut libos, &args.local(), &args.remote())?;
     Ok(())
 }

--- a/tests/rust/tcp-test/main.rs
+++ b/tests/rust/tcp-test/main.rs
@@ -8,6 +8,7 @@
 // Modules
 //======================================================================================================================
 
+mod accept;
 mod args;
 mod bind;
 mod listen;
@@ -39,5 +40,6 @@ fn main() -> Result<()> {
     socket::run(&mut libos)?;
     bind::run(&mut libos, &args.local().ip())?;
     listen::run(&mut libos, &args.local())?;
+    accept::run(&mut libos, &args.local())?;
     Ok(())
 }

--- a/tests/rust/tcp-test/main.rs
+++ b/tests/rust/tcp-test/main.rs
@@ -9,6 +9,7 @@
 //======================================================================================================================
 
 mod args;
+mod bind;
 mod socket;
 
 //======================================================================================================================
@@ -23,7 +24,7 @@ use demikernel::{
 };
 
 fn main() -> Result<()> {
-    ProgramArguments::new(
+    let args: ProgramArguments = ProgramArguments::new(
         "tcp",
         "Pedro Henrique Penna <ppenna@microsoft.com>",
         "Integration test for TCP queues.",
@@ -35,5 +36,6 @@ fn main() -> Result<()> {
     };
 
     socket::run(&mut libos)?;
+    bind::run(&mut libos, &args.local().ip())?;
     Ok(())
 }

--- a/tests/rust/tcp-test/main.rs
+++ b/tests/rust/tcp-test/main.rs
@@ -10,6 +10,7 @@
 
 mod args;
 mod bind;
+mod listen;
 mod socket;
 
 //======================================================================================================================
@@ -37,5 +38,6 @@ fn main() -> Result<()> {
 
     socket::run(&mut libos)?;
     bind::run(&mut libos, &args.local().ip())?;
+    listen::run(&mut libos, &args.local())?;
     Ok(())
 }

--- a/tests/rust/tcp-test/socket/mod.rs
+++ b/tests/rust/tcp-test/socket/mod.rs
@@ -1,0 +1,161 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//======================================================================================================================
+// Imports
+//======================================================================================================================
+
+use anyhow::Result;
+use demikernel::{
+    runtime::fail::Fail,
+    LibOS,
+};
+
+//======================================================================================================================
+// Constants
+//======================================================================================================================
+
+#[cfg(target_os = "windows")]
+pub const AF_INET: i32 = windows::Win32::Networking::WinSock::AF_INET.0 as i32;
+
+#[cfg(target_os = "windows")]
+pub const SOCK_STREAM: i32 = windows::Win32::Networking::WinSock::SOCK_STREAM as i32;
+
+#[cfg(target_os = "linux")]
+pub const AF_INET: i32 = libc::AF_INET;
+
+#[cfg(target_os = "linux")]
+pub const SOCK_STREAM: i32 = libc::SOCK_STREAM;
+
+//======================================================================================================================
+// Standalone Functions
+//======================================================================================================================
+
+/// Drives integration tests for socket() on TCP sockets.
+pub fn run(libos: &mut LibOS) -> Result<()> {
+    create_socket_using_unsupported_domain(libos)?;
+    create_socket_using_unsupported_type(libos)?;
+
+    Ok(())
+}
+
+/// Attempts to create a TCP socket using an unsupported domain.
+fn create_socket_using_unsupported_domain(libos: &mut LibOS) -> Result<()> {
+    println!("{}", stringify!(create_socket_using_unsupported_domain));
+
+    // Unsupported domains in Linux.
+    #[cfg(target_os = "linux")]
+    let domains: Vec<libc::c_int> = vec![
+        libc::AF_ALG,
+        libc::AF_APPLETALK,
+        libc::AF_ASH,
+        libc::AF_ATMPVC,
+        libc::AF_ATMSVC,
+        libc::AF_AX25,
+        libc::AF_BLUETOOTH,
+        libc::AF_BRIDGE,
+        libc::AF_CAIF,
+        libc::AF_CAN,
+        libc::AF_DECnet,
+        libc::AF_ECONET,
+        libc::AF_IB,
+        libc::AF_IEEE802154,
+        // libc::AF_INET,
+        libc::AF_INET6,
+        libc::AF_IPX,
+        libc::AF_IRDA,
+        libc::AF_ISDN,
+        libc::AF_IUCV,
+        libc::AF_KEY,
+        libc::AF_LLC,
+        libc::AF_LOCAL,
+        libc::AF_MPLS,
+        libc::AF_NETBEUI,
+        libc::AF_NETLINK,
+        libc::AF_NETROM,
+        libc::AF_NFC,
+        libc::AF_PACKET,
+        libc::AF_PHONET,
+        libc::AF_PPPOX,
+        libc::AF_RDS,
+        libc::AF_ROSE,
+        libc::AF_ROUTE,
+        libc::AF_RXRPC,
+        libc::AF_SECURITY,
+        libc::AF_SNA,
+        libc::AF_TIPC,
+        libc::AF_UNIX,
+        libc::AF_UNSPEC,
+        libc::AF_VSOCK,
+        libc::AF_WANPIPE,
+        libc::AF_X25,
+        libc::AF_XDP,
+    ];
+
+    // Unsupported domains in Windows.
+    #[cfg(target_os = "windows")]
+    let domains: Vec<libc::c_int> = vec![
+        WinSock::AF_APPLETALK as i32,
+        WinSock::AF_DECnet as i32,
+        // WinSock::AF_INET as i32,
+        WinSock::AF_INET6.0 as i32,
+        WinSock::AF_IPX as i32,
+        WinSock::AF_IRDA as i32,
+        WinSock::AF_SNA as i32,
+        WinSock::AF_UNIX as i32,
+        WinSock::AF_UNSPEC.0 as i32,
+    ];
+
+    // Attempt to create a TCP socket with all unsupported domains.
+    for domain in domains {
+        // Fail to create socket.
+        let e: Fail = libos
+            .socket(domain, SOCK_STREAM, 0)
+            .expect_err("create a TCP socket with a unsupported domain should fail");
+
+        // Sanity check error code.
+        assert_eq!(e.errno, libc::ENOTSUP, "socket() failed with {}", e.cause);
+    }
+
+    Ok(())
+}
+
+/// Attempts to create a TCP socket using an unsupported socket type.
+fn create_socket_using_unsupported_type(libos: &mut LibOS) -> Result<()> {
+    println!("{}", stringify!(create_socket_using_unsupported_type));
+
+    // Invalid socket types in Linux.
+    #[cfg(target_os = "linux")]
+    let socket_types: Vec<libc::c_int> = vec![
+        libc::SOCK_DCCP,
+        // libc::SOCK_DGRAM,
+        libc::SOCK_PACKET,
+        libc::SOCK_RAW,
+        libc::SOCK_RDM,
+        libc::SOCK_SEQPACKET,
+        // libc::SOCK_STREAM,
+    ];
+
+    // Invalid socket types in Windows.
+    #[cfg(target_os = "windows")]
+    let socket_types: Vec<libc::c_int> = vec![
+        // WinSock::SOCK_DGRAM as i32,
+        WinSock::SOCK_RAW as i32,
+        WinSock::SOCK_RDM as i32,
+        WinSock::SOCK_SEQPACKET as i32,
+        // WinSock::SOCK_STREAM as i32,
+    ];
+
+    // Attempt to create a TCP socket with all invalid socket types.
+    for socket_type in socket_types {
+        // Fail to create socket.
+        let e: Fail = libos
+            .socket(AF_INET, socket_type, 0)
+            .expect_err("create a TCP socket with an invalid socket type should fail");
+
+        // Sanity check error code.
+        assert_eq!(e.errno, libc::ENOTSUP, "socket() failed with {}", e.cause);
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Description

- This PR partially addresses https://github.com/demikernel/demikernel/issues/554
- This PR partially addresses https://github.com/demikernel/demikernel/issues/549
- This PR partially addresses https://github.com/demikernel/demikernel/issues/526
- This PR partially addresses https://github.com/demikernel/demikernel/issues/501
- This PR partially addresses https://github.com/demikernel/demikernel/issues/567
- This PR partially addresses https://github.com/demikernel/demikernel/issues/566

## Summary of Changes

Added the following integration tests for TCP `accept()`:

- Attempt to accept connections on an invalid queue descriptor
- Attempt to accept connections on a TCP socket that is not bound
- Attempt to accept connections on a TCP socket that is not listening
- Attempt to accept connections on a TCP socket that is listening
- Attempt to accept connections on a TCP socket that is connecting
- Attempt to accept connections on a TCP socket that is already accepting connections

Added the following integration tests for TCP `bind()`:

- Attempt to bind an address to an invalid queue descriptor
- Attempt to bind multiple addresses to the same socket
- Attempt to bind the same address to two sockets
- Attempt to bind to all private ports

Added the following integration tests for TCP `close()`:

- Attempt to close an invalid queue descriptor
- Attempt to close a TCP socket multiple times
- Attempt to close a TCP socket that is not bound
- Attempt to close a TCP socket that is bound
- Attempt to close a TCP socket that is listening
- Attempt to close a TCP socket that is accepting
- Attempt to close a TCP socket that is connecting

Added the following integration tests for TCP `connect()`:

- Attempt to connect an invalid queue descriptor
- Attempt to connect a TCP socket that is not bound
- Attempt to connect a TCP socket that is listening
- Attempt to connect a TCP socket that is already connecting
- Attempt to connect a TCP socket that is accepting connections

Added the following integration tests for TCP `listen()`:

- Attempt to listen for connections on an invalid queue descriptor
- Attempt to listen for connections on a TCP socket that is not bound
- Attempt to listen for connections on a TCP socket that is already listening for connections
- Attempt to listen for connections on a TCP socket that is bound
- Attempt to listen for connections on a TCP socket that is connecting
- Attempt to listen for connections on a TCP socket that is accepting connections

Added the following integration tests for TCP `socket()`:

- Attempt to create a TCP socket using an unsupported domain
- Attempt to create a TCP socket using an unsupported socket type

























































