### PR TITLE
[test] Remove panic from collections unit tests

### DIFF
--- a/src/rust/collections/intrusive/intrusive_queue.rs
+++ b/src/rust/collections/intrusive/intrusive_queue.rs
@@ -128,15 +128,15 @@ pub trait IntrusivelyQueueable {
 // Unit tests for IntrusiveQueue type and IntrusivelyQueueable trait.
 #[cfg(test)]
 mod tests {
+    use super::{
+        IntrusiveQueue,
+        IntrusivelyQueueable,
+    };
+    use ::anyhow::Result;
     use core::cell::Cell;
     use std::{
         ptr::NonNull,
         rc::Rc,
-    };
-
-    use super::{
-        IntrusiveQueue,
-        IntrusivelyQueueable,
     };
 
     // A test element.
@@ -170,13 +170,13 @@ mod tests {
     }
 
     #[test]
-    fn fifo_order() {
+    fn fifo_order() -> Result<()> {
         // Create the queue.
         let mut test_iq: IntrusiveQueue<TestThingy> = IntrusiveQueue::new();
 
         // Verify: The queue should be empty.
-        assert!(test_iq.is_empty());
-        assert_eq!(test_iq.len(), 0);
+        crate::ensure_eq!(test_iq.is_empty(), true);
+        crate::ensure_eq!(test_iq.len(), 0);
 
         // Create some test elements.
         let element1: Rc<TestThingy> = Rc::new(TestThingy::new(1));
@@ -191,8 +191,8 @@ mod tests {
         test_iq.push_element(element4);
 
         // Verify: The queue should now contain 4 elements.
-        assert_eq!(test_iq.is_empty(), false);
-        assert_eq!(test_iq.len(), 4);
+        crate::ensure_eq!(test_iq.is_empty(), false);
+        crate::ensure_eq!(test_iq.len(), 4);
 
         // Pop the elements off of the front of the queue.
         // They should come off in the same order they went on (i.e. FIFO queue).
@@ -201,22 +201,24 @@ mod tests {
             check_data += 1;
 
             // Verify the correct element popped.
-            assert_eq!(popped_element.data, check_data);
+            crate::ensure_eq!(popped_element.data, check_data);
 
             // Verify refcount on element Rc is 1.
-            assert_eq!(Rc::strong_count(&popped_element), 1);
+            crate::ensure_eq!(Rc::strong_count(&popped_element), 1,);
 
             // Verify length of queue is correct.
-            assert_eq!(test_iq.len(), 4 - check_data as usize);
+            crate::ensure_eq!(test_iq.len(), 4 - check_data as usize);
         }
 
         // Verify: The queue should be empty.
-        assert!(test_iq.is_empty());
-        assert_eq!(test_iq.len(), 0);
+        crate::ensure_eq!(test_iq.is_empty(), true);
+        crate::ensure_eq!(test_iq.len(), 0);
+
+        Ok(())
     }
 
     #[test]
-    fn drop() {
+    fn drop() -> Result<()> {
         // Create some test elements.
         let element5: Rc<TestThingy> = Rc::new(TestThingy::new(5));
         let element6: Rc<TestThingy> = Rc::new(TestThingy::new(6));
@@ -224,40 +226,48 @@ mod tests {
         let element8: Rc<TestThingy> = Rc::new(TestThingy::new(8));
 
         // Verify refcount on each Rc is 1.
-        assert_eq!(Rc::strong_count(&element5), 1);
-        assert_eq!(Rc::strong_count(&element6), 1);
-        assert_eq!(Rc::strong_count(&element7), 1);
-        assert_eq!(Rc::strong_count(&element8), 1);
+        crate::ensure_eq!(Rc::strong_count(&element5), 1);
+        crate::ensure_eq!(Rc::strong_count(&element6), 1);
+        crate::ensure_eq!(Rc::strong_count(&element7), 1);
+        crate::ensure_eq!(Rc::strong_count(&element8), 1);
 
         // Call a subroutine, passing a clone of each element.
-        sub(element5.clone(), element6.clone(), element7.clone(), element8.clone());
+        sub(element5.clone(), element6.clone(), element7.clone(), element8.clone())?;
 
         // Verify that upon return from the subroutine, the refcount on each Rc is back to 1.
-        assert_eq!(Rc::strong_count(&element5), 1);
-        assert_eq!(Rc::strong_count(&element6), 1);
-        assert_eq!(Rc::strong_count(&element7), 1);
-        assert_eq!(Rc::strong_count(&element8), 1);
+        crate::ensure_eq!(Rc::strong_count(&element5), 1);
+        crate::ensure_eq!(Rc::strong_count(&element6), 1);
+        crate::ensure_eq!(Rc::strong_count(&element7), 1);
+        crate::ensure_eq!(Rc::strong_count(&element8), 1);
 
-        fn sub(element5: Rc<TestThingy>, element6: Rc<TestThingy>, element7: Rc<TestThingy>, element8: Rc<TestThingy>) {
+        fn sub(
+            element5: Rc<TestThingy>,
+            element6: Rc<TestThingy>,
+            element7: Rc<TestThingy>,
+            element8: Rc<TestThingy>,
+        ) -> Result<()> {
             // Create another queue.
             let mut another_iq: IntrusiveQueue<TestThingy> = IntrusiveQueue::new();
 
             // Verify refcount on each Rc is now 2.
-            assert_eq!(Rc::strong_count(&element5), 2);
-            assert_eq!(Rc::strong_count(&element6), 2);
-            assert_eq!(Rc::strong_count(&element7), 2);
-            assert_eq!(Rc::strong_count(&element8), 2);
+            crate::ensure_eq!(Rc::strong_count(&element5), 2);
+            crate::ensure_eq!(Rc::strong_count(&element6), 2);
+            crate::ensure_eq!(Rc::strong_count(&element7), 2);
+            crate::ensure_eq!(Rc::strong_count(&element8), 2);
 
             // Put only two of the elements on the queue.
             another_iq.push_element(element5);
             another_iq.push_element(element7);
 
             // Verify: The queue should now contain 2 elements.
-            assert_eq!(another_iq.is_empty(), false);
-            assert_eq!(another_iq.len(), 2);
+            crate::ensure_eq!(another_iq.is_empty(), false);
+            crate::ensure_eq!(another_iq.len(), 2);
 
             // Leaving this scope should drop the IntrusiveQueue with the two elements that are on it, as well as the
             // two unattached elements.
+            Ok(())
         }
+
+        Ok(())
     }
 }


### PR DESCRIPTION
This PR addresses issue #207 for all of the unit tests in src/rust/collections. It also adds a return value to every test and replaces assert with ensure and assert_eq with the new ensure_eq macro.