### PR TITLE
[test] Integration Tests for TCP `create_pipe()`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,11 @@ path = "tests/rust/tcp-test/main.rs"
 harness = false
 
 [[test]]
+name = "pipe-test"
+path = "tests/rust/pipe-test/main.rs"
+harness = false
+
+[[test]]
 name = "tcp"
 path = "tests/rust/tcp.rs"
 

--- a/linux.mk
+++ b/linux.mk
@@ -182,6 +182,7 @@ export MTU ?= 1500
 export MSS ?= 1500
 export PEER ?= server
 export TEST ?= udp-push-pop
+export TEST_INTEGRATION ?= tcp-test
 export TIMEOUT ?= 30
 
 # Runs system tests.
@@ -212,4 +213,4 @@ test-unit-rust:
 
 # Runs Rust integration tests.
 test-integration-rust:
-	$(CARGO) test --test tcp-test $(CARGO_FLAGS) $(CARGO_FEATURES) -- $(ARGS)
+	$(CARGO) test --test $(TEST_INTEGRATION) $(CARGO_FLAGS) $(CARGO_FEATURES) -- $(ARGS)

--- a/tests/rust/pipe-test/args.rs
+++ b/tests/rust/pipe-test/args.rs
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//======================================================================================================================
+// Imports
+//======================================================================================================================
+
+use ::anyhow::Result;
+use ::clap::{
+    Arg,
+    ArgMatches,
+    Command,
+};
+
+//======================================================================================================================
+// Program Arguments
+//======================================================================================================================
+
+/// Program Arguments
+#[derive(Debug)]
+pub struct ProgramArguments {
+    /// Pipe name.
+    pipe_name: String,
+}
+
+impl ProgramArguments {
+    /// Parses the program arguments from the command line interface.
+    pub fn new(app_name: &'static str, app_author: &'static str, app_about: &'static str) -> Result<Self> {
+        let matches: ArgMatches = Command::new(app_name)
+            .author(app_author)
+            .about(app_about)
+            .arg(
+                Arg::new("pipe-name")
+                    .long("pipe-name")
+                    .value_parser(clap::value_parser!(String))
+                    .required(true)
+                    .value_name("NAME")
+                    .help("Sets pipename"),
+            )
+            .get_matches();
+
+        // Pipe name.
+        let pipe_name: String = matches
+            .get_one::<String>("pipe-name")
+            .ok_or(anyhow::anyhow!("missing pipe_nameess"))?
+            .to_string();
+
+        Ok(Self { pipe_name })
+    }
+
+    /// Returns the `pipe_name` command line argument.
+    pub fn pipe_name(&self) -> String {
+        self.pipe_name.clone()
+    }
+}

--- a/tests/rust/pipe-test/create_pipe/mod.rs
+++ b/tests/rust/pipe-test/create_pipe/mod.rs
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//======================================================================================================================
+// Imports
+//======================================================================================================================
+
+use ::anyhow::Result;
+use ::demikernel::{
+    runtime::fail::Fail,
+    LibOS,
+};
+
+//======================================================================================================================
+// Standalone Functions
+//======================================================================================================================
+
+/// Drives integration tests for pipe queues.
+pub fn run(libos: &mut LibOS, pipe_name: &str) -> Result<()> {
+    let mut ret: Result<(), anyhow::Error> = Ok(());
+
+    match create_pipe_with_invalid_name(libos) {
+        Ok(_) => println!("[passed] {}", stringify!(create_pipe_with_invalid_name)),
+        Err(e) => {
+            // Don't overwrite previous error.
+            if ret.is_ok() {
+                ret = Err(e);
+            }
+            println!("[FAILED] {}", stringify!(create_pipe_with_invalid_name))
+        },
+    };
+
+    ret
+}
+
+/// Attempts to create a pipe with an invalid name.
+fn create_pipe_with_invalid_name(libos: &mut LibOS) -> Result<()> {
+    // Fail to create pipe with an invalid name.
+    match libos.create_pipe(&format!("")) {
+        Err(e) if e.errno == libc::EINVAL => Ok(()),
+        Ok(_) => anyhow::bail!("create_pipe() with invalid name should fail"),
+        Err(e) => anyhow::bail!("create_pipe() failed with {}", e.cause),
+    }
+}

--- a/tests/rust/pipe-test/create_pipe/mod.rs
+++ b/tests/rust/pipe-test/create_pipe/mod.rs
@@ -7,8 +7,8 @@
 
 use ::anyhow::Result;
 use ::demikernel::{
-    runtime::fail::Fail,
     LibOS,
+    QDesc,
 };
 
 //======================================================================================================================
@@ -30,6 +30,17 @@ pub fn run(libos: &mut LibOS, pipe_name: &str) -> Result<()> {
         },
     };
 
+    match create_pipe_with_same_name(libos, pipe_name) {
+        Ok(_) => println!("[passed] {}", stringify!(create_pipe_with_same_name)),
+        Err(e) => {
+            // Don't overwrite previous error.
+            if ret.is_ok() {
+                ret = Err(e);
+            }
+            println!("[FAILED] {}", stringify!(create_pipe_with_same_name))
+        },
+    };
+
     ret
 }
 
