### PR TITLE
[build] Drop Use of `new_uninit`

### DIFF
--- a/src/rust/lib.rs
+++ b/src/rust/lib.rs
@@ -3,7 +3,6 @@
 
 #![cfg_attr(feature = "strict", deny(clippy:all))]
 #![recursion_limit = "512"]
-#![feature(new_uninit)]
 #![feature(atomic_from_mut)]
 #![feature(never_type)]
 #![feature(test)]

--- a/tests/rust/tcp.rs
+++ b/tests/rust/tcp.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-#![feature(new_uninit)]
-
 mod common;
 
 //======================================================================================================================

--- a/tests/rust/udp.rs
+++ b/tests/rust/udp.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-#![feature(new_uninit)]
-
 mod common;
 
 //==============================================================================


### PR DESCRIPTION
## Description

- This PR is a partial fix for https://github.com/demikernel/demikernel/issues/172

## Summary of Changes

- Drop use of `new_uninit` unstable feature