### PR TITLE
[ci] Enable `tcp-echo` for Catnap LibOS

### DIFF
--- a/examples/tcp-echo/client.rs
+++ b/examples/tcp-echo/client.rs
@@ -96,7 +96,7 @@ impl TcpEchoClient {
             let qt: QToken = self.libos.connect(sockqd, self.remote)?;
             let qr: demi_qresult_t = self.libos.wait(qt, None)?;
             if qr.qr_opcode != demi_opcode_t::DEMI_OPC_CONNECT {
-                anyhow::bail!("unexpected result")
+                anyhow::bail!("failed to connect to server")
             }
 
             println!("INFO: {} clients connected", self.clients.len());
@@ -180,7 +180,7 @@ impl TcpEchoClient {
         let qd: QDesc = qr.qr_qd.into();
         let sga: demi_sgarray_t = unsafe { qr.qr_value.sga };
         if sga.sga_segs[0].sgaseg_len == 0 {
-            eprint!("INFO: server closed connection");
+            println!("INFO: server closed connection");
             self.handle_close(qd)?;
         } else {
             // Retrieve client buffer.
@@ -235,7 +235,7 @@ impl TcpEchoClient {
         let qd: QDesc = qr.qr_qd.into();
         let qt: QToken = qr.qr_qt.into();
 
-        eprintln!(
+        println!(
             "WARN: unexpected {} operation completed, ignoring (qd={:?}, qt={:?})",
             op_name, qd, qt
         );
@@ -251,10 +251,10 @@ impl TcpEchoClient {
 
         // Check if client has reset the connection.
         if errno == libc::ECONNRESET {
-            eprintln!("INFO: server reset connection (qd={:?})", qd);
+            println!("INFO: server reset connection (qd={:?})", qd);
             self.handle_close(qd)?;
         } else {
-            eprintln!(
+            println!(
                 "WARN: operation failed, ignoring (qd={:?}, qt={:?}, errno={:?})",
                 qd, qt, errno
             );

--- a/examples/tcp-echo/main.rs
+++ b/examples/tcp-echo/main.rs
@@ -201,7 +201,7 @@ fn main() -> Result<()> {
     match args.peer_type.as_str() {
         "server" => {
             let mut server: TcpEchoServer = TcpEchoServer::new(libos, args.saddr.unwrap())?;
-            server.run(args.log_interval, args.nrequests)?;
+            server.run(args.log_interval)?;
         },
         "client" => {
             let mut client: TcpEchoClient = TcpEchoClient::new(

--- a/tools/demikernel_ci.py
+++ b/tools/demikernel_ci.py
@@ -239,6 +239,19 @@ def test_tcp_close(
         delay, config_path, log_directory)
 
 
+def test_tcp_echo(server: str, client: str, libos: str, is_debug: bool, is_sudo: bool, repository: str,
+                  server_addr: str, client_addr: str, delay: float, config_path: str, log_directory: str,
+                  nclients: int, nrequests: int, bufsize: int, run_mode: str) -> bool:
+    test_alias: str = "tcp-echo-{}".format(run_mode)
+    test_name: str = "tcp-echo"
+    server_args: str = "--peer server --address {}:12345".format(server_addr)
+    client_args: str = "--peer client --address {}:12345 --nclients {} --nrequests {} --bufsize {}".format(
+        client_addr, nclients, nrequests, bufsize)
+    return job_test_system_rust(
+        test_alias, test_name, repository, libos, is_debug, server, client, server_args, client_args, is_sudo, True,
+        delay, config_path, log_directory)
+
+
 def test_pipe_open(
         server: str, client: str, is_debug: bool, repository: str, delay: float,
         config_path: str, log_directory: str) -> bool:
@@ -347,6 +360,18 @@ def run_pipeline(
                         status["tcp_close"] = test_tcp_close(server, client, libos, is_debug, is_sudo,
                                                              repository, server_addr,  server_addr, delay, config_path,
                                                              log_directory, nclients=32, run_mode="concurrent")
+
+                # TCP Echo (optional)
+                if test_system == "all" or test_system == "tcp_echo":
+                    if libos != "catnip" and libos != "catpowder" and libos != "catloop" and libos != "catcollar":
+                        status["tcp_echo"] = test_tcp_echo(
+                            server, client, libos, is_debug, is_sudo, repository, server_addr, server_addr, delay,
+                            config_path, log_directory, nclients=32, nrequests="100", bufsize="64",
+                            run_mode="small-bufsize")
+                        status["tcp_echo"] = test_tcp_echo(
+                            server, client, libos, is_debug, is_sudo, repository, server_addr, server_addr, delay,
+                            config_path, log_directory, nclients=32, nrequests="100", bufsize="1024",
+                            run_mode="large-bufsize")
             else:
                 if test_system == "all" or test_system == "pipe_open":
                     status["pipe_open"] = test_pipe_open(server, server, is_debug, repository, delay,


### PR DESCRIPTION
## Description

- This PR is a partial fix for https://github.com/demikernel/demikernel/issues/578

## Summary of changes

- Changed stop condition for TCP Echo server.
- Improved logs on TCP Echo application to use stdout and not conflict with stderr
- Enabled `tcp-echo` for Catap LibOS in `demikernel-ci`