### PR TITLE
[catnip] Bad Assumption on Packet Header Size

### DIFF
--- a/src/rust/catnip/runtime/memory/manager.rs
+++ b/src/rust/catnip/runtime/memory/manager.rs
@@ -9,7 +9,7 @@ use super::mempool::MemoryPool;
 use crate::{
     inetstack::protocols::{
         ethernet2::ETHERNET2_HEADER_SIZE,
-        ipv4::IPV4_HEADER_DEFAULT_SIZE,
+        ipv4::IPV4_HEADER_MAX_SIZE,
         tcp::MAX_TCP_HEADER_SIZE,
     },
     runtime::{
@@ -242,8 +242,7 @@ impl MemoryManager {
 /// Associated Functions for Memory Managers
 impl Inner {
     fn new(config: MemoryConfig) -> Result<Self, Error> {
-        // TODO: The following computation for header size is bad. It should be fixed to maximum possible size.
-        let header_size: usize = ETHERNET2_HEADER_SIZE + IPV4_HEADER_DEFAULT_SIZE + MAX_TCP_HEADER_SIZE;
+        let header_size: usize = ETHERNET2_HEADER_SIZE + (IPV4_HEADER_MAX_SIZE as usize) + MAX_TCP_HEADER_SIZE;
         let header_mbuf_size: usize = header_size + config.get_inline_body_size();
 
         // Create memory pool for holding packet headers.

--- a/src/rust/inetstack/protocols/ipv4/datagram.rs
+++ b/src/rust/inetstack/protocols/ipv4/datagram.rs
@@ -28,14 +28,14 @@ use ::std::{
 // Constants
 //==============================================================================
 
-/// Default size of IPv4 Headers (in bytes).
-pub const IPV4_HEADER_DEFAULT_SIZE: usize = IPV4_DATAGRAM_MIN_SIZE as usize;
+/// Minimum size of IPv4 header (in bytes).
+pub const IPV4_HEADER_MIN_SIZE: u16 = IPV4_DATAGRAM_MIN_SIZE;
+
+/// Maximum size of IPv4 header (in bytes).
+pub const IPV4_HEADER_MAX_SIZE: u16 = 60;
 
 /// Minimum size for an IPv4 datagram (in bytes).
 const IPV4_DATAGRAM_MIN_SIZE: u16 = 20;
-
-/// Minimum size for an IPv4 datagram (in bytes).
-const IPV4_HEADER_MIN_SIZE: u16 = IPV4_DATAGRAM_MIN_SIZE;
 
 /// IPv4 header length when no options are present (in 32-bit words).
 const IPV4_IHL_NO_OPTIONS: u8 = (IPV4_HEADER_MIN_SIZE as u8) / 4;
@@ -105,7 +105,7 @@ impl Ipv4Header {
             ihl: IPV4_IHL_NO_OPTIONS,
             dscp: 0,
             ecn: 0,
-            total_length: IPV4_HEADER_MIN_SIZE,
+            total_length: IPV4_HEADER_MIN_SIZE as u16,
             identification: 0,
             flags: IPV4_CTRL_FLAG_DF,
             fragment_offset: 0,
@@ -119,7 +119,7 @@ impl Ipv4Header {
 
     /// Computes the size of the target IPv4 header.
     pub fn compute_size(&self) -> usize {
-        IPV4_HEADER_MIN_SIZE as usize
+        (self.ihl as usize) << 2
     }
 
     /// Parses a buffer into an IPv4 header and payload.
@@ -138,7 +138,7 @@ impl Ipv4Header {
         // Internet header length.
         let ihl: u8 = buf[0] & 0xF;
         let hdr_size: u16 = (ihl as u16) << 2;
-        if hdr_size < IPV4_HEADER_MIN_SIZE {
+        if hdr_size < IPV4_HEADER_MIN_SIZE as u16 {
             return Err(Fail::new(EBADMSG, "ipv4 IHL is too small"));
         }
         if buf.len() < hdr_size as usize {

--- a/src/rust/inetstack/protocols/ipv4/mod.rs
+++ b/src/rust/inetstack/protocols/ipv4/mod.rs
@@ -12,5 +12,6 @@ mod tests;
 
 pub use self::datagram::{
     Ipv4Header,
-    IPV4_HEADER_DEFAULT_SIZE,
+    IPV4_HEADER_MIN_SIZE,
+    IPV4_HEADER_MAX_SIZE,
 };

--- a/src/rust/inetstack/protocols/udp/datagram/mod.rs
+++ b/src/rust/inetstack/protocols/udp/datagram/mod.rs
@@ -131,7 +131,7 @@ mod test {
                 ETHERNET2_HEADER_SIZE,
             },
             ip::IpProtocol,
-            ipv4::IPV4_HEADER_DEFAULT_SIZE,
+            ipv4::IPV4_HEADER_MIN_SIZE,
         },
         runtime::{
             memory::DemiBuffer,
@@ -143,7 +143,7 @@ mod test {
     #[test]
     fn test_udp_datagram_header_serialization() {
         // Total header size.
-        const HEADER_SIZE: usize = ETHERNET2_HEADER_SIZE + IPV4_HEADER_DEFAULT_SIZE + UDP_HEADER_SIZE;
+        const HEADER_SIZE: usize = ETHERNET2_HEADER_SIZE + (IPV4_HEADER_MIN_SIZE as usize) + UDP_HEADER_SIZE;
 
         // Build fake Ethernet2 header.
         let dst_addr: MacAddress = MacAddress::new([0xd, 0xe, 0xa, 0xd, 0x0, 0x0]);
@@ -171,11 +171,11 @@ mod test {
         let mut hdr: [u8; HEADER_SIZE] = [0; HEADER_SIZE];
         ethernet2_hdr.serialize(&mut hdr[0..ETHERNET2_HEADER_SIZE]);
         ipv4_hdr.serialize(
-            &mut hdr[ETHERNET2_HEADER_SIZE..(ETHERNET2_HEADER_SIZE + IPV4_HEADER_DEFAULT_SIZE)],
+            &mut hdr[ETHERNET2_HEADER_SIZE..(ETHERNET2_HEADER_SIZE + (IPV4_HEADER_MIN_SIZE as usize))],
             UDP_HEADER_SIZE + data.len(),
         );
         udp_hdr.serialize(
-            &mut hdr[(ETHERNET2_HEADER_SIZE + IPV4_HEADER_DEFAULT_SIZE)..],
+            &mut hdr[(ETHERNET2_HEADER_SIZE + (IPV4_HEADER_MIN_SIZE as usize))..],
             &ipv4_hdr,
             &data,
             checksum_offload,


### PR DESCRIPTION
### Description

- This PR closes #85.

### Summary of Changes
- Introduced the `IPV4_HEADER_MAX_SIZE` which is 60 bytes;
- Considered the maximum size for headers as `ETHERNET2_HEADER_SIZE + IPV4_HEADER_MAX_SIZE + MAX_TCP_HEADER_SIZE`;
- Fixed the `compute_size` function, calculating the IPv4 header size according to the `ihl` field.

### Observation
- This PR does not consider IEEE 802.1Q (Simple VLAN) nor 802.1ad (Double VLAN) where `ETHERNET2_HEADER_SIZE` could be greater than 14 bytes (as defined in [src/rust/inetstack/protocols/ethernet2/frame.rs](https://github.com/demikernel/demikernel/blob/dev/src/rust/inetstack/protocols/ethernet2/frame.rs#L18)).