### PR TITLE
[test] Wait on Invalid Queue Token Pipe

### DIFF
--- a/tests/rust/pipe-test/main.rs
+++ b/tests/rust/pipe-test/main.rs
@@ -15,6 +15,7 @@ mod create_pipe;
 mod open_pipe;
 mod pop_wait;
 mod push_wait;
+mod wait;
 
 //======================================================================================================================
 // Imports
@@ -89,6 +90,7 @@ fn main() -> Result<()> {
             crate::collect!(result, create_pipe::run(&mut libos, &args.pipe_name()));
             crate::collect!(result, open_pipe::run(&mut libos, &args.pipe_name()));
             crate::collect!(result, close::run(&mut libos, &args.pipe_name()));
+            crate::collect!(result, wait::run(&mut libos));
             crate::collect!(result, async_close::run(&mut libos, &args.pipe_name()));
 
             // Dump results.

--- a/tests/rust/pipe-test/wait/mod.rs
+++ b/tests/rust/pipe-test/wait/mod.rs
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//======================================================================================================================
+// Imports
+//======================================================================================================================
+
+use ::anyhow::Result;
+use ::demikernel::{
+    LibOS,
+    QToken,
+};
+use ::std::time::Duration;
+
+//======================================================================================================================
+// Standalone Functions
+//======================================================================================================================
+
+/// Drives integration tests for pipe queues.
+pub fn run(libos: &mut LibOS) -> Vec<(String, String, Result<(), anyhow::Error>)> {
+    let mut result: Vec<(String, String, Result<(), anyhow::Error>)> = Vec::new();
+
+    crate::collect!(result, crate::test!(wait_on_invalid_queue_token(libos)));
+
+    result
+}
+
+// Attempts to wait on an invalid queue token.
+fn wait_on_invalid_queue_token(libos: &mut LibOS) -> Result<()> {
+    // Wait on an invalid queue token made from u64 MAX value.
+    match libos.wait(QToken::from(u64::MAX), Some(Duration::from_micros(0))) {
+        Err(e) if e.errno == libc::EINVAL => {},
+        Ok(_) => anyhow::bail!("wait() should not succeed on invalid token"),
+        Err(e) => anyhow::bail!("wait() should fail with EINVAL (error={:?})", e),
+    }
+
+    // Wait on an invalid queue token made from 0 value.
+    match libos.wait(QToken::from(0), Some(Duration::from_micros(0))) {
+        Err(e) if e.errno == libc::EINVAL => {},
+        Ok(_) => anyhow::bail!("wait() should not succeed on invalid token"),
+        Err(e) => anyhow::bail!("wait() should fal with EINVAL (error={:?})", e),
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Description

This PR partially addresses https://github.com/demikernel/demikernel/issues/619

## Summary of Changes

- Added integration test for "attempt to wait on an invalid queue token".