### PR TITLE
[test] Integration Tests for TCP `listen()`

### DIFF
--- a/tests/rust/tcp-test/listen/mod.rs
+++ b/tests/rust/tcp-test/listen/mod.rs
@@ -43,6 +43,7 @@ pub fn run(libos: &mut LibOS, addr: &SocketAddrV4) -> Result<()> {
     listen_unbound_socket(libos)?;
     listen_bound_socket(libos, addr)?;
     listen_large_backlog_length(libos, addr)?;
+    listen_invalid_zero_backlog_length(libos, addr)?;
     listen_listening_socket(libos, addr)?;
     listen_connecting_socket(libos, addr)?;
     listen_accepting_socket(libos, addr)?;
@@ -96,6 +97,26 @@ fn listen_bound_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()> {
 
     // Succeed to listen().
     libos.listen(sockqd, 16)?;
+
+    // Succeed to close socket.
+    libos.close(sockqd)?;
+
+    Ok(())
+}
+
+/// Attempts to listen for connections on a TCP socket with a zero backlog length.
+fn listen_invalid_zero_backlog_length(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()> {
+    println!("{}", stringify!(listen_invalid_zero_backlog_length));
+
+    // Create a bound socket.
+    let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
+    libos.bind(sockqd, local.to_owned())?;
+
+    // Backlog length.
+    let backlog: usize = 0;
+
+    // Succeed to listen().
+    libos.listen(sockqd, backlog)?;
 
     // Succeed to close socket.
     libos.close(sockqd)?;

--- a/tests/rust/tcp-test/listen/mod.rs
+++ b/tests/rust/tcp-test/listen/mod.rs
@@ -42,6 +42,7 @@ pub fn run(libos: &mut LibOS, addr: &SocketAddrV4) -> Result<()> {
     listen_invalid_queue_descriptor(libos)?;
     listen_unbound_socket(libos)?;
     listen_bound_socket(libos, addr)?;
+    listen_large_backlog_length(libos, addr)?;
     listen_listening_socket(libos, addr)?;
     listen_connecting_socket(libos, addr)?;
     listen_accepting_socket(libos, addr)?;
@@ -95,6 +96,26 @@ fn listen_bound_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()> {
 
     // Succeed to listen().
     libos.listen(sockqd, 16)?;
+
+    // Succeed to close socket.
+    libos.close(sockqd)?;
+
+    Ok(())
+}
+
+/// Attempts to listen for connections on a TCP socket with a large backlog length.
+fn listen_large_backlog_length(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()> {
+    println!("{}", stringify!(listen_invalid_backlog_length));
+
+    // Create a bound socket.
+    let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
+    libos.bind(sockqd, local.to_owned())?;
+
+    // Backlog length.
+    let backlog: usize = (libc::SOMAXCONN + 1) as usize;
+
+    // Succeed to listen().
+    libos.listen(sockqd, backlog)?;
 
     // Succeed to close socket.
     libos.close(sockqd)?;

--- a/tests/rust/tcp-test/listen/mod.rs
+++ b/tests/rust/tcp-test/listen/mod.rs
@@ -47,6 +47,7 @@ pub fn run(libos: &mut LibOS, addr: &SocketAddrV4) -> Result<()> {
     listen_listening_socket(libos, addr)?;
     listen_connecting_socket(libos, addr)?;
     listen_accepting_socket(libos, addr)?;
+    listen_closed_socket(libos, addr)?;
 
     Ok(())
 }
@@ -223,6 +224,31 @@ fn listen_accepting_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()
 
     // Succeed to close socket.
     libos.close(sockqd)?;
+
+    Ok(())
+}
+
+/// Attempts to listen for connections on a TCP socket that is closed.
+fn listen_closed_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()> {
+    println!("{}", stringify!(listen_closed_socket));
+
+    // Create a bound socket.
+    let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
+    libos.bind(sockqd, local.to_owned())?;
+
+    // Succeed to listen().
+    libos.listen(sockqd, 16)?;
+
+    // Succeed to close socket.
+    libos.close(sockqd)?;
+
+    // Fail to listen().
+    let e: Fail = libos
+        .listen(sockqd, 16)
+        .expect_err("listen() on a socket that is closed should fail");
+
+    // Sanity check error code.
+    assert_eq!(e.errno, libc::EBADF, "listen() failed with {}", e.cause);
 
     Ok(())
 }


### PR DESCRIPTION
## Description

- This PR closes https://github.com/demikernel/demikernel/issues/566
- This PR exposes https://github.com/demikernel/demikernel/issues/584

## Summary of Changes

Added the following integration tests for TCP `listen()`:
- Attempt to listen for connections on a TCP socket with a zero backlog length.
- Attempt to listen for connections on a TCP socket with an invalid backlog length.
- Attempt to listen for connections on a TCP socket that is closed.