### PR TITLE
[pdpix] Consistent Behavior When `listen()` with Invalid Backlog Length

### DIFF
--- a/src/rust/catcollar/mod.rs
+++ b/src/rust/catcollar/mod.rs
@@ -209,6 +209,9 @@ impl CatcollarLibOS {
     pub fn listen(&mut self, qd: QDesc, backlog: usize) -> Result<(), Fail> {
         trace!("listen() qd={:?}, backlog={:?}", qd, backlog);
 
+        // We just assert backlog here, because it was previously checked at PDPIX layer.
+        debug_assert!((backlog > 0) && (backlog <= libc::SOMAXCONN as usize));
+
         // Issue listen operation.
         match self.qtable.borrow().get(&qd) {
             Some(queue) => match queue.get_fd() {

--- a/src/rust/catloop/mod.rs
+++ b/src/rust/catloop/mod.rs
@@ -211,12 +211,15 @@ impl CatloopLibOS {
     }
 
     /// Sets a socket as a passive one.
+    // FIXME: https://github.com/demikernel/demikernel/issues/697
     pub fn listen(&mut self, qd: QDesc, backlog: usize) -> Result<(), Fail> {
         trace!("listen() qd={:?}, backlog={:?}", qd, backlog);
-        let mut qtable: RefMut<IoQueueTable<CatloopQueue>> = self.qtable.borrow_mut();
+
+        // We just assert backlog here, because it was previously checked at PDPIX layer.
+        debug_assert!((backlog > 0) && (backlog <= libc::SOMAXCONN as usize));
 
         // Check if the queue descriptor is registered in the sockets table.
-        match qtable.get_mut(&qd) {
+        match self.qtable.borrow_mut().get_mut(&qd) {
             Some(queue) => match queue.get_socket() {
                 Socket::Active(Some(local)) => {
                     queue.set_socket(Socket::Passive(local));

--- a/src/rust/catnap/mod.rs
+++ b/src/rust/catnap/mod.rs
@@ -235,23 +235,8 @@ impl CatnapLibOS {
     }
 
     /// Sets a socket as a passive one.
-    pub fn listen(&mut self, qd: QDesc, mut backlog: usize) -> Result<(), Fail> {
+    pub fn listen(&mut self, qd: QDesc, backlog: usize) -> Result<(), Fail> {
         trace!("listen() qd={:?}, backlog={:?}", qd, backlog);
-
-        // Truncate backlog length.
-        if backlog > libc::SOMAXCONN as usize {
-            let cause: String = format!(
-                "backlog length is too large, truncating (qd={:?}, backlog={:?})",
-                qd, backlog
-            );
-            debug!("listen(): {}", &cause);
-            backlog = libc::SOMAXCONN as usize;
-        }
-
-        // Round up backlog length.
-        if backlog == 0 {
-            backlog = 1;
-        }
 
         // Issue listen operation.
         match self.qtable.borrow_mut().get_mut(&qd) {

--- a/src/rust/catnap/mod.rs
+++ b/src/rust/catnap/mod.rs
@@ -238,6 +238,9 @@ impl CatnapLibOS {
     pub fn listen(&mut self, qd: QDesc, backlog: usize) -> Result<(), Fail> {
         trace!("listen() qd={:?}, backlog={:?}", qd, backlog);
 
+        // We just assert backlog here, because it was previously checked at PDPIX layer.
+        debug_assert!((backlog > 0) && (backlog <= libc::SOMAXCONN as usize));
+
         // Issue listen operation.
         match self.qtable.borrow_mut().get_mut(&qd) {
             Some(queue) => match queue.get_fd() {

--- a/src/rust/inetstack/mod.rs
+++ b/src/rust/inetstack/mod.rs
@@ -247,10 +247,13 @@ impl InetStack {
     pub fn listen(&mut self, qd: QDesc, backlog: usize) -> Result<(), Fail> {
         #[cfg(feature = "profiler")]
         timer!("inetstack::listen");
-        trace!("listen(): qd={:?} backlog={:?}", qd, backlog);
+        trace!("listen() qd={:?}, backlog={:?}", qd, backlog);
+
+        // FIXME: https://github.com/demikernel/demikernel/issues/584
         if backlog == 0 {
             return Err(Fail::new(libc::EINVAL, "invalid backlog length"));
         }
+
         match self.lookup_qtype(&qd) {
             Some(QType::TcpSocket) => self.ipv4.tcp.listen(qd, backlog),
             Some(_) => Err(Fail::new(libc::EINVAL, "invalid queue type")),


### PR DESCRIPTION
## Description

This PR is a partial fix for https://github.com/demikernel/demikernel/issues/584

## Summary of Changes

- Moved check logic for backlog length to PDPIX layer
- Added debug assert on Catnap LibOS for backlog length.
- Added debug assert on Catcollar LibOS for backlog length.
- Added debug assert on Catloop LibOS for backlog length.

## Additional Notes

It was not possible to fix this for Catpowder and Catnip because the legacy test infrastructure would fail. Once we have the new infrastructure enabled for them, we can have the issue closed.