### PR TITLE
[pdpix] Have a System-Wide Maximum Size for a Receive Buffer

### DIFF
--- a/src/rust/catcollar/mod.rs
+++ b/src/rust/catcollar/mod.rs
@@ -32,6 +32,7 @@ use crate::{
     pal::linux,
     runtime::{
         fail::Fail,
+        limits,
         memory::{
             DemiBuffer,
             MemoryRuntime,
@@ -66,13 +67,6 @@ use ::std::{
     pin::Pin,
     rc::Rc,
 };
-
-//======================================================================================================================
-// Constants
-//======================================================================================================================
-
-// Size of receive buffers.
-const CATCOLLAR_RECVBUF_SIZE: usize = 9000;
 
 //======================================================================================================================
 // Structures
@@ -465,7 +459,7 @@ impl CatcollarLibOS {
         }
 
         let buf: DemiBuffer = {
-            let size: usize = size.unwrap_or(CATCOLLAR_RECVBUF_SIZE as usize);
+            let size: usize = size.unwrap_or(limits::RECVBUF_SIZE_MAX);
             DemiBuffer::new(size as u16)
         };
 

--- a/src/rust/catmem/futures/pop.rs
+++ b/src/rust/catmem/futures/pop.rs
@@ -9,6 +9,7 @@ use crate::{
     catmem::SharedRingBuffer,
     runtime::{
         fail::Fail,
+        limits,
         memory::DemiBuffer,
     },
 };
@@ -40,9 +41,6 @@ pub struct PopFuture {
 
 /// Associate Functions for Pop Operation Descriptors
 impl PopFuture {
-    /// Maximum Size for a Pop Operation
-    const POP_SIZE_MAX: usize = 9216;
-
     /// Creates a descriptor for a pop operation.
     pub fn new(ring: Rc<SharedRingBuffer<u16>>, size: Option<usize>) -> Self {
         PopFuture { ring, size }
@@ -60,7 +58,7 @@ impl Future for PopFuture {
     /// Polls the target [PopFuture].
     fn poll(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Self::Output> {
         let self_: &mut PopFuture = self.get_mut();
-        let size: usize = self_.size.unwrap_or(Self::POP_SIZE_MAX);
+        let size: usize = self_.size.unwrap_or(limits::RECVBUF_SIZE_MAX);
         let mut buf: DemiBuffer = DemiBuffer::new(size as u16);
         let mut eof: bool = false;
         let mut index: usize = 0;

--- a/src/rust/runtime/limits.rs
+++ b/src/rust/runtime/limits.rs
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/// Maximum size for a receive buffer.
+/// This is set to be the largest power of two that fits in 9000-byte jumbo frames.
+pub const RECVBUF_SIZE_MAX: usize = 8192;

--- a/src/rust/runtime/mod.rs
+++ b/src/rust/runtime/mod.rs
@@ -6,6 +6,7 @@
 //==============================================================================
 
 pub mod fail;
+pub mod limits;
 pub mod logging;
 pub mod memory;
 pub mod network;


### PR DESCRIPTION
## Description

This PR closes https://github.com/demikernel/demikernel/issues/698

## Summary of Changes

- Added a system-wide constant for the maximum size of receive buffers.
- Changed Catnap LibOS to use that system-wide constant.
- Changed Catmem LibOS to use that system-wide constant.
- Changed Catcollar LibOS to use that system-wide constant.
- Changed Catpowder LibOS to use that system-wide constant.