### PR TITLE
[test] Fix compiler errors and warnings

### DIFF
--- a/examples/rust/udp-echo.rs
+++ b/examples/rust/udp-echo.rs
@@ -203,7 +203,7 @@ impl Application {
                         Err(e) => {
                             // If error, close socket.
                             // FIXME: https://github.com/demikernel/demikernel/issues/651
-                            anyhow::bail!("could not parse sockaddr")
+                            anyhow::bail!("could not parse sockaddr: {}", e)
                         },
                     };
                     nbytes += sga.sga_segs[0].sgaseg_len as usize;

--- a/src/rust/catnap/socket.rs
+++ b/src/rust/catnap/socket.rs
@@ -293,6 +293,7 @@ impl Socket {
         self.local
     }
 
+    #[allow(dead_code)]
     /// Returns the `remote` address tot which [self] is connected.
     pub fn remote(&self) -> Option<SocketAddrV4> {
         self.remote

--- a/src/rust/inetstack/protocols/tcp/tests/mod.rs
+++ b/src/rust/inetstack/protocols/tcp/tests/mod.rs
@@ -21,6 +21,7 @@ use crate::{
         network::types::MacAddress,
     },
 };
+use ::anyhow::Result;
 use ::std::net::Ipv4Addr;
 
 //=============================================================================
@@ -35,24 +36,24 @@ pub fn check_packet_data(
     window_size: u16,
     seq_num: SeqNumber,
     ack_num: Option<SeqNumber>,
-) -> usize {
+) -> Result<usize> {
     let (eth2_header, eth2_payload) = Ethernet2Header::parse(bytes).unwrap();
-    assert_eq!(eth2_header.src_addr(), eth2_src_addr);
-    assert_eq!(eth2_header.dst_addr(), eth2_dst_addr);
-    assert_eq!(eth2_header.ether_type(), EtherType2::Ipv4);
+    crate::ensure_eq!(eth2_header.src_addr(), eth2_src_addr);
+    crate::ensure_eq!(eth2_header.dst_addr(), eth2_dst_addr);
+    crate::ensure_eq!(eth2_header.ether_type(), EtherType2::Ipv4);
     let (ipv4_header, ipv4_payload) = Ipv4Header::parse(eth2_payload).unwrap();
-    assert_eq!(ipv4_header.get_src_addr(), ipv4_src_addr);
-    assert_eq!(ipv4_header.get_dest_addr(), ipv4_dst_addr);
+    crate::ensure_eq!(ipv4_header.get_src_addr(), ipv4_src_addr);
+    crate::ensure_eq!(ipv4_header.get_dest_addr(), ipv4_dst_addr);
     let (tcp_header, tcp_payload) = TcpHeader::parse(&ipv4_header, ipv4_payload, false).unwrap();
-    assert_ne!(tcp_payload.len(), 0);
-    assert_eq!(tcp_header.window_size, window_size);
-    assert_eq!(tcp_header.seq_num, seq_num);
+    crate::ensure_neq!(tcp_payload.len(), 0);
+    crate::ensure_eq!(tcp_header.window_size, window_size);
+    crate::ensure_eq!(tcp_header.seq_num, seq_num);
     if let Some(ack_num) = ack_num {
-        assert_eq!(tcp_header.ack, true);
-        assert_eq!(tcp_header.ack_num, ack_num);
+        crate::ensure_eq!(tcp_header.ack, true);
+        crate::ensure_eq!(tcp_header.ack_num, ack_num);
     }
 
-    tcp_payload.len()
+    Ok(tcp_payload.len())
 }
 
 //=============================================================================
@@ -70,16 +71,18 @@ pub fn check_packet_pure_ack(
     ipv4_src_addr: Ipv4Addr,
     ipv4_dst_addr: Ipv4Addr,
     ack_num: SeqNumber,
-) {
+) -> Result<()> {
     let (eth2_header, eth2_payload) = Ethernet2Header::parse(bytes).unwrap();
-    assert_eq!(eth2_header.src_addr(), eth2_src_addr);
-    assert_eq!(eth2_header.dst_addr(), eth2_dst_addr);
-    assert_eq!(eth2_header.ether_type(), EtherType2::Ipv4);
+    crate::ensure_eq!(eth2_header.src_addr(), eth2_src_addr);
+    crate::ensure_eq!(eth2_header.dst_addr(), eth2_dst_addr);
+    crate::ensure_eq!(eth2_header.ether_type(), EtherType2::Ipv4);
     let (ipv4_header, ipv4_payload) = Ipv4Header::parse(eth2_payload).unwrap();
-    assert_eq!(ipv4_header.get_src_addr(), ipv4_src_addr);
-    assert_eq!(ipv4_header.get_dest_addr(), ipv4_dst_addr);
+    crate::ensure_eq!(ipv4_header.get_src_addr(), ipv4_src_addr);
+    crate::ensure_eq!(ipv4_header.get_dest_addr(), ipv4_dst_addr);
     let (tcp_header, tcp_payload) = TcpHeader::parse(&ipv4_header, ipv4_payload, false).unwrap();
-    assert_eq!(tcp_payload.len(), 0);
-    assert_eq!(tcp_header.ack, true);
-    assert_eq!(tcp_header.ack_num, ack_num);
+    crate::ensure_eq!(tcp_payload.len(), 0);
+    crate::ensure_eq!(tcp_header.ack, true);
+    crate::ensure_eq!(tcp_header.ack_num, ack_num);
+
+    Ok(())
 }

