### PR TITLE
[test] Wait Push After Asynchronous Close

### DIFF
--- a/tests/rust/pipe-test/args.rs
+++ b/tests/rust/pipe-test/args.rs
@@ -55,7 +55,7 @@ impl ProgramArguments {
                     .long("run-mode")
                     .value_parser(clap::value_parser!(String))
                     .required(true)
-                    .value_name("standalone|push-wait|pop-wait")
+                    .value_name("standalone|push-wait|pop-wait|push-wait-async")
                     .help("Sets run mode"),
             )
             .get_matches();

--- a/tests/rust/pipe-test/main.rs
+++ b/tests/rust/pipe-test/main.rs
@@ -131,6 +131,17 @@ fn main() -> Result<()> {
             },
             _ => anyhow::bail!("invalid peer type"),
         },
+        "push-wait-async" => match args.peer_type().ok_or(anyhow::anyhow!("missing peer type"))?.as_str() {
+            "client" => {
+                let mut client: push_wait::PipeClient = push_wait::PipeClient::new(libos, args.pipe_name())?;
+                client.run_aynsc()
+            },
+            "server" => {
+                let mut server: push_wait::PipeServer = push_wait::PipeServer::new(libos, args.pipe_name())?;
+                server.run()
+            },
+            _ => anyhow::bail!("invalid peer type"),
+        },
         _ => anyhow::bail!("invalid run mode"),
     }
 }

--- a/tests/rust/pipe-test/push_wait/client.rs
+++ b/tests/rust/pipe-test/push_wait/client.rs
@@ -13,7 +13,10 @@ use ::demikernel::{
     QDesc,
     QToken,
 };
-use ::std::slice;
+use ::std::{
+    slice,
+    time::Duration,
+};
 
 //======================================================================================================================
 // Structures
@@ -68,6 +71,61 @@ impl PipeClient {
             Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_PUSH && qr.qr_ret == 0 => {},
             Ok(_) => anyhow::bail!("wait() should not complete successfully with an opcode other than DEMI_OPC_PUSH"),
             Err(e) => anyhow::bail!("wait() should not fail (error={:?})", e),
+        }
+
+        Ok(())
+    }
+
+    // Runs the target pipe client.
+    pub fn run_aynsc(&mut self) -> Result<()> {
+        let mut push_completed: bool = false;
+
+        // Push some data.
+        // The number of pushes is set to an arbitrary value,
+        // but a small one to avoid contention on the underling ring buffer.
+        for _ in 0..16 {
+            self.push_and_wait()?;
+        }
+
+        // Push again, but don't wait the operation to complete.
+        let qt: QToken = self.push_and_dont_wait()?;
+
+        // Poll once to ensure that the co-routine runs.
+        match self.libos.wait(qt, Some(Duration::from_micros(0))) {
+            Err(e) if e.errno == libc::ETIMEDOUT => {},
+            Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_PUSH && qr.qr_ret == 0 => push_completed = true,
+            Ok(_) => anyhow::bail!("wait() should not complete successfully with an opcode other than DEMI_OPC_PUSH"),
+            Err(e) => anyhow::bail!("wait() should not fail wth error other than ETIMEDOUT (error={:?})", e),
+        }
+
+        // Succeed to close pipe.
+        // The following call to except() is safe because pipeqd is ensured to be open and assigned Some() value.
+        let qt_close: QToken = match self.libos.async_close(self.pipeqd.expect("pipe should not be closed")) {
+            Ok(qt) => qt,
+            Err(e) => anyhow::bail!("async_close() failed (error={:?})", e),
+        };
+
+        // Ensure that async_close() completes.
+        match self.libos.wait(qt_close, None) {
+            Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_CLOSE && qr.qr_ret == 0 => self.pipeqd = None,
+            Ok(_) => anyhow::bail!("wait() should not complete successfully with an opcode other than DEMI_OPC_CLOSE"),
+            Err(e) => anyhow::bail!("wait() should not fail (error={:?})", e),
+        }
+
+        // Wait for push() operation to complete.
+        if !push_completed {
+            match self.libos.wait(qt, None) {
+                Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_FAILED && qr.qr_ret == libc::ECANCELED => {},
+                Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_PUSH && qr.qr_ret == 0 => {},
+                Ok(_) => anyhow::bail!("wait() should complete successfully or fail with ECANCELED"),
+                Err(e) => anyhow::bail!("wait() should not fail (error={:?})", e),
+            }
+        } else {
+            match self.libos.wait(qt, None) {
+                Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_FAILED && qr.qr_ret == libc::ECANCELED => {},
+                Ok(_) => anyhow::bail!("wait() should fail with ECANCELED"),
+                Err(e) => anyhow::bail!("wait() should not fail (error={:?})", e),
+            }
         }
 
         Ok(())


### PR DESCRIPTION
## Description

This PR partially addresses https://github.com/demikernel/demikernel/issues/619

## Summary of Changes

- Fixed `push_wait` integration test to run the co-routine once before calling `close()`
- Added integration test for "attempt to wait for a `push()` operation to complete after asynchronously closing a pipe."