### PR TITLE
[test] Remove panic, expect and unwrap from integration tests

### DIFF
--- a/tests/rust/common/libos.rs
+++ b/tests/rust/common/libos.rs
@@ -9,6 +9,7 @@ use super::runtime::DummyRuntime;
 use ::demikernel::{
     inetstack::InetStack,
     runtime::{
+        fail::Fail,
         logging,
         memory::DemiBuffer,
         network::{
@@ -55,7 +56,7 @@ impl DummyLibOS {
         tx: Sender<DemiBuffer>,
         rx: Receiver<DemiBuffer>,
         arp: HashMap<Ipv4Addr, MacAddress>,
-    ) -> InetStack {
+    ) -> Result<InetStack, Fail> {
         let now: Instant = Instant::now();
         let rt: Rc<DummyRuntime> = Rc::new(DummyRuntime::new(now, rx, tx));
         let arp_options: ArpConfig = ArpConfig::new(
@@ -82,7 +83,6 @@ impl DummyLibOS {
             rng_seed,
             arp_options,
         )
-        .unwrap()
     }
 
     /// Cooks a buffer.

--- a/tests/rust/sga.rs
+++ b/tests/rust/sga.rs
@@ -5,6 +5,7 @@
 // Imports
 //==============================================================================
 
+use ::anyhow::Result;
 use ::demikernel::{
     runtime::types::demi_sgarray_t,
     LibOS,
@@ -26,35 +27,35 @@ const SGA_SIZE_BIG: usize = 1280;
 //==============================================================================
 
 /// Tests for a single scatter-gather array allocation and deallocation.
-fn do_test_unit_sga_alloc_free_single(size: usize) {
+fn do_test_unit_sga_alloc_free_single(size: usize) -> Result<()> {
     let libos_name: LibOSName = match LibOSName::from_env() {
         Ok(libos_name) => libos_name.into(),
-        Err(e) => panic!("{:?}", e),
+        Err(e) => anyhow::bail!("{:?}", e),
     };
     let libos: LibOS = match LibOS::new(libos_name) {
         Ok(libos) => libos,
-        Err(e) => panic!("failed to initialize libos: {:?}", e.cause),
+        Err(e) => anyhow::bail!("failed to initialize libos: {:?}", e),
     };
 
     let sga: demi_sgarray_t = match libos.sgaalloc(size) {
         Ok(sga) => sga,
-        Err(e) => panic!("failed to allocate sga: {:?}", e.cause),
+        Err(e) => anyhow::bail!("failed to allocate sga: {:?}", e),
     };
     match libos.sgafree(sga) {
-        Ok(()) => (),
-        Err(e) => panic!("failed to release sga: {:?}", e.cause),
-    };
+        Ok(()) => Ok(()),
+        Err(e) => anyhow::bail!("failed to release sga: {:?}", e.cause),
+    }
 }
 
 /// Tests a single allocation and deallocation of a small scatter-gather array.
 #[test]
-fn test_unit_sga_alloc_free_single_small() {
+fn test_unit_sga_alloc_free_single_small() -> Result<()> {
     do_test_unit_sga_alloc_free_single(SGA_SIZE_SMALL)
 }
 
 /// Tests a single allocation and deallocation of a big scatter-gather array.
 #[test]
-fn test_unit_sga_alloc_free_single_big() {
+fn test_unit_sga_alloc_free_single_big() -> Result<()> {
     do_test_unit_sga_alloc_free_single(SGA_SIZE_BIG)
 }
 
@@ -63,38 +64,48 @@ fn test_unit_sga_alloc_free_single_big() {
 //==============================================================================
 
 /// Tests looped allocation and deallocation of scatter-gather arrays.
-fn do_test_unit_sga_alloc_free_loop_tight(size: usize) {
+fn do_test_unit_sga_alloc_free_loop_tight(size: usize) -> Result<()> {
     let libos_name: LibOSName = match LibOSName::from_env() {
         Ok(libos_name) => libos_name.into(),
-        Err(e) => panic!("{:?}", e),
+        Err(e) => anyhow::bail!("{:?}", e),
     };
     let libos: LibOS = match LibOS::new(libos_name) {
         Ok(libos) => libos,
-        Err(e) => panic!("failed to initialize libos: {:?}", e.cause),
+        Err(e) => anyhow::bail!("failed to initialize libos: {:?}", e),
     };
 
     // Allocate and deallocate several times.
     for _ in 0..1_000_000 {
         let sga: demi_sgarray_t = match libos.sgaalloc(size) {
             Ok(sga) => sga,
-            Err(e) => panic!("failed to allocate sga: {:?}", e.cause),
+            Err(e) => {
+                // Free previously allocated sgas on error.
+                // FIXME: https://github.com/demikernel/demikernel/issues/633
+                anyhow::bail!("failed to allocate sga: {:?}", e)
+            },
         };
         match libos.sgafree(sga) {
             Ok(()) => (),
-            Err(e) => panic!("failed to release sga: {:?}", e.cause),
+            Err(e) => {
+                // Continue freeing remainder on error?
+                // FIXME: https://github.com/demikernel/demikernel/issues/633
+                anyhow::bail!("failed to release sga: {:?}", e.cause)
+            },
         };
     }
+
+    Ok(())
 }
 
 /// Tests looped allocation and deallocation of small scatter-gather arrays.
 #[test]
-fn test_unit_sga_alloc_free_loop_tight_small() {
+fn test_unit_sga_alloc_free_loop_tight_small() -> Result<()> {
     do_test_unit_sga_alloc_free_loop_tight(SGA_SIZE_SMALL)
 }
 
 /// Tests looped allocation and deallocation of big scatter-gather arrays.
 #[test]
-fn test_unit_sga_alloc_free_loop_tight_big() {
+fn test_unit_sga_alloc_free_loop_tight_big() -> Result<()> {
     do_test_unit_sga_alloc_free_loop_tight(SGA_SIZE_BIG)
 }
 
@@ -103,15 +114,15 @@ fn test_unit_sga_alloc_free_loop_tight_big() {
 //==============================================================================
 
 /// Tests decoupled looped allocation and deallocation of scatter-gather arrays.
-fn do_test_unit_sga_alloc_free_loop_decoupled(size: usize) {
+fn do_test_unit_sga_alloc_free_loop_decoupled(size: usize) -> Result<()> {
     let mut sgas: Vec<demi_sgarray_t> = Vec::with_capacity(1_000);
     let libos_name: LibOSName = match LibOSName::from_env() {
         Ok(libos_name) => libos_name.into(),
-        Err(e) => panic!("{:?}", e),
+        Err(e) => anyhow::bail!("{:?}", e),
     };
     let libos: LibOS = match LibOS::new(libos_name) {
         Ok(libos) => libos,
-        Err(e) => panic!("failed to initialize libos: {:?}", e.cause),
+        Err(e) => anyhow::bail!("failed to initialize libos: {:?}", e),
     };
 
     // Allocate and deallocate several times.
@@ -120,30 +131,47 @@ fn do_test_unit_sga_alloc_free_loop_decoupled(size: usize) {
         for _ in 0..1_000 {
             let sga: demi_sgarray_t = match libos.sgaalloc(size) {
                 Ok(sga) => sga,
-                Err(e) => panic!("failed to allocate sga: {:?}", e.cause),
+                Err(e) => {
+                    // Free previously allocated sgas on error.
+                    // FIXME: https://github.com/demikernel/demikernel/issues/633
+                    anyhow::bail!("failed to allocate sga: {:?}", e)
+                },
             };
             sgas.push(sga);
         }
 
         // Deallocate all scatter-gather arrays.
         for _ in 0..1_000 {
-            let sga: demi_sgarray_t = sgas.pop().expect("pop from empty vector?");
+            let sga: demi_sgarray_t = match sgas.pop() {
+                Some(sga) => sga,
+                None => {
+                    // Free previously allocated sgas on error.
+                    // FIXME: https://github.com/demikernel/demikernel/issues/633
+                    anyhow::bail!("pop from empty vector?")
+                },
+            };
             match libos.sgafree(sga) {
                 Ok(()) => (),
-                Err(e) => panic!("failed to release sga: {:?}", e.cause),
+                Err(e) => {
+                    // Continue freeing remainder on error?
+                    // FIXME: https://github.com/demikernel/demikernel/issues/633
+                    anyhow::bail!("failed to release sga: {:?}", e.cause)
+                },
             };
         }
     }
+
+    Ok(())
 }
 
 /// Tests decoupled looped allocation and deallocation of small scatter-gather arrays.
 #[test]
-fn test_unit_sga_alloc_free_loop_decoupled_small() {
+fn test_unit_sga_alloc_free_loop_decoupled_small() -> Result<()> {
     do_test_unit_sga_alloc_free_loop_decoupled(SGA_SIZE_SMALL)
 }
 
 /// Tests decoupled looped allocation and deallocation of big scatter-gather arrays.
 #[test]
-fn test_unit_sga_alloc_free_loop_decoupled_big() {
+fn test_unit_sga_alloc_free_loop_decoupled_big() -> Result<()> {
     do_test_unit_sga_alloc_free_loop_decoupled(SGA_SIZE_BIG)
 }


### PR DESCRIPTION
This PR addresses #207 for our integration tests (i.e., everything under the tests/rust director). It aligns the TCP and UDP tests with the new TCP integration tests.