### PR TITLE
[test] Test Macros for Demikernel

### DIFF
--- a/src/rust/lib.rs
+++ b/src/rust/lib.rs
@@ -165,6 +165,29 @@ macro_rules! collect {
     };
 }
 
+/// Dumps results of tests.
+#[macro_export]
+macro_rules! dump_test {
+    ($vec:ident) => {{
+        let mut nfailed: usize = 0;
+        // Dump results.
+        for (test_name, test_status, test_result) in $vec {
+            std::println!("[{}] {}", test_status, test_name);
+            if let Err(e) = test_result {
+                nfailed += 1;
+                std::println!("{}", e);
+            }
+        }
+
+        if nfailed > 0 {
+            anyhow::bail!("{} tests failed", nfailed);
+        } else {
+            std::println!("all tests passed");
+            Ok(())
+        }
+    }};
+}
+
 #[test]
 fn test_ensure() -> Result<(), anyhow::Error> {
     ensure_eq!(1, 1);

--- a/src/rust/lib.rs
+++ b/src/rust/lib.rs
@@ -133,7 +133,7 @@ macro_rules! ensure_neq {
 
 /// Runs a test and prints if it passed or failed on the standard output.
 #[macro_export]
-macro_rules! test {
+macro_rules! run_test {
     ($fn_name:ident($($arg:expr),*)) => {{
         match $fn_name($($arg),*) {
             Ok(ok) =>
@@ -147,7 +147,7 @@ macro_rules! test {
 /// Updates the error variable `err_var` with `anyhow::anyhow!(msg)` if `err_var` is `Ok`.
 /// Otherwise it prints `msg` on the standard output.
 #[macro_export]
-macro_rules! update_error {
+macro_rules! update_test_error {
     ($err_var:ident, $msg:expr) => {
         if $err_var.is_ok() {
             $err_var = Err(anyhow::anyhow!($msg));
@@ -159,7 +159,7 @@ macro_rules! update_error {
 
 /// Collects the result of a test and appends it to a vector.
 #[macro_export]
-macro_rules! collect {
+macro_rules! collect_test {
     ($vec:ident, $expr:expr) => {
         $vec.append(&mut $expr);
     };

--- a/src/rust/lib.rs
+++ b/src/rust/lib.rs
@@ -131,6 +131,40 @@ macro_rules! ensure_neq {
     });
 }
 
+/// Runs a test and prints if it passed or failed on the standard output.
+#[macro_export]
+macro_rules! test {
+    ($fn_name:ident($($arg:expr),*)) => {{
+        match $fn_name($($arg),*) {
+            Ok(ok) =>
+                vec![(stringify!($fn_name).to_string(), "passed".to_string(), Ok(ok))],
+            Err(err) =>
+                vec![(stringify!($fn_name).to_string(), "failed".to_string(), Err(err))],
+        }
+    }};
+}
+
+/// Updates the error variable `err_var` with `anyhow::anyhow!(msg)` if `err_var` is `Ok`.
+/// Otherwise it prints `msg` on the standard output.
+#[macro_export]
+macro_rules! update_error {
+    ($err_var:ident, $msg:expr) => {
+        if $err_var.is_ok() {
+            $err_var = Err(anyhow::anyhow!($msg));
+        } else {
+            println!("{}", $msg);
+        }
+    };
+}
+
+/// Collects the result of a test and appends it to a vector.
+#[macro_export]
+macro_rules! collect {
+    ($vec:ident, $expr:expr) => {
+        $vec.append(&mut $expr);
+    };
+}
+
 #[test]
 fn test_ensure() -> Result<(), anyhow::Error> {
     ensure_eq!(1, 1);

--- a/tests/rust/pipe-test/async_close/mod.rs
+++ b/tests/rust/pipe-test/async_close/mod.rs
@@ -22,18 +22,18 @@ use ::std::time::Duration;
 pub fn run(libos: &mut LibOS, pipe_name: &str) -> Vec<(String, String, Result<(), anyhow::Error>)> {
     let mut result: Vec<(String, String, Result<(), anyhow::Error>)> = Vec::new();
 
-    crate::collect!(result, crate::test!(async_close_invalid_pipe(libos)));
-    crate::collect!(
+    demikernel::collect!(result, demikernel::test!(async_close_invalid_pipe(libos)));
+    demikernel::collect!(
         result,
-        crate::test!(async_close_pipe_multiple_times_1(libos, pipe_name))
+        demikernel::test!(async_close_pipe_multiple_times_1(libos, pipe_name))
     );
-    crate::collect!(
+    demikernel::collect!(
         result,
-        crate::test!(async_close_pipe_multiple_times_2(libos, pipe_name))
+        demikernel::test!(async_close_pipe_multiple_times_2(libos, pipe_name))
     );
-    crate::collect!(
+    demikernel::collect!(
         result,
-        crate::test!(async_close_pipe_multiple_times_3(libos, pipe_name))
+        demikernel::test!(async_close_pipe_multiple_times_3(libos, pipe_name))
     );
 
     result

--- a/tests/rust/pipe-test/async_close/mod.rs
+++ b/tests/rust/pipe-test/async_close/mod.rs
@@ -22,18 +22,18 @@ use ::std::time::Duration;
 pub fn run(libos: &mut LibOS, pipe_name: &str) -> Vec<(String, String, Result<(), anyhow::Error>)> {
     let mut result: Vec<(String, String, Result<(), anyhow::Error>)> = Vec::new();
 
-    demikernel::collect!(result, demikernel::test!(async_close_invalid_pipe(libos)));
-    demikernel::collect!(
+    demikernel::collect_test!(result, demikernel::run_test!(async_close_invalid_pipe(libos)));
+    demikernel::collect_test!(
         result,
-        demikernel::test!(async_close_pipe_multiple_times_1(libos, pipe_name))
+        demikernel::run_test!(async_close_pipe_multiple_times_1(libos, pipe_name))
     );
-    demikernel::collect!(
+    demikernel::collect_test!(
         result,
-        demikernel::test!(async_close_pipe_multiple_times_2(libos, pipe_name))
+        demikernel::run_test!(async_close_pipe_multiple_times_2(libos, pipe_name))
     );
-    demikernel::collect!(
+    demikernel::collect_test!(
         result,
-        demikernel::test!(async_close_pipe_multiple_times_3(libos, pipe_name))
+        demikernel::run_test!(async_close_pipe_multiple_times_3(libos, pipe_name))
     );
 
     result

--- a/tests/rust/pipe-test/close/mod.rs
+++ b/tests/rust/pipe-test/close/mod.rs
@@ -19,8 +19,11 @@ use ::demikernel::{
 pub fn run(libos: &mut LibOS, pipe_name: &str) -> Vec<(String, String, Result<(), anyhow::Error>)> {
     let mut result: Vec<(String, String, Result<(), anyhow::Error>)> = Vec::new();
 
-    demikernel::collect!(result, demikernel::test!(close_invalid_pipe(libos)));
-    demikernel::collect!(result, demikernel::test!(close_pipe_multiple_times(libos, pipe_name)));
+    demikernel::collect_test!(result, demikernel::run_test!(close_invalid_pipe(libos)));
+    demikernel::collect_test!(
+        result,
+        demikernel::run_test!(close_pipe_multiple_times(libos, pipe_name))
+    );
 
     result
 }

--- a/tests/rust/pipe-test/close/mod.rs
+++ b/tests/rust/pipe-test/close/mod.rs
@@ -19,8 +19,8 @@ use ::demikernel::{
 pub fn run(libos: &mut LibOS, pipe_name: &str) -> Vec<(String, String, Result<(), anyhow::Error>)> {
     let mut result: Vec<(String, String, Result<(), anyhow::Error>)> = Vec::new();
 
-    crate::collect!(result, crate::test!(close_invalid_pipe(libos)));
-    crate::collect!(result, crate::test!(close_pipe_multiple_times(libos, pipe_name)));
+    demikernel::collect!(result, demikernel::test!(close_invalid_pipe(libos)));
+    demikernel::collect!(result, demikernel::test!(close_pipe_multiple_times(libos, pipe_name)));
 
     result
 }

--- a/tests/rust/pipe-test/create_pipe/mod.rs
+++ b/tests/rust/pipe-test/create_pipe/mod.rs
@@ -19,8 +19,8 @@ use ::demikernel::{
 pub fn run(libos: &mut LibOS, pipe_name: &str) -> Vec<(String, String, Result<(), anyhow::Error>)> {
     let mut result: Vec<(String, String, Result<(), anyhow::Error>)> = Vec::new();
 
-    crate::collect!(result, crate::test!(create_pipe_with_invalid_name(libos)));
-    crate::collect!(result, crate::test!(create_pipe_with_same_name(libos, pipe_name)));
+    demikernel::collect!(result, demikernel::test!(create_pipe_with_invalid_name(libos)));
+    demikernel::collect!(result, demikernel::test!(create_pipe_with_same_name(libos, pipe_name)));
 
     result
 }
@@ -55,7 +55,7 @@ fn create_pipe_with_same_name(libos: &mut LibOS, pipe_name: &str) -> Result<()> 
         Ok(_) => (),
         Err(e) => {
             let errmsg: String = format!("close() failed ({})", e);
-            crate::update_error!(ret, errmsg);
+            demikernel::update_error!(ret, errmsg);
             println!("[ERROR] leaking pipeqd={:?}", pipeqd);
         },
     }

--- a/tests/rust/pipe-test/create_pipe/mod.rs
+++ b/tests/rust/pipe-test/create_pipe/mod.rs
@@ -19,8 +19,11 @@ use ::demikernel::{
 pub fn run(libos: &mut LibOS, pipe_name: &str) -> Vec<(String, String, Result<(), anyhow::Error>)> {
     let mut result: Vec<(String, String, Result<(), anyhow::Error>)> = Vec::new();
 
-    demikernel::collect!(result, demikernel::test!(create_pipe_with_invalid_name(libos)));
-    demikernel::collect!(result, demikernel::test!(create_pipe_with_same_name(libos, pipe_name)));
+    demikernel::collect_test!(result, demikernel::run_test!(create_pipe_with_invalid_name(libos)));
+    demikernel::collect_test!(
+        result,
+        demikernel::run_test!(create_pipe_with_same_name(libos, pipe_name))
+    );
 
     result
 }
@@ -55,7 +58,7 @@ fn create_pipe_with_same_name(libos: &mut LibOS, pipe_name: &str) -> Result<()> 
         Ok(_) => (),
         Err(e) => {
             let errmsg: String = format!("close() failed ({})", e);
-            demikernel::update_error!(ret, errmsg);
+            demikernel::update_test_error!(ret, errmsg);
             println!("[ERROR] leaking pipeqd={:?}", pipeqd);
         },
     }

--- a/tests/rust/pipe-test/main.rs
+++ b/tests/rust/pipe-test/main.rs
@@ -48,11 +48,11 @@ fn main() -> Result<()> {
 
     match args.run_mode().as_str() {
         "standalone" => {
-            demikernel::collect!(result, create_pipe::run(&mut libos, &args.pipe_name()));
-            demikernel::collect!(result, open_pipe::run(&mut libos, &args.pipe_name()));
-            demikernel::collect!(result, close::run(&mut libos, &args.pipe_name()));
-            demikernel::collect!(result, wait::run(&mut libos));
-            demikernel::collect!(result, async_close::run(&mut libos, &args.pipe_name()));
+            demikernel::collect_test!(result, create_pipe::run(&mut libos, &args.pipe_name()));
+            demikernel::collect_test!(result, open_pipe::run(&mut libos, &args.pipe_name()));
+            demikernel::collect_test!(result, close::run(&mut libos, &args.pipe_name()));
+            demikernel::collect_test!(result, wait::run(&mut libos));
+            demikernel::collect_test!(result, async_close::run(&mut libos, &args.pipe_name()));
 
             // Dump results.
             demikernel::dump_test!(result)

--- a/tests/rust/pipe-test/main.rs
+++ b/tests/rust/pipe-test/main.rs
@@ -33,7 +33,6 @@ use demikernel::{
 //======================================================================================================================
 
 fn main() -> Result<()> {
-    let mut nfailed: usize = 0;
     let mut result: Vec<(String, String, Result<(), anyhow::Error>)> = Vec::new();
 
     let args: ProgramArguments = ProgramArguments::new(
@@ -56,20 +55,7 @@ fn main() -> Result<()> {
             demikernel::collect!(result, async_close::run(&mut libos, &args.pipe_name()));
 
             // Dump results.
-            for (test_name, test_status, test_result) in result {
-                println!("[{}] {}", test_status, test_name);
-                if let Err(e) = test_result {
-                    nfailed += 1;
-                    println!("    {}", e);
-                }
-            }
-
-            if nfailed > 0 {
-                anyhow::bail!("{} tests failed", nfailed);
-            } else {
-                println!("all tests passed");
-                Ok(())
-            }
+            demikernel::dump_test!(result)
         },
         "push-wait" => match args.peer_type().ok_or(anyhow::anyhow!("missing peer type"))?.as_str() {
             "client" => {

--- a/tests/rust/pipe-test/main.rs
+++ b/tests/rust/pipe-test/main.rs
@@ -29,44 +29,6 @@ use demikernel::{
 };
 
 //======================================================================================================================
-// Macros
-//======================================================================================================================
-
-/// Runs a test and prints if it passed or failed on the standard output.
-#[macro_export]
-macro_rules! test {
-    ($fn_name:ident($($arg:expr),*)) => {{
-        match $fn_name($($arg),*) {
-            Ok(ok) =>
-                vec![(stringify!($fn_name).to_string(), "passed".to_string(), Ok(ok))],
-            Err(err) =>
-                vec![(stringify!($fn_name).to_string(), "failed".to_string(), Err(err))],
-        }
-    }};
-}
-
-/// Updates the error variable `err_var` with `anyhow::anyhow!(msg)` if `err_var` is `Ok`.
-/// Otherwise it prints `msg` on the standard output.
-#[macro_export]
-macro_rules! update_error {
-    ($err_var:ident, $msg:expr) => {
-        if $err_var.is_ok() {
-            $err_var = Err(anyhow::anyhow!($msg));
-        } else {
-            println!("{}", $msg);
-        }
-    };
-}
-
-/// Collects the result of a test and appends it to a vector.
-#[macro_export]
-macro_rules! collect {
-    ($vec:ident, $expr:expr) => {
-        $vec.append(&mut $expr);
-    };
-}
-
-//======================================================================================================================
 // Standalone Functions
 //======================================================================================================================
 
@@ -87,11 +49,11 @@ fn main() -> Result<()> {
 
     match args.run_mode().as_str() {
         "standalone" => {
-            crate::collect!(result, create_pipe::run(&mut libos, &args.pipe_name()));
-            crate::collect!(result, open_pipe::run(&mut libos, &args.pipe_name()));
-            crate::collect!(result, close::run(&mut libos, &args.pipe_name()));
-            crate::collect!(result, wait::run(&mut libos));
-            crate::collect!(result, async_close::run(&mut libos, &args.pipe_name()));
+            demikernel::collect!(result, create_pipe::run(&mut libos, &args.pipe_name()));
+            demikernel::collect!(result, open_pipe::run(&mut libos, &args.pipe_name()));
+            demikernel::collect!(result, close::run(&mut libos, &args.pipe_name()));
+            demikernel::collect!(result, wait::run(&mut libos));
+            demikernel::collect!(result, async_close::run(&mut libos, &args.pipe_name()));
 
             // Dump results.
             for (test_name, test_status, test_result) in result {

--- a/tests/rust/pipe-test/open_pipe/mod.rs
+++ b/tests/rust/pipe-test/open_pipe/mod.rs
@@ -19,9 +19,12 @@ use ::demikernel::{
 pub fn run(libos: &mut LibOS, pipe_name: &str) -> Vec<(String, String, Result<(), anyhow::Error>)> {
     let mut result: Vec<(String, String, Result<(), anyhow::Error>)> = Vec::new();
 
-    crate::collect!(result, crate::test!(open_pipe_with_invalid_name(libos)));
-    crate::collect!(result, crate::test!(open_pipe_that_does_not_exist(libos, pipe_name)));
-    crate::collect!(result, crate::test!(open_pipe_multiple_times(libos, pipe_name)));
+    demikernel::collect!(result, demikernel::test!(open_pipe_with_invalid_name(libos)));
+    demikernel::collect!(
+        result,
+        demikernel::test!(open_pipe_that_does_not_exist(libos, pipe_name))
+    );
+    demikernel::collect!(result, demikernel::test!(open_pipe_multiple_times(libos, pipe_name)));
 
     result
 }
@@ -62,7 +65,7 @@ fn open_pipe_multiple_times(libos: &mut LibOS, pipe_name: &str) -> Result<()> {
             Ok(pipeqd) => pipeqd,
             Err(e) => {
                 let errmsg: String = format!("open_pipe() failed ({})", e);
-                crate::update_error!(ret, errmsg);
+                demikernel::update_error!(ret, errmsg);
                 println!("[ERROR] leaking pipeqd={:?}", pipeqd);
                 break;
             },
@@ -72,7 +75,7 @@ fn open_pipe_multiple_times(libos: &mut LibOS, pipe_name: &str) -> Result<()> {
             Ok(_) => (),
             Err(e) => {
                 let errmsg: String = format!("close() failed ({})", e);
-                crate::update_error!(ret, errmsg);
+                demikernel::update_error!(ret, errmsg);
                 println!("[ERROR] leaking pipeqd={:?}", pipeqd);
                 break;
             },
@@ -84,7 +87,7 @@ fn open_pipe_multiple_times(libos: &mut LibOS, pipe_name: &str) -> Result<()> {
         Ok(_) => (),
         Err(e) => {
             let errmsg: String = format!("close() failed ({})", e);
-            crate::update_error!(ret, errmsg);
+            demikernel::update_error!(ret, errmsg);
             println!("[ERROR] leaking pipeqd={:?}", pipeqd);
         },
     }

--- a/tests/rust/pipe-test/open_pipe/mod.rs
+++ b/tests/rust/pipe-test/open_pipe/mod.rs
@@ -19,12 +19,15 @@ use ::demikernel::{
 pub fn run(libos: &mut LibOS, pipe_name: &str) -> Vec<(String, String, Result<(), anyhow::Error>)> {
     let mut result: Vec<(String, String, Result<(), anyhow::Error>)> = Vec::new();
 
-    demikernel::collect!(result, demikernel::test!(open_pipe_with_invalid_name(libos)));
-    demikernel::collect!(
+    demikernel::collect_test!(result, demikernel::run_test!(open_pipe_with_invalid_name(libos)));
+    demikernel::collect_test!(
         result,
-        demikernel::test!(open_pipe_that_does_not_exist(libos, pipe_name))
+        demikernel::run_test!(open_pipe_that_does_not_exist(libos, pipe_name))
     );
-    demikernel::collect!(result, demikernel::test!(open_pipe_multiple_times(libos, pipe_name)));
+    demikernel::collect_test!(
+        result,
+        demikernel::run_test!(open_pipe_multiple_times(libos, pipe_name))
+    );
 
     result
 }
@@ -65,7 +68,7 @@ fn open_pipe_multiple_times(libos: &mut LibOS, pipe_name: &str) -> Result<()> {
             Ok(pipeqd) => pipeqd,
             Err(e) => {
                 let errmsg: String = format!("open_pipe() failed ({})", e);
-                demikernel::update_error!(ret, errmsg);
+                demikernel::update_test_error!(ret, errmsg);
                 println!("[ERROR] leaking pipeqd={:?}", pipeqd);
                 break;
             },
@@ -75,7 +78,7 @@ fn open_pipe_multiple_times(libos: &mut LibOS, pipe_name: &str) -> Result<()> {
             Ok(_) => (),
             Err(e) => {
                 let errmsg: String = format!("close() failed ({})", e);
-                demikernel::update_error!(ret, errmsg);
+                demikernel::update_test_error!(ret, errmsg);
                 println!("[ERROR] leaking pipeqd={:?}", pipeqd);
                 break;
             },
@@ -87,7 +90,7 @@ fn open_pipe_multiple_times(libos: &mut LibOS, pipe_name: &str) -> Result<()> {
         Ok(_) => (),
         Err(e) => {
             let errmsg: String = format!("close() failed ({})", e);
-            demikernel::update_error!(ret, errmsg);
+            demikernel::update_test_error!(ret, errmsg);
             println!("[ERROR] leaking pipeqd={:?}", pipeqd);
         },
     }

--- a/tests/rust/pipe-test/wait/mod.rs
+++ b/tests/rust/pipe-test/wait/mod.rs
@@ -20,7 +20,7 @@ use ::std::time::Duration;
 pub fn run(libos: &mut LibOS) -> Vec<(String, String, Result<(), anyhow::Error>)> {
     let mut result: Vec<(String, String, Result<(), anyhow::Error>)> = Vec::new();
 
-    crate::collect!(result, crate::test!(wait_on_invalid_queue_token(libos)));
+    demikernel::collect!(result, demikernel::test!(wait_on_invalid_queue_token(libos)));
 
     result
 }

--- a/tests/rust/pipe-test/wait/mod.rs
+++ b/tests/rust/pipe-test/wait/mod.rs
@@ -20,7 +20,7 @@ use ::std::time::Duration;
 pub fn run(libos: &mut LibOS) -> Vec<(String, String, Result<(), anyhow::Error>)> {
     let mut result: Vec<(String, String, Result<(), anyhow::Error>)> = Vec::new();
 
-    demikernel::collect!(result, demikernel::test!(wait_on_invalid_queue_token(libos)));
+    demikernel::collect_test!(result, demikernel::run_test!(wait_on_invalid_queue_token(libos)));
 
     result
 }


### PR DESCRIPTION
## Description

This PR closes https://github.com/demikernel/demikernel/issues/687.

## Summary of Changes

- Moved test macros to Demikernel source tree.
- Added `dump_test!()` macro.
- Renamed test macros.