### PR TITLE
[test] Integration Tests for TCP `open_pipe()`

### DIFF
--- a/tests/rust/pipe-test/create_pipe/mod.rs
+++ b/tests/rust/pipe-test/create_pipe/mod.rs
@@ -16,32 +16,13 @@ use ::demikernel::{
 //======================================================================================================================
 
 /// Drives integration tests for pipe queues.
-pub fn run(libos: &mut LibOS, pipe_name: &str) -> Result<()> {
-    let mut ret: Result<(), anyhow::Error> = Ok(());
+pub fn run(libos: &mut LibOS, pipe_name: &str) -> Vec<(String, String, Result<(), anyhow::Error>)> {
+    let mut result: Vec<(String, String, Result<(), anyhow::Error>)> = Vec::new();
 
-    match create_pipe_with_invalid_name(libos) {
-        Ok(_) => println!("[passed] {}", stringify!(create_pipe_with_invalid_name)),
-        Err(e) => {
-            // Don't overwrite previous error.
-            if ret.is_ok() {
-                ret = Err(e);
-            }
-            println!("[FAILED] {}", stringify!(create_pipe_with_invalid_name))
-        },
-    };
+    crate::collect!(result, crate::test!(create_pipe_with_invalid_name(libos)));
+    crate::collect!(result, crate::test!(create_pipe_with_same_name(libos, pipe_name)));
 
-    match create_pipe_with_same_name(libos, pipe_name) {
-        Ok(_) => println!("[passed] {}", stringify!(create_pipe_with_same_name)),
-        Err(e) => {
-            // Don't overwrite previous error.
-            if ret.is_ok() {
-                ret = Err(e);
-            }
-            println!("[FAILED] {}", stringify!(create_pipe_with_same_name))
-        },
-    };
-
-    ret
+    result
 }
 
 /// Attempts to create a pipe with an invalid name.
@@ -56,7 +37,7 @@ fn create_pipe_with_invalid_name(libos: &mut LibOS) -> Result<()> {
 
 /// Attempts to create two pipes with the same name.
 fn create_pipe_with_same_name(libos: &mut LibOS, pipe_name: &str) -> Result<()> {
-    // Succeed to create first pipe
+    // Succeed to create first pipe.
     let pipeqd: QDesc = match libos.create_pipe(pipe_name) {
         Ok(pipeqd) => pipeqd,
         Err(e) => anyhow::bail!("create_pipe() failed with {}", e.cause),
@@ -69,17 +50,13 @@ fn create_pipe_with_same_name(libos: &mut LibOS, pipe_name: &str) -> Result<()> 
         Err(e) => Err(anyhow::anyhow!("create_pipe() failed with {}", e.cause)),
     };
 
-    // Close pipe first pipe.
+    // Close first pipe.
     match libos.close(pipeqd) {
         Ok(_) => (),
         Err(e) => {
             let errmsg: String = format!("close() failed with {}", e.cause);
-            // Don't overwrite previous error.
-            if ret.is_ok() {
-                ret = Err(anyhow::anyhow!("{}", errmsg));
-            } else {
-                println!("{}", errmsg);
-            }
+            crate::update_error!(ret, errmsg);
+            println!("[ERROR] leaking pipeqd={:?}", pipeqd);
         },
     }
 

--- a/tests/rust/pipe-test/create_pipe/mod.rs
+++ b/tests/rust/pipe-test/create_pipe/mod.rs
@@ -31,7 +31,7 @@ fn create_pipe_with_invalid_name(libos: &mut LibOS) -> Result<()> {
     match libos.create_pipe(&format!("")) {
         Err(e) if e.errno == libc::EINVAL => Ok(()),
         Ok(_) => anyhow::bail!("create_pipe() with invalid name should fail"),
-        Err(e) => anyhow::bail!("create_pipe() failed with {}", e.cause),
+        Err(e) => anyhow::bail!("create_pipe() failed ({})", e),
     }
 }
 
@@ -40,21 +40,21 @@ fn create_pipe_with_same_name(libos: &mut LibOS, pipe_name: &str) -> Result<()> 
     // Succeed to create first pipe.
     let pipeqd: QDesc = match libos.create_pipe(pipe_name) {
         Ok(pipeqd) => pipeqd,
-        Err(e) => anyhow::bail!("create_pipe() failed with {}", e.cause),
+        Err(e) => anyhow::bail!("create_pipe() failed ({})", e),
     };
 
     // Fail to create pipe with the same name.
     let mut ret: Result<(), anyhow::Error> = match libos.create_pipe(pipe_name) {
         Err(e) if e.errno == libc::EEXIST => Ok(()),
         Ok(_) => Err(anyhow::anyhow!("create_pipe() with same name should fail")),
-        Err(e) => Err(anyhow::anyhow!("create_pipe() failed with {}", e.cause)),
+        Err(e) => Err(anyhow::anyhow!("create_pipe() failed ({})", e)),
     };
 
     // Close first pipe.
     match libos.close(pipeqd) {
         Ok(_) => (),
         Err(e) => {
-            let errmsg: String = format!("close() failed with {}", e.cause);
+            let errmsg: String = format!("close() failed ({})", e);
             crate::update_error!(ret, errmsg);
             println!("[ERROR] leaking pipeqd={:?}", pipeqd);
         },

--- a/tests/rust/pipe-test/main.rs
+++ b/tests/rust/pipe-test/main.rs
@@ -10,6 +10,7 @@
 
 mod args;
 mod create_pipe;
+mod open_pipe;
 
 //======================================================================================================================
 // Imports
@@ -80,6 +81,7 @@ fn main() -> Result<()> {
     };
 
     crate::collect!(result, create_pipe::run(&mut libos, &args.pipe_name()));
+    crate::collect!(result, open_pipe::run(&mut libos, &args.pipe_name()));
 
     // Dump results.
     for (test_name, test_status, test_result) in result {

--- a/tests/rust/pipe-test/main.rs
+++ b/tests/rust/pipe-test/main.rs
@@ -23,6 +23,44 @@ use ::demikernel::{
 };
 
 //======================================================================================================================
+// Macros
+//======================================================================================================================
+
+/// Runs a test and prints if it passed or failed on the standard output.
+#[macro_export]
+macro_rules! test {
+    ($fn_name:ident($($arg:expr),*)) => {{
+        match $fn_name($($arg),*) {
+            Ok(ok) =>
+                vec![(stringify!($fn_name).to_string(), "passed".to_string(), Ok(ok))],
+            Err(err) =>
+                vec![(stringify!($fn_name).to_string(), "failed".to_string(), Err(err))],
+        }
+    }};
+}
+
+/// Updates the error variable `err_var` with `anyhow::anyhow!(msg)` if `err_var` is `Ok`.
+/// Otherwise it prints `msg` on the standard output.
+#[macro_export]
+macro_rules! update_error {
+    ($err_var:ident, $msg:expr) => {
+        if $err_var.is_ok() {
+            $err_var = Err(anyhow::anyhow!($msg));
+        } else {
+            println!("{}", $msg);
+        }
+    };
+}
+
+/// Collects the result of a test and appends it to a vector.
+#[macro_export]
+macro_rules! collect {
+    ($vec:ident, $expr:expr) => {
+        $vec.append(&mut $expr);
+    };
+}
+
+//======================================================================================================================
 // Standalone Functions
 //======================================================================================================================
 

--- a/tests/rust/pipe-test/open_pipe/mod.rs
+++ b/tests/rust/pipe-test/open_pipe/mod.rs
@@ -1,0 +1,93 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//======================================================================================================================
+// Imports
+//======================================================================================================================
+
+use ::anyhow::Result;
+use ::demikernel::{
+    LibOS,
+    QDesc,
+};
+
+//======================================================================================================================
+// Standalone Functions
+//======================================================================================================================
+
+/// Drives integration tests for pipe queues.
+pub fn run(libos: &mut LibOS, pipe_name: &str) -> Vec<(String, String, Result<(), anyhow::Error>)> {
+    let mut result: Vec<(String, String, Result<(), anyhow::Error>)> = Vec::new();
+
+    crate::collect!(result, crate::test!(open_pipe_with_invalid_name(libos)));
+    crate::collect!(result, crate::test!(open_pipe_that_does_not_exist(libos, pipe_name)));
+    crate::collect!(result, crate::test!(open_pipe_multiple_times(libos, pipe_name)));
+
+    result
+}
+
+/// Attempts to open a pipe with an invalid name.
+fn open_pipe_with_invalid_name(libos: &mut LibOS) -> Result<()> {
+    // Fail to create pipe with an invalid name.
+    match libos.create_pipe(&format!("")) {
+        Err(e) if e.errno == libc::EINVAL => Ok(()),
+        Ok(_) => anyhow::bail!("create_pipe() with invalid name should fail"),
+        Err(e) => anyhow::bail!("create_pipe() failed ({})", e),
+    }
+}
+
+/// Attempts to open a pipe that does not exist.
+fn open_pipe_that_does_not_exist(libos: &mut LibOS, pipe_name: &str) -> Result<()> {
+    // Fail to open pipe that does not exist.
+    match libos.open_pipe(&format!("{}-does-not-exist", pipe_name)) {
+        Err(e) if e.errno == libc::ENOENT => Ok(()),
+        Ok(_) => anyhow::bail!("open_pipe() that does not exist should fail"),
+        Err(e) => anyhow::bail!("open_pipe() failed ({})", e),
+    }
+}
+
+/// Attempts to open a pipe multiple times.
+fn open_pipe_multiple_times(libos: &mut LibOS, pipe_name: &str) -> Result<()> {
+    let mut ret: Result<(), anyhow::Error> = Ok(());
+
+    // Create a pipe.
+    let pipeqd: QDesc = match libos.create_pipe(pipe_name) {
+        Ok(pipeqd) => pipeqd,
+        Err(e) => anyhow::bail!("create_pipe() failed ({})", e),
+    };
+
+    // Succeed to open pipe multiple times. The number of iterations was set arbitrarily.
+    for _ in 0..128 {
+        let pipeqd: QDesc = match libos.open_pipe(pipe_name) {
+            Ok(pipeqd) => pipeqd,
+            Err(e) => {
+                let errmsg: String = format!("open_pipe() failed ({})", e);
+                crate::update_error!(ret, errmsg);
+                println!("[ERROR] leaking pipeqd={:?}", pipeqd);
+                break;
+            },
+        };
+
+        match libos.close(pipeqd) {
+            Ok(_) => (),
+            Err(e) => {
+                let errmsg: String = format!("close() failed ({})", e);
+                crate::update_error!(ret, errmsg);
+                println!("[ERROR] leaking pipeqd={:?}", pipeqd);
+                break;
+            },
+        }
+    }
+
+    // Succeed to close pipe.
+    match libos.close(pipeqd) {
+        Ok(_) => (),
+        Err(e) => {
+            let errmsg: String = format!("close() failed ({})", e);
+            crate::update_error!(ret, errmsg);
+            println!("[ERROR] leaking pipeqd={:?}", pipeqd);
+        },
+    }
+
+    ret
+}


### PR DESCRIPTION
## Description

- This PR closes https://github.com/demikernel/demikernel/issues/616

## Summary of Changes

- Added `test!()` helper macro that lunches a test a prints on the standard output if that test has passed or failed.
- Added `update_error!()` helper macro that updates an error variable with an error without overwriting previous error.
- Changed integration tests for `open_pipe()` to use the `test!()` and `update_error!()` helper macros.
- Added the following integration tests for `create_pipe()`:
  - Attempt to open a pipe with an invalid name.
  - Attempt to open a pipe that does not exist.
  - Attempt to open open the same pipe multiple times.