### PR TITLE
[test] Add `ensure_eq!` macro

### DIFF
--- a/src/rust/lib.rs
+++ b/src/rust/lib.rs
@@ -74,3 +74,59 @@ pub use crate::runtime::{
 };
 
 pub mod demikernel;
+
+//======================================================================================================================
+// Macros
+//======================================================================================================================
+
+/// Ensures that two expressions are equivalent or return an Error.
+#[macro_export]
+macro_rules! ensure_eq {
+    ($left:expr, $right:expr) => ({
+        match (&$left, &$right) {
+            (left_val, right_val) => {
+                if !(*left_val == *right_val) {
+                    anyhow::bail!(r#"ensure failed: `(left == right)` left: `{:?}`,right: `{:?}`"#, left_val, right_val)
+                }
+            }
+        }
+    });
+    ($left:expr, $right:expr,) => ({
+        crate::ensure_eq!($left, $right)
+    });
+    ($left:expr, $right:expr, $($arg:tt)+) => ({
+        match (&($left), &($right)) {
+            (left_val, right_val) => {
+                if !(*left_val == *right_val) {
+                    anyhow::bail!(r#"ensure failed: `(left == right)` left: `{:?}`, right: `{:?}`: {}"#, left_val, right_val, format_args!($($arg)+))
+                }
+            }
+        }
+    });
+}
+
+/// Ensure that two expressions are not equal or returns an Error.
+#[macro_export]
+macro_rules! ensure_neq {
+    ($left:expr, $right:expr) => ({
+        match (&$left, &$right) {
+            (left_val, right_val) => {
+                if (*left_val == *right_val) {
+                    anyhow::bail!(r#"ensure failed: `(left == right)` left: `{:?}`,right: `{:?}`"#, left_val, right_val)
+                }
+            }
+        }
+    });
+    ($left:expr, $right:expr,) => ({
+        crate::ensure_neq!($left, $right)
+    });
+    ($left:expr, $right:expr, $($arg:tt)+) => ({
+        match (&($left), &($right)) {
+            (left_val, right_val) => {
+                if (*left_val == *right_val) {
+                    anyhow::bail!(r#"ensure failed: `(left == right)` left: `{:?}`, right: `{:?}`: {}"#, left_val, right_val, format_args!($($arg)+))
+                }
+            }
+        }
+    });
+}

--- a/src/rust/lib.rs
+++ b/src/rust/lib.rs
@@ -130,3 +130,12 @@ macro_rules! ensure_neq {
         }
     });
 }
+
+#[test]
+fn test_ensure() -> Result<(), anyhow::Error> {
+    ensure_eq!(1, 1);
+    ensure_eq!(1, 1, "test");
+    ensure_neq!(1, 2);
+    ensure_neq!(1, 2, "test");
+    Ok(())
+}


### PR DESCRIPTION
This PR introduces ensure_eq and ensure_neq, which are the equivalent of ensure for assert_eq and assert_neq. Since the anyhow crate doesn't support ensure_eq and ensure_neq, we have implemented it here for our use.