@@ -41,4 +52,36 @@ fn create_pipe_with_invalid_name(libos: &mut LibOS) -> Result<()> {
         Ok(_) => anyhow::bail!("create_pipe() with invalid name should fail"),
         Err(e) => anyhow::bail!("create_pipe() failed with {}", e.cause),
     }
+}
+
+/// Attempts to create two pipes with the same name.
+fn create_pipe_with_same_name(libos: &mut LibOS, pipe_name: &str) -> Result<()> {
+    // Succeed to create first pipe
+    let pipeqd: QDesc = match libos.create_pipe(pipe_name) {
+        Ok(pipeqd) => pipeqd,
+        Err(e) => anyhow::bail!("create_pipe() failed with {}", e.cause),
+    };
+
+    // Fail to create pipe with the same name.
+    let mut ret: Result<(), anyhow::Error> = match libos.create_pipe(pipe_name) {
+        Err(e) if e.errno == libc::EEXIST => Ok(()),
+        Ok(_) => Err(anyhow::anyhow!("create_pipe() with same name should fail")),
+        Err(e) => Err(anyhow::anyhow!("create_pipe() failed with {}", e.cause)),
+    };
+
+    // Close pipe first pipe.
+    match libos.close(pipeqd) {
+        Ok(_) => (),
+        Err(e) => {
+            let errmsg: String = format!("close() failed with {}", e.cause);
+            // Don't overwrite previous error.
+            if ret.is_ok() {
+                ret = Err(anyhow::anyhow!("{}", errmsg));
+            } else {
+                println!("{}", errmsg);
+            }
+        },
+    }
+
+    ret
 }

--- a/tests/rust/pipe-test/main.rs
+++ b/tests/rust/pipe-test/main.rs
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#![cfg_attr(feature = "strict", deny(warnings))]
+#![deny(clippy::all)]
+
+//======================================================================================================================
+// Modules
+//======================================================================================================================
+
+mod args;
+mod create_pipe;
+
+//======================================================================================================================
+// Imports
+//======================================================================================================================
+
+use self::args::ProgramArguments;
+use ::anyhow::Result;
+use ::demikernel::{
+    LibOS,
+    LibOSName,
+};
+
+//======================================================================================================================
+// Standalone Functions
+//======================================================================================================================
+
+fn main() -> Result<()> {
+    let args: ProgramArguments = ProgramArguments::new(
+        "pipe-test",
+        "Pedro Henrique Penna <ppenna@microsoft.com>",
+        "Integration test for pipe queues.",
+    )?;
+
+    let mut libos: LibOS = {
+        let libos_name: LibOSName = LibOSName::from_env()?.into();
+        LibOS::new(libos_name)?
+    };
+
+    create_pipe::run(&mut libos, &args.pipe_name())?;
+
+    Ok(())
+}

--- a/tools/demikernel_ci.py
+++ b/tools/demikernel_ci.py
@@ -150,13 +150,15 @@ def job_test_unit_rust(repo: str, libos: str, is_debug: bool, server: str, clien
     return wait_and_report(test_name, log_directory, jobs, True)
 
 
-def job_test_integration_rust(
+def job_test_integration_tcp_rust(
         repo: str, libos: str, is_debug: bool, server: str, client: str, server_addr: str, client_addr: str,
         is_sudo: bool, config_path: str, log_directory: str) -> bool:
     server_args: str = "--local-address {}:12345 --remote-address {}:23456".format(server_addr, client_addr)
     client_args: str = "--local-address {}:23456 --remote-address {}:12345".format(client_addr, server_addr)
-    server_cmd: str = "test-integration-rust LIBOS={} ARGS=\\\"{}\\\"".format(libos, server_args)
-    client_cmd: str = "test-integration-rust LIBOS={} ARGS=\\\"{}\\\"".format(libos, client_args)
+    server_cmd: str = "test-integration-rust TEST_INTEGRATION=tcp-test LIBOS={} ARGS=\\\"{}\\\"".format(
+        libos, server_args)
+    client_cmd: str = "test-integration-rust TEST_INTEGRATION=tcp-test LIBOS={} ARGS=\\\"{}\\\"".format(
+        libos, client_args)
     test_name = "integration-test"
     jobs: dict[str, subprocess.Popen[str]] = {}
     jobs[test_name + "-server-" + server] = remote_run(server, repo, is_debug, server_cmd, is_sudo, config_path)
@@ -328,7 +330,7 @@ def run_pipeline(
             status["unit_tests"] = job_test_unit_rust(repository, libos, is_debug, server, client,
                                                       is_sudo, config_path, log_directory)
             if libos == "catnap":
-                status["integration_tests"] = job_test_integration_rust(
+                status["integration_tests"] = job_test_integration_tcp_rust(
                     repository, libos, is_debug, server, client, server_addr, client_addr, is_sudo, config_path, log_directory)
 
     # STEP 4: Run system tests.


### PR DESCRIPTION
## Description

This PR closes https://github.com/demikernel/demikernel/issues/615

## Summary of Changes

- Added switch for integration tests in the build system.
  - Run integration tests in TCP queues: `make test-integration-rust TEST_INTEGRATION=tcp-test ...`
  - Run integration tests in pipe queues: `make test-integration-rust TEST_INTEGRATION=pipe-test ...`
- Added the following integration tests for `create_pipe()`:
  - Attempt to create a pipe with an invalid name.
  - Attempt to create two pipes with the same name.