### PR TITLE
[test] Integration Tests for TCP `bind()`

### DIFF
--- a/src/rust/catnap/mod.rs
+++ b/src/rust/catnap/mod.rs
@@ -168,6 +168,7 @@ impl CatnapLibOS {
         }
 
         // Check if we are binding to the wildcard port.
+        // FIXME: https://github.com/demikernel/demikernel/issues/582
         if local.port() == 0 {
             let cause: String = format!("cannot bind to port 0 (qd={:?})", qd);
             error!("bind(): {}", cause);

--- a/src/rust/catnap/mod.rs
+++ b/src/rust/catnap/mod.rs
@@ -64,7 +64,10 @@ use ::std::{
         RefMut,
     },
     mem,
-    net::SocketAddrV4,
+    net::{
+        Ipv4Addr,
+        SocketAddrV4,
+    },
     os::unix::prelude::RawFd,
     pin::Pin,
     rc::Rc,
@@ -155,6 +158,15 @@ impl CatnapLibOS {
     pub fn bind(&mut self, qd: QDesc, local: SocketAddrV4) -> Result<(), Fail> {
         trace!("bind() qd={:?}, local={:?}", qd, local);
         let mut qtable: RefMut<IoQueueTable<CatnapQueue>> = self.qtable.borrow_mut();
+
+        // Check if we are binding to the wildcard address.
+        // FIXME: https://github.com/demikernel/demikernel/issues/189
+        if local.ip() == &Ipv4Addr::UNSPECIFIED {
+            let cause: String = format!("cannot bind to wildcard address (qd={:?})", qd);
+            error!("bind(): {}", cause);
+            return Err(Fail::new(libc::ENOTSUP, &cause));
+        }
+
         // Check if we are binding to the wildcard port.
         if local.port() == 0 {
             let cause: String = format!("cannot bind to port 0 (qd={:?})", qd);

--- a/tests/rust/tcp-test/bind/mod.rs
+++ b/tests/rust/tcp-test/bind/mod.rs
@@ -196,8 +196,14 @@ fn bind_to_wildcard_address(libos: &mut LibOS) -> Result<()> {
         SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, port)
     };
 
-    // Bind socket.
-    libos.bind(sockqd, addr)?;
+    // Fail to bind socket.
+    // FIXME: https://github.com/demikernel/demikernel/issues/189
+    let e: Fail = libos
+        .bind(sockqd, addr)
+        .expect_err("bind() to the wildcard address should fail");
+
+    // Sanity check error code.
+    assert_eq!(e.errno, libc::ENOTSUP, "bind() failed with {}", e.cause);
 
     // Close socket.
     libos.close(sockqd)?;

--- a/tests/rust/tcp-test/bind/mod.rs
+++ b/tests/rust/tcp-test/bind/mod.rs
@@ -42,6 +42,7 @@ pub fn run(libos: &mut LibOS, local: &Ipv4Addr, remote: &Ipv4Addr) -> Result<()>
     bind_multiple_addresses_to_same_socket(libos, local)?;
     bind_same_address_to_two_sockets(libos, local)?;
     bind_to_private_ports(libos, local)?;
+    bind_to_wildcard_port(libos, local)?;
     bind_to_non_local_address(libos, remote)?;
     bind_to_closed_socket(libos, local)?;
 
@@ -159,6 +160,23 @@ fn bind_to_private_ports(libos: &mut LibOS, local: &Ipv4Addr) -> Result<()> {
         // Close socket.
         libos.close(sockqd)?;
     }
+
+    Ok(())
+}
+
+/// Attempts to bind to the wildcard port.
+fn bind_to_wildcard_port(libos: &mut LibOS, ipv4: &Ipv4Addr) -> Result<()> {
+    println!("{}", stringify!(bind_to_wildcard_port));
+
+    // Create a TCP socket.
+    let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
+
+    // Bind socket.
+    let addr: SocketAddrV4 = SocketAddrV4::new(*ipv4, 0);
+    libos.bind(sockqd, addr)?;
+
+    // Close socket.
+    libos.close(sockqd)?;
 
     Ok(())
 }

--- a/tests/rust/tcp-test/bind/mod.rs
+++ b/tests/rust/tcp-test/bind/mod.rs
@@ -229,8 +229,15 @@ fn bind_to_wildcard_address_and_port(libos: &mut LibOS) -> Result<()> {
     // Bind address.
     let addr: SocketAddrV4 = SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0);
 
-    // Bind socket.
-    libos.bind(sockqd, addr)?;
+    // Fail to bind socket.
+    // FIXME: https://github.com/demikernel/demikernel/issues/582
+    // FIXME: https://github.com/demikernel/demikernel/issues/189
+    let e: Fail = libos
+        .bind(sockqd, addr)
+        .expect_err("bind() to the wildcard address port should fail");
+
+    // Sanity check error code.
+    assert_eq!(e.errno, libc::ENOTSUP, "bind() failed with {}", e.cause);
 
     // Close socket.
     libos.close(sockqd)?;

--- a/tests/rust/tcp-test/bind/mod.rs
+++ b/tests/rust/tcp-test/bind/mod.rs
@@ -43,6 +43,7 @@ pub fn run(libos: &mut LibOS, local: &Ipv4Addr, remote: &Ipv4Addr) -> Result<()>
     bind_same_address_to_two_sockets(libos, local)?;
     bind_to_private_ports(libos, local)?;
     bind_to_wildcard_port(libos, local)?;
+    bind_to_wildcard_address(libos)?;
     bind_to_non_local_address(libos, remote)?;
     bind_to_closed_socket(libos, local)?;
 
@@ -173,6 +174,28 @@ fn bind_to_wildcard_port(libos: &mut LibOS, ipv4: &Ipv4Addr) -> Result<()> {
 
     // Bind socket.
     let addr: SocketAddrV4 = SocketAddrV4::new(*ipv4, 0);
+    libos.bind(sockqd, addr)?;
+
+    // Close socket.
+    libos.close(sockqd)?;
+
+    Ok(())
+}
+
+/// Attempts to bind to the wildcard address.
+fn bind_to_wildcard_address(libos: &mut LibOS) -> Result<()> {
+    println!("{}", stringify!(bind_to_wildcard_address));
+
+    // Create a TCP socket.
+    let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
+
+    // Bind address.
+    let addr: SocketAddrV4 = {
+        let port: u16 = 8080;
+        SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, port)
+    };
+
+    // Bind socket.
     libos.bind(sockqd, addr)?;
 
     // Close socket.

--- a/tests/rust/tcp-test/bind/mod.rs
+++ b/tests/rust/tcp-test/bind/mod.rs
@@ -37,23 +37,23 @@ pub const SOCK_STREAM: i32 = libc::SOCK_STREAM;
 //======================================================================================================================
 
 /// Drives integration tests for bind() on TCP sockets.
-pub fn run(libos: &mut LibOS, ipv4: &Ipv4Addr) -> Result<()> {
-    bind_addr_to_invalid_queue_descriptor(libos, ipv4)?;
-    bind_multiple_addresses_to_same_socket(libos, ipv4)?;
-    bind_same_address_to_two_sockets(libos, ipv4)?;
-    bind_to_private_ports(libos, ipv4)?;
+pub fn run(libos: &mut LibOS, local: &Ipv4Addr) -> Result<()> {
+    bind_addr_to_invalid_queue_descriptor(libos, local)?;
+    bind_multiple_addresses_to_same_socket(libos, local)?;
+    bind_same_address_to_two_sockets(libos, local)?;
+    bind_to_private_ports(libos, local)?;
 
     Ok(())
 }
 
 /// Attempts to bind an address to an invalid queue_descriptor.
-fn bind_addr_to_invalid_queue_descriptor(libos: &mut LibOS, ipv4: &Ipv4Addr) -> Result<()> {
+fn bind_addr_to_invalid_queue_descriptor(libos: &mut LibOS, local: &Ipv4Addr) -> Result<()> {
     println!("{}", stringify!(bind_addr_to_invalid_queue_descriptor));
 
     // Bind address.
     let addr: SocketAddrV4 = {
         let http_port: u16 = 6379;
-        SocketAddrV4::new(*ipv4, http_port)
+        SocketAddrV4::new(*local, http_port)
     };
 
     // Fail to bind socket.
@@ -68,7 +68,7 @@ fn bind_addr_to_invalid_queue_descriptor(libos: &mut LibOS, ipv4: &Ipv4Addr) -> 
 }
 
 /// Attempts to bind multiple addresses to the same socket.
-fn bind_multiple_addresses_to_same_socket(libos: &mut LibOS, ipv4: &Ipv4Addr) -> Result<()> {
+fn bind_multiple_addresses_to_same_socket(libos: &mut LibOS, local: &Ipv4Addr) -> Result<()> {
     println!("{}", stringify!(bind_multiple_addresses_to_same_socket));
 
     // Create a TCP socket.
@@ -77,7 +77,7 @@ fn bind_multiple_addresses_to_same_socket(libos: &mut LibOS, ipv4: &Ipv4Addr) ->
     // Bind address.
     let addr: SocketAddrV4 = {
         let any_port: u16 = 6739;
-        SocketAddrV4::new(*ipv4, any_port)
+        SocketAddrV4::new(*local, any_port)
     };
 
     // Bind socket.
@@ -86,7 +86,7 @@ fn bind_multiple_addresses_to_same_socket(libos: &mut LibOS, ipv4: &Ipv4Addr) ->
     // Bind address.
     let addr: SocketAddrV4 = {
         let any_port: u16 = 6780;
-        SocketAddrV4::new(*ipv4, any_port)
+        SocketAddrV4::new(*local, any_port)
     };
 
     // Fail to bind socket.
@@ -104,7 +104,7 @@ fn bind_multiple_addresses_to_same_socket(libos: &mut LibOS, ipv4: &Ipv4Addr) ->
 }
 
 /// Attempts to bind the same address to two sockets.
-fn bind_same_address_to_two_sockets(libos: &mut LibOS, ipv4: &Ipv4Addr) -> Result<()> {
+fn bind_same_address_to_two_sockets(libos: &mut LibOS, local: &Ipv4Addr) -> Result<()> {
     println!("{}", stringify!(bind_same_address_to_two_sockets));
 
     // Create two TCP sockets.
@@ -114,7 +114,7 @@ fn bind_same_address_to_two_sockets(libos: &mut LibOS, ipv4: &Ipv4Addr) -> Resul
     // Bind address.
     let addr: SocketAddrV4 = {
         let http_port: u16 = 8080;
-        SocketAddrV4::new(*ipv4, http_port)
+        SocketAddrV4::new(*local, http_port)
     };
 
     // Bind first socket.
@@ -136,7 +136,7 @@ fn bind_same_address_to_two_sockets(libos: &mut LibOS, ipv4: &Ipv4Addr) -> Resul
 }
 
 /// Attempts to bind to all private ports.
-fn bind_to_private_ports(libos: &mut LibOS, ipv4: &Ipv4Addr) -> Result<()> {
+fn bind_to_private_ports(libos: &mut LibOS, local: &Ipv4Addr) -> Result<()> {
     println!("{}", stringify!(bind_to_private_ports));
 
     // Traverse all ports in the private range.
@@ -145,7 +145,7 @@ fn bind_to_private_ports(libos: &mut LibOS, ipv4: &Ipv4Addr) -> Result<()> {
         let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
 
         // Bind socket.
-        let addr: SocketAddrV4 = SocketAddrV4::new(*ipv4, port);
+        let addr: SocketAddrV4 = SocketAddrV4::new(*local, port);
         match libos.bind(sockqd, addr) {
             Ok(()) => {},
             Err(e) => {

--- a/tests/rust/tcp-test/bind/mod.rs
+++ b/tests/rust/tcp-test/bind/mod.rs
@@ -44,6 +44,7 @@ pub fn run(libos: &mut LibOS, local: &Ipv4Addr, remote: &Ipv4Addr) -> Result<()>
     bind_to_private_ports(libos, local)?;
     bind_to_wildcard_port(libos, local)?;
     bind_to_wildcard_address(libos)?;
+    bind_to_wildcard_address_and_port(libos)?;
     bind_to_non_local_address(libos, remote)?;
     bind_to_closed_socket(libos, local)?;
 
@@ -194,6 +195,25 @@ fn bind_to_wildcard_address(libos: &mut LibOS) -> Result<()> {
         let port: u16 = 8080;
         SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, port)
     };
+
+    // Bind socket.
+    libos.bind(sockqd, addr)?;
+
+    // Close socket.
+    libos.close(sockqd)?;
+
+    Ok(())
+}
+
+/// Attempts to bind to the wildcard address and port.
+fn bind_to_wildcard_address_and_port(libos: &mut LibOS) -> Result<()> {
+    println!("{}", stringify!(bind_to_wildcard_address_and_port));
+
+    // Create a TCP socket.
+    let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
+
+    // Bind address.
+    let addr: SocketAddrV4 = SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0);
 
     // Bind socket.
     libos.bind(sockqd, addr)?;

--- a/tests/rust/tcp-test/bind/mod.rs
+++ b/tests/rust/tcp-test/bind/mod.rs
@@ -173,9 +173,17 @@ fn bind_to_wildcard_port(libos: &mut LibOS, ipv4: &Ipv4Addr) -> Result<()> {
     // Create a TCP socket.
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
 
-    // Bind socket.
+    // Bind address.
     let addr: SocketAddrV4 = SocketAddrV4::new(*ipv4, 0);
-    libos.bind(sockqd, addr)?;
+
+    // Fail to bind socket.
+    // FIXME: https://github.com/demikernel/demikernel/issues/582
+    let e: Fail = libos
+        .bind(sockqd, addr)
+        .expect_err("bind() to the wildcard address port should fail");
+
+    // Sanity check error code.
+    assert_eq!(e.errno, libc::ENOTSUP, "bind() failed with {}", e.cause);
 
     // Close socket.
     libos.close(sockqd)?;

--- a/tests/rust/tcp-test/main.rs
+++ b/tests/rust/tcp-test/main.rs
@@ -40,7 +40,7 @@ fn main() -> Result<()> {
     };
 
     socket::run(&mut libos)?;
-    bind::run(&mut libos, &args.local().ip())?;
+    bind::run(&mut libos, &args.local().ip(), &args.remote().ip())?;
     listen::run(&mut libos, &args.local())?;
     accept::run(&mut libos, &args.local())?;
     connect::run(&mut libos, &args.local(), &args.remote())?;


### PR DESCRIPTION
## Description

- This PR closes https://github.com/demikernel/demikernel/issues/501
- This PR exposes https://github.com/demikernel/demikernel/issues/189
- This PR exposes https://github.com/demikernel/demikernel/issues/582

## Summary of Changes

Added the following integration tests for TCP bind():
- Attempt to bind to the wildcard port.
- Attempt to bind to the wildcard address.
- Attempt to bind to the wildcard address and port.
- Attempt to bind to a non-local address.
- Attempt to bind a TCP socket that is closed.