### PR TITLE
[pdpix] Have an Upper Limit for Fixed-Size `pop()`s

### DIFF
--- a/src/rust/catcollar/mod.rs
+++ b/src/rust/catcollar/mod.rs
@@ -454,12 +454,8 @@ impl CatcollarLibOS {
     pub fn pop(&mut self, qd: QDesc, size: Option<usize>) -> Result<QToken, Fail> {
         trace!("pop() qd={:?}, size={:?}", qd, size);
 
-        // Check if the pop size is valid.
-        if size.is_some() && size.unwrap() == 0 {
-            let cause: String = format!("invalid pop size (size={:?})", size);
-            error!("pop(): {:?}", &cause);
-            return Err(Fail::new(libc::EINVAL, &cause));
-        }
+        // We just assert 'size' here, because it was previously checked at PDPIX layer.
+        debug_assert!(size.is_none() || ((size.unwrap() > 0) && (size.unwrap() <= limits::POP_SIZE_MAX)));
 
         let buf: DemiBuffer = {
             let size: usize = size.unwrap_or(limits::RECVBUF_SIZE_MAX);

--- a/src/rust/catnap/mod.rs
+++ b/src/rust/catnap/mod.rs
@@ -34,6 +34,7 @@ use crate::{
     pal::linux,
     runtime::{
         fail::Fail,
+        limits,
         memory::{
             DemiBuffer,
             MemoryRuntime,
@@ -609,12 +610,8 @@ impl CatnapLibOS {
     pub fn pop(&mut self, qd: QDesc, size: Option<usize>) -> Result<QToken, Fail> {
         trace!("pop() qd={:?}, size={:?}", qd, size);
 
-        // Check if the pop size is valid.
-        if size.is_some() && size.unwrap() == 0 {
-            let cause: String = format!("invalid pop size (size={:?})", size);
-            error!("pop(): {:?}", &cause);
-            return Err(Fail::new(libc::EINVAL, &cause));
-        }
+        // We just assert 'size' here, because it was previously checked at PDPIX layer.
+        debug_assert!(size.is_none() || ((size.unwrap() > 0) && (size.unwrap() <= limits::POP_SIZE_MAX)));
 
         // Issue pop operation.
         match self.qtable.borrow_mut().get_mut(&qd) {

--- a/src/rust/inetstack/mod.rs
+++ b/src/rust/inetstack/mod.rs
@@ -30,6 +30,7 @@ use crate::{
     },
     runtime::{
         fail::Fail,
+        limits,
         memory::DemiBuffer,
         network::{
             config::{
@@ -527,12 +528,8 @@ impl InetStack {
 
         trace!("pop() qd={:?}, size={:?}", qd, size);
 
-        // Check if the pop size is valid.
-        if size.is_some() && size.unwrap() == 0 {
-            let cause: String = format!("invalid pop size (size={:?})", size);
-            error!("pop(): {:?}", &cause);
-            return Err(Fail::new(libc::EINVAL, &cause));
-        }
+        // We just assert 'size' here, because it was previously checked at PDPIX layer.
+        debug_assert!(size.is_none() || ((size.unwrap() > 0) && (size.unwrap() <= limits::POP_SIZE_MAX)));
 
         let (task_id, coroutine): (String, Pin<Box<Operation>>) = match self.lookup_qtype(&qd) {
             Some(QType::TcpSocket) => {

--- a/src/rust/runtime/limits.rs
+++ b/src/rust/runtime/limits.rs
@@ -4,3 +4,7 @@
 /// Maximum size for a receive buffer.
 /// This is set to be the largest power of two that fits in 9000-byte jumbo frames.
 pub const RECVBUF_SIZE_MAX: usize = 8192;
+
+/// Maximum size for a fixed-size pop operation.
+/// This is set to be at most `RECVBUF_SIZE_MAX`.
+pub const POP_SIZE_MAX: usize = RECVBUF_SIZE_MAX;


### PR DESCRIPTION
## Description

This PR closes https://github.com/demikernel/demikernel/issues/559

## Summary of Changes

- Introduced `POP_SIZE_MAX` limit.
- Changed PDPIX layer to check size of pops.
- Changed Catnap LibOS to assert size of pops.
- Changed Catcollar LibOS to assert size of pops.
- Changed Catnip LibOS to assert size of pops.
- Changed Catpowder LibOS to assert size of pops.
- Changed Catloop LibOS to assert size of pops.
- Changed Catmem LibOS to assert size of pops.