### PR TITLE
[test] Switch to collect macro for tcp integration tests

### DIFF
--- a/tests/rust/tcp-test/accept/mod.rs
+++ b/tests/rust/tcp-test/accept/mod.rs
@@ -38,16 +38,18 @@ pub const SOCK_STREAM: i32 = libc::SOCK_STREAM;
 //======================================================================================================================
 
 /// Runs standalone tests.
-pub fn run(libos: &mut LibOS, addr: &SocketAddrV4) -> Result<()> {
-    accept_invalid_queue_descriptor(libos)?;
-    accept_unbound_socket(libos)?;
-    accept_active_socket(libos, addr)?;
-    accept_listening_socket(libos, addr)?;
-    accept_connecting_socket(libos, addr)?;
-    accept_accepting_socket(libos, addr)?;
-    accept_closed_socket(libos, addr)?;
+pub fn run(libos: &mut LibOS, addr: &SocketAddrV4) -> Vec<(String, String, Result<(), anyhow::Error>)> {
+    let mut result: Vec<(String, String, Result<(), anyhow::Error>)> = Vec::new();
 
-    Ok(())
+    crate::collect!(result, crate::test!(accept_invalid_queue_descriptor(libos)));
+    crate::collect!(result, crate::test!(accept_unbound_socket(libos)));
+    crate::collect!(result, crate::test!(accept_active_socket(libos, addr)));
+    crate::collect!(result, crate::test!(accept_listening_socket(libos, addr)));
+    crate::collect!(result, crate::test!(accept_connecting_socket(libos, addr)));
+    crate::collect!(result, crate::test!(accept_accepting_socket(libos, addr)));
+    crate::collect!(result, crate::test!(accept_closed_socket(libos, addr)));
+
+    result
 }
 
 /// Attempts to accept connections on an invalid queue descriptor.

--- a/tests/rust/tcp-test/bind/mod.rs
+++ b/tests/rust/tcp-test/bind/mod.rs
@@ -36,18 +36,26 @@ pub const SOCK_STREAM: i32 = libc::SOCK_STREAM;
 //======================================================================================================================
 
 /// Drives integration tests for bind() on TCP sockets.
-pub fn run(libos: &mut LibOS, local: &Ipv4Addr, remote: &Ipv4Addr) -> Result<()> {
-    bind_addr_to_invalid_queue_descriptor(libos, local)?;
-    bind_multiple_addresses_to_same_socket(libos, local)?;
-    bind_same_address_to_two_sockets(libos, local)?;
-    bind_to_private_ports(libos, local)?;
-    bind_to_wildcard_port(libos, local)?;
-    bind_to_wildcard_address(libos)?;
-    bind_to_wildcard_address_and_port(libos)?;
-    bind_to_non_local_address(libos, remote)?;
-    bind_to_closed_socket(libos, local)?;
+pub fn run(libos: &mut LibOS, local: &Ipv4Addr, remote: &Ipv4Addr) -> Vec<(String, String, Result<(), anyhow::Error>)> {
+    let mut result: Vec<(String, String, Result<(), anyhow::Error>)> = Vec::new();
 
-    Ok(())
+    crate::collect!(
+        result,
+        crate::test!(bind_addr_to_invalid_queue_descriptor(libos, local))
+    );
+    crate::collect!(
+        result,
+        crate::test!(bind_multiple_addresses_to_same_socket(libos, local))
+    );
+    crate::collect!(result, crate::test!(bind_same_address_to_two_sockets(libos, local)));
+    crate::collect!(result, crate::test!(bind_to_private_ports(libos, local)));
+    crate::collect!(result, crate::test!(bind_to_wildcard_port(libos, local)));
+    crate::collect!(result, crate::test!(bind_to_wildcard_address(libos)));
+    crate::collect!(result, crate::test!(bind_to_wildcard_address_and_port(libos)));
+    crate::collect!(result, crate::test!(bind_to_non_local_address(libos, remote)));
+    crate::collect!(result, crate::test!(bind_to_closed_socket(libos, local)));
+
+    result
 }
 
 /// Attempts to bind an address to an invalid queue_descriptor.

--- a/tests/rust/tcp-test/close/async_close.rs
+++ b/tests/rust/tcp-test/close/async_close.rs
@@ -38,14 +38,16 @@ pub const SOCK_STREAM: i32 = libc::SOCK_STREAM;
 //======================================================================================================================
 
 /// Drives integration tests for async_close() on TCP sockets.
-pub fn run(libos: &mut LibOS, addr: &SocketAddrV4) -> Result<()> {
-    async_close_invalid_queue_descriptor(libos)?;
-    async_close_socket_twice(libos)?;
-    async_close_unbound_socket(libos)?;
-    async_close_bound_socket(libos, addr)?;
-    async_close_listening_socket(libos, addr)?;
+pub fn run(libos: &mut LibOS, addr: &SocketAddrV4) -> Vec<(String, String, Result<(), anyhow::Error>)> {
+    let mut result: Vec<(String, String, Result<(), anyhow::Error>)> = Vec::new();
 
-    Ok(())
+    crate::collect!(result, crate::test!(async_close_invalid_queue_descriptor(libos)));
+    crate::collect!(result, crate::test!(async_close_socket_twice(libos)));
+    crate::collect!(result, crate::test!(async_close_unbound_socket(libos)));
+    crate::collect!(result, crate::test!(async_close_bound_socket(libos, addr)));
+    crate::collect!(result, crate::test!(async_close_listening_socket(libos, addr)));
+
+    result
 }
 
 /// Attempts to close an invalid queue descriptor.

--- a/tests/rust/tcp-test/close/wait.rs
+++ b/tests/rust/tcp-test/close/wait.rs
@@ -38,16 +38,30 @@ pub const SOCK_STREAM: i32 = libc::SOCK_STREAM;
 //======================================================================================================================
 
 /// Drives integration tests for close() on TCP sockets.
-pub fn run(libos: &mut LibOS, addr: &SocketAddrV4) -> Result<()> {
-    wait_after_close_accepting_socket(libos, addr)?;
-    wait_after_close_connecting_socket(libos, addr)?;
-    wait_after_async_close_accepting_socket(libos, addr)?;
-    wait_after_async_close_connecting_socket(libos, addr)?;
-    wait_on_invalid_queue_token_returns_einval(libos)?;
-    wait_for_accept_after_issuing_async_close(libos, addr)?;
-    wait_for_connect_after_issuing_async_close(libos, addr)?;
+pub fn run(libos: &mut LibOS, addr: &SocketAddrV4) -> Vec<(String, String, Result<(), anyhow::Error>)> {
+    let mut result: Vec<(String, String, Result<(), anyhow::Error>)> = Vec::new();
 
-    Ok(())
+    crate::collect!(result, crate::test!(wait_after_close_accepting_socket(libos, addr)));
+    crate::collect!(result, crate::test!(wait_after_close_connecting_socket(libos, addr)));
+    crate::collect!(
+        result,
+        crate::test!(wait_after_async_close_accepting_socket(libos, addr))
+    );
+    crate::collect!(
+        result,
+        crate::test!(wait_after_async_close_connecting_socket(libos, addr))
+    );
+    crate::collect!(result, crate::test!(wait_on_invalid_queue_token_returns_einval(libos)));
+    crate::collect!(
+        result,
+        crate::test!(wait_for_accept_after_issuing_async_close(libos, addr))
+    );
+    crate::collect!(
+        result,
+        crate::test!(wait_for_connect_after_issuing_async_close(libos, addr))
+    );
+
+    result
 }
 
 // Attempts to close a TCP socket that is accepting and then waits on the qtoken.

--- a/tests/rust/tcp-test/connect/mod.rs
+++ b/tests/rust/tcp-test/connect/mod.rs
@@ -41,17 +41,23 @@ pub const SOCK_STREAM: i32 = libc::SOCK_STREAM;
 //======================================================================================================================
 
 /// Drives integration tests for connect() on TCP sockets.
-pub fn run(libos: &mut LibOS, local: &SocketAddrV4, remote: &SocketAddrV4) -> Result<()> {
-    connect_invalid_queue_descriptor(libos, remote)?;
-    connect_to_bad_remote(libos)?;
-    connect_unbound_socket(libos, remote)?;
-    connect_bound_socket(libos, local, remote)?;
-    connect_listening_socket(libos, local, remote)?;
-    connect_connecting_socket(libos, remote)?;
-    connect_accepting_socket(libos, local, remote)?;
-    connect_closed_socket(libos, remote)?;
+pub fn run(
+    libos: &mut LibOS,
+    local: &SocketAddrV4,
+    remote: &SocketAddrV4,
+) -> Vec<(String, String, Result<(), anyhow::Error>)> {
+    let mut result: Vec<(String, String, Result<(), anyhow::Error>)> = Vec::new();
 
-    Ok(())
+    crate::collect!(result, crate::test!(connect_invalid_queue_descriptor(libos, remote)));
+    crate::collect!(result, crate::test!(connect_to_bad_remote(libos)));
+    crate::collect!(result, crate::test!(connect_unbound_socket(libos, remote)));
+    crate::collect!(result, crate::test!(connect_bound_socket(libos, local, remote)));
+    crate::collect!(result, crate::test!(connect_listening_socket(libos, local, remote)));
+    crate::collect!(result, crate::test!(connect_connecting_socket(libos, remote)));
+    crate::collect!(result, crate::test!(connect_accepting_socket(libos, local, remote)));
+    crate::collect!(result, crate::test!(connect_closed_socket(libos, remote)));
+
+    result
 }
 
 /// Attempts to connect an invalid queue descriptor.

--- a/tests/rust/tcp-test/listen/mod.rs
+++ b/tests/rust/tcp-test/listen/mod.rs
@@ -38,18 +38,20 @@ pub const SOCK_STREAM: i32 = libc::SOCK_STREAM;
 //======================================================================================================================
 
 /// Drives integration tests for listen() on TCP sockets.
-pub fn run(libos: &mut LibOS, addr: &SocketAddrV4) -> Result<()> {
-    listen_invalid_queue_descriptor(libos)?;
-    listen_unbound_socket(libos)?;
-    listen_bound_socket(libos, addr)?;
-    listen_large_backlog_length(libos, addr)?;
-    listen_invalid_zero_backlog_length(libos, addr)?;
-    listen_listening_socket(libos, addr)?;
-    listen_connecting_socket(libos, addr)?;
-    listen_accepting_socket(libos, addr)?;
-    listen_closed_socket(libos, addr)?;
+pub fn run(libos: &mut LibOS, addr: &SocketAddrV4) -> Vec<(String, String, Result<(), anyhow::Error>)> {
+    let mut result: Vec<(String, String, Result<(), anyhow::Error>)> = Vec::new();
 
-    Ok(())
+    crate::collect!(result, crate::test!(listen_invalid_queue_descriptor(libos)));
+    crate::collect!(result, crate::test!(listen_unbound_socket(libos)));
+    crate::collect!(result, crate::test!(listen_bound_socket(libos, addr)));
+    crate::collect!(result, crate::test!(listen_large_backlog_length(libos, addr)));
+    crate::collect!(result, crate::test!(listen_invalid_zero_backlog_length(libos, addr)));
+    crate::collect!(result, crate::test!(listen_listening_socket(libos, addr)));
+    crate::collect!(result, crate::test!(listen_connecting_socket(libos, addr)));
+    crate::collect!(result, crate::test!(listen_accepting_socket(libos, addr)));
+    crate::collect!(result, crate::test!(listen_closed_socket(libos, addr)));
+
+    result
 }
 
 /// Attempts to listen for connections on an invalid queue descriptor.

--- a/tests/rust/tcp-test/main.rs
+++ b/tests/rust/tcp-test/main.rs
@@ -27,7 +27,52 @@ use demikernel::{
     LibOSName,
 };
 
+//======================================================================================================================
+// Macros
+//======================================================================================================================
+
+/// Runs a test and prints if it passed or failed on the standard output.
+#[macro_export]
+macro_rules! test {
+    ($fn_name:ident($($arg:expr),*)) => {{
+        match $fn_name($($arg),*) {
+            Ok(ok) =>
+                vec![(stringify!($fn_name).to_string(), "passed".to_string(), Ok(ok))],
+            Err(err) =>
+                vec![(stringify!($fn_name).to_string(), "failed".to_string(), Err(err))],
+        }
+    }};
+}
+
+/// Updates the error variable `err_var` with `anyhow::anyhow!(msg)` if `err_var` is `Ok`.
+/// Otherwise it prints `msg` on the standard output.
+#[macro_export]
+macro_rules! update_error {
+    ($err_var:ident, $msg:expr) => {
+        if $err_var.is_ok() {
+            $err_var = Err(anyhow::anyhow!($msg));
+        } else {
+            println!("{}", $msg);
+        }
+    };
+}
+
+/// Collects the result of a test and appends it to a vector.
+#[macro_export]
+macro_rules! collect {
+    ($vec:ident, $expr:expr) => {
+        $vec.append(&mut $expr);
+    };
+}
+
+//======================================================================================================================
+// Standalone Functions
+//======================================================================================================================
+
 fn main() -> Result<()> {
+    let mut nfailed: usize = 0;
+    let mut result: Vec<(String, String, Result<(), anyhow::Error>)> = Vec::new();
+
     let args: ProgramArguments = ProgramArguments::new(
         "tcp",
         "Pedro Henrique Penna <ppenna@microsoft.com>",
@@ -39,12 +84,26 @@ fn main() -> Result<()> {
         LibOS::new(libos_name)?
     };
 
-    socket::run(&mut libos)?;
-    bind::run(&mut libos, &args.local().ip(), &args.remote().ip())?;
-    listen::run(&mut libos, &args.local())?;
-    accept::run(&mut libos, &args.local())?;
-    connect::run(&mut libos, &args.local(), &args.remote())?;
-    close::run(&mut libos, &args.local())?;
+    crate::collect!(result, socket::run(&mut libos));
+    crate::collect!(result, bind::run(&mut libos, &args.local().ip(), &args.remote().ip()));
+    crate::collect!(result, listen::run(&mut libos, &args.local()));
+    crate::collect!(result, accept::run(&mut libos, &args.local()));
+    crate::collect!(result, connect::run(&mut libos, &args.local(), &args.remote()));
+    crate::collect!(result, close::run(&mut libos, &args.local()));
 
-    Ok(())
+    // Dump results.
+    for (test_name, test_status, test_result) in result {
+        println!("[{}] {}", test_status, test_name);
+        if let Err(e) = test_result {
+            nfailed += 1;
+            println!("    {}", e);
+        }
+    }
+
+    if nfailed > 0 {
+        anyhow::bail!("{} tests failed", nfailed);
+    } else {
+        println!("all tests passed");
+        Ok(())
+    }
 }

--- a/tests/rust/tcp-test/socket/mod.rs
+++ b/tests/rust/tcp-test/socket/mod.rs
@@ -29,11 +29,13 @@ pub const SOCK_STREAM: i32 = libc::SOCK_STREAM;
 //======================================================================================================================
 
 /// Drives integration tests for socket() on TCP sockets.
-pub fn run(libos: &mut LibOS) -> Result<()> {
-    create_socket_using_unsupported_domain(libos)?;
-    create_socket_using_unsupported_type(libos)?;
+pub fn run(libos: &mut LibOS) -> Vec<(String, String, Result<(), anyhow::Error>)> {
+    let mut result: Vec<(String, String, Result<(), anyhow::Error>)> = Vec::new();
 
-    Ok(())
+    crate::collect!(result, crate::test!(create_socket_using_unsupported_domain(libos)));
+    crate::collect!(result, crate::test!(create_socket_using_unsupported_type(libos)));
+
+    result
 }
 
 /// Attempts to create a TCP socket using an unsupported domain.


### PR DESCRIPTION
This PR switches the tests in tests/rust/tcp-test to use the new collect macro.