--- a/src/rust/inetstack/protocols/tcp/tests/setup.rs
+++ b/src/rust/inetstack/protocols/tcp/tests/setup.rs
@@ -90,7 +90,7 @@ fn test_connection_timeout() -> Result<()> {
         test_helpers::ALICE_IPV4,
         test_helpers::BOB_IPV4,
         listen_port,
-    );
+    )?;
 
     for _ in 0..nretries {
         for _ in 0..timeout.as_secs() {
@@ -272,7 +272,7 @@ fn test_refuse_connection_missing_syn() -> Result<()> {
         test_helpers::ALICE_IPV4,
         test_helpers::BOB_IPV4,
         listen_port,
-    );
+    )?;
 
     // Temper packet.
     let (eth2_header, ipv4_header, tcp_header): (Ethernet2Header, Ipv4Header, TcpHeader) =

--- a/src/rust/perftools/profiler/tests.rs
+++ b/src/rust/perftools/profiler/tests.rs
@@ -20,7 +20,7 @@ fn test_multiple_roots() -> Result<()> {
         }
     }
 
-    profiler::PROFILER.with(|p| {
+    profiler::PROFILER.with(|p| -> Result<()> {
         let p = p.borrow();
 
         crate::ensure_eq!(p.roots.len(), 2);
@@ -35,9 +35,9 @@ fn test_multiple_roots() -> Result<()> {
 
         crate::ensure_eq!(p.roots[0].borrow().num_calls, 6);
         crate::ensure_eq!(p.roots[1].borrow().num_calls, 1);
-    });
 
-    Ok(())
+        Ok(())
+    })
 }
 
 #[test]
@@ -55,7 +55,7 @@ fn test_succ_reuse() -> Result<()> {
 
     crate::ensure_eq!(profiler::PROFILER.with(|p| p.borrow().roots.len()), 1);
 
-    profiler::PROFILER.with(|p| {
+    profiler::PROFILER.with(|p| -> Result<()> {
         let p = p.borrow();
 
         crate::ensure_eq!(p.roots.len(), 1);
@@ -68,10 +68,12 @@ fn test_succ_reuse() -> Result<()> {
 
         let succ = root.succs[0].borrow();
         crate::ensure_eq!(succ.name, "b");
-        crate::ensure_eq!(ptr::eq(succ.pred.as_ref().unwrap().as_ref(), p.roots[0].as_ref()));
+        crate::ensure_eq!(ptr::eq(succ.pred.as_ref().unwrap().as_ref(), p.roots[0].as_ref()), true);
         crate::ensure_eq!(succ.succs.is_empty(), true);
         crate::ensure_eq!(succ.num_calls, 3);
-    });
+
+        Ok(())
+    })
 }
 
 #[test]
@@ -93,12 +95,12 @@ fn test_reset_during_frame() -> Result<()> {
         }
     }
 
-    profiler::PROFILER.with(|p| {
+    profiler::PROFILER.with(|p| -> Result<()> {
         let p = p.borrow();
 
         crate::ensure_eq!(p.roots.is_empty(), true);
         crate::ensure_eq!(p.current.is_none(), true);
-    });
 
-    Ok(())
+        Ok(())
+    })
 }

--- a/src/rust/runtime/memory/demibuffer.rs
+++ b/src/rust/runtime/memory/demibuffer.rs
@@ -998,7 +998,6 @@ impl TryFrom<&[u8]> for DemiBuffer {
 #[cfg(test)]
 mod tests {
     use super::DemiBuffer;
-    use crate::runtime::fail::Fail;
     use ::anyhow::Result;
     use std::ptr::NonNull;
 
@@ -1102,7 +1101,7 @@ mod tests {
         // `DemiBuffer::split_back` shouldn't fail, as we passed it a valid offset.
         let another_buf: DemiBuffer = match split_buf.split_back(9) {
             Ok(buf) => buf,
-            Err(e) => anyhow::bail!("DemiBuffer::split_back shouldn't fail for this offset"),
+            Err(e) => anyhow::bail!("DemiBuffer::split_back shouldn't fail for this offset: {}", e),
         };
 
         crate::ensure_eq!(buf.len(), 24);


### PR DESCRIPTION
This PR covers the following:
- Fixes and closes #674 
- Fixes a warning from an unused function in Catnap's new socket abstraction
- Fixes errors introduced by the new tests where we are not checking the outcome of some functions
- Fixes and closes #679 
These cleanups will make the build easier to understand by fixing and removing most spurious warnings.It removes a warning in catnap for an unused function
