### PR TITLE
[test] Removing Scheduler Assumptions from Tests

### DIFF
--- a/tests/rust/tcp-test/close/wait.rs
+++ b/tests/rust/tcp-test/close/wait.rs
@@ -121,11 +121,11 @@ fn wait_after_close_connecting_socket(libos: &mut LibOS, remote: &SocketAddrV4) 
             Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_CONNECT && qr.qr_ret == 0 => {
                 anyhow::bail!("connect() should not succeed because remote does not exist")
             },
-
             Ok(_) => anyhow::bail!("wait() should return an error on connect() after close()"),
             Err(_) => anyhow::bail!("wait() should not time out"),
         }
     }
+
     Ok(())
 }
 


### PR DESCRIPTION
This PR closes issue #626. I removed 2 tests from the close and async_close tests because they are replicated by the wait after close tests. For example, close_accepting_socket and close_connecting_socket is now identical to wait_after_close_accepting_socket. There are additional tests that are duplicated, for example, accept_listening_socket is identical to wait_after_closing_accepting socket. Likewise, close_listening_socket is identical to listen_bound_socket. I chose not to remove those duplicates as they are in different modules and potentially serve different purposes, but I removed the duplicate tests that were all for close. Let me know if we want to do something else.