### PR TITLE
[test] Remove panics from tcp-echo system test

### DIFF
--- a/examples/tcp-echo/main.rs
+++ b/examples/tcp-echo/main.rs
@@ -207,11 +207,11 @@ fn main() -> Result<()> {
 
     let libos_name: LibOSName = match LibOSName::from_env() {
         Ok(libos_name) => libos_name.into(),
-        Err(e) => panic!("{:?}", e),
+        Err(e) => anyhow::bail!("{:?}", e),
     };
     let libos: LibOS = match LibOS::new(libos_name) {
         Ok(libos) => libos,
-        Err(e) => panic!("failed to initialize libos: {:?}", e.cause),
+        Err(e) => anyhow::bail!("failed to initialize libos: {:?}", e.cause),
     };
 
     match args.peer_type.as_str() {

--- a/examples/tcp-echo/server.rs
+++ b/examples/tcp-echo/server.rs
@@ -99,9 +99,15 @@ impl TcpEchoServer {
 
         // Accept first connection.
         {
+            // If error, close socket and exit.
+            // FIXME: https://github.com/demikernel/demikernel/issues/642
             let qt: QToken = self.libos.accept(self.sockqd)?;
+            // If error, close socket and exit.
+            // FIXME: https://github.com/demikernel/demikernel/issues/642
             let qr: demi_qresult_t = self.libos.wait(qt, None)?;
             if qr.qr_opcode != demi_opcode_t::DEMI_OPC_ACCEPT {
+                // If error, close socket and exit.
+                // FIXME: https://github.com/demikernel/demikernel/issues/642
                 anyhow::bail!("failed to accept connection")
             }
             self.handle_accept(&qr)?;
@@ -146,6 +152,8 @@ impl TcpEchoServer {
 
     /// Issues an accept operation.
     fn issue_accept(&mut self) -> Result<()> {
+        // If error, consider closing this socket.
+        // FIXME: https://github.com/demikernel/demikernel/issues/642
         let qt: QToken = self.libos.accept(self.sockqd)?;
         self.register_operation(self.sockqd, qt);
         Ok(())
@@ -153,6 +161,8 @@ impl TcpEchoServer {
 
     /// Issues a push operation.
     fn issue_push(&mut self, qd: QDesc, sga: &demi_sgarray_t) -> Result<()> {
+        // If error, consider closing this socket.
+        // FIXME: https://github.com/demikernel/demikernel/issues/642
         let qt: QToken = self.libos.push(qd, &sga)?;
         self.register_operation(qd, qt);
         Ok(())
@@ -160,6 +170,8 @@ impl TcpEchoServer {
 
     /// Issues a pop operation.
     fn issue_pop(&mut self, qd: QDesc) -> Result<()> {
+        // If error, consider closing this socket.
+        // FIXME: https://github.com/demikernel/demikernel/issues/642
         let qt: QToken = self.libos.pop(qd, None)?;
         self.register_operation(qd, qt);
         Ok(())
@@ -209,9 +221,13 @@ impl TcpEchoServer {
         self.clients.insert(new_qd);
 
         // Pop first packet.
+        // If error, consider closing this socket.
+        // FIXME: https://github.com/demikernel/demikernel/issues/642
         self.issue_pop(new_qd)?;
 
         // Accept more connections.
+        // If error, consider closing this socket.
+        // FIXME: https://github.com/demikernel/demikernel/issues/642
         self.issue_accept()?;
 
         Ok(())
@@ -228,9 +244,13 @@ impl TcpEchoServer {
             self.handle_close(qd)?;
         } else {
             // Push packet back.
+            // If error, consider closing this socket.
+            // FIXME: https://github.com/demikernel/demikernel/issues/642
             self.issue_push(qd, &sga)?;
 
             // Pop more data.
+            // If error, consider closing this socket.
+            // FIXME: https://github.com/demikernel/demikernel/issues/642
             self.issue_pop(qd)?;
         }
 


### PR DESCRIPTION
This PR removes any use of panic! from the tcp-echo system test in examples/tcp-close. Instead, we use bail! to fail gracefully and add tags for where open sockets or scatter-gather arrays should be closed/freed.