### PR TITLE
[test]  Wait Pop After Asynchronous Close Pipe

### DIFF
--- a/tests/rust/pipe-test/args.rs
+++ b/tests/rust/pipe-test/args.rs
@@ -5,8 +5,8 @@
 // Imports
 //======================================================================================================================
 
-use ::anyhow::Result;
-use ::clap::{
+use anyhow::Result;
+use clap::{
     Arg,
     ArgMatches,
     Command,
@@ -55,7 +55,7 @@ impl ProgramArguments {
                     .long("run-mode")
                     .value_parser(clap::value_parser!(String))
                     .required(true)
-                    .value_name("standalone|push-wait|pop-wait|push-wait-async")
+                    .value_name("standalone|push-wait|pop-wait|push-wait-async|pop-wait-async")
                     .help("Sets run mode"),
             )
             .get_matches();

--- a/tests/rust/pipe-test/main.rs
+++ b/tests/rust/pipe-test/main.rs
@@ -22,8 +22,8 @@ mod wait;
 //======================================================================================================================
 
 use self::args::ProgramArguments;
-use ::anyhow::Result;
-use ::demikernel::{
+use anyhow::Result;
+use demikernel::{
     LibOS,
     LibOSName,
 };
@@ -139,6 +139,17 @@ fn main() -> Result<()> {
             "server" => {
                 let mut server: push_wait::PipeServer = push_wait::PipeServer::new(libos, args.pipe_name())?;
                 server.run()
+            },
+            _ => anyhow::bail!("invalid peer type"),
+        },
+        "pop-wait-async" => match args.peer_type().ok_or(anyhow::anyhow!("missing peer type"))?.as_str() {
+            "client" => {
+                let mut client: pop_wait::PipeClient = pop_wait::PipeClient::new(libos, args.pipe_name())?;
+                client.run()
+            },
+            "server" => {
+                let mut server: pop_wait::PipeServer = pop_wait::PipeServer::new(libos, args.pipe_name())?;
+                server.run_async()
             },
             _ => anyhow::bail!("invalid peer type"),
         },


### PR DESCRIPTION
## Description

This PR partially addresses https://github.com/demikernel/demikernel/issues/619

## Summary of Changes

- Added integration test for "attempt to wait for a `pop()` operation to complete after asynchronously closing a pipe."