### PR TITLE
[PDPIX] Do not reuse qtokens

### DIFF
--- a/src/rust/catloop/duplex_pipe.rs
+++ b/src/rust/catloop/duplex_pipe.rs
@@ -94,8 +94,9 @@ impl DuplexPipe {
 
         // Return this operation to the scheduling queue by removing the associated key
         // (which would otherwise cause the operation to be freed).
+        // FIXME: https://github.com/demikernel/demikernel/issues/593
         if !handle.has_completed() {
-            handle.take_key();
+            handle.take_token();
             return Ok(None);
         }
 

--- a/src/rust/catnap/queue.rs
+++ b/src/rust/catnap/queue.rs
@@ -92,7 +92,7 @@ impl CatnapQueue {
             // Remove the key so this doesn't cause the scheduler to drop the whole task.
             // We need a better explicit mechanism to remove tasks from the scheduler.
             // FIXME: https://github.com/demikernel/demikernel/issues/593
-            scheduler_handle.take_key();
+            scheduler_handle.take_token();
         }
     }
 }

--- a/src/rust/demikernel/libos/mod.rs
+++ b/src/rust/demikernel/libos/mod.rs
@@ -260,7 +260,8 @@ impl LibOS {
             if abstime.is_none() || SystemTime::now() >= abstime.unwrap() {
                 // Return this operation to the scheduling queue by removing the associated key
                 // (which would otherwise cause the operation to be freed).
-                handle.take_key();
+                // FIXME: https://github.com/demikernel/demikernel/issues/593
+                handle.take_token();
                 return Err(Fail::new(libc::ETIMEDOUT, "timer expired"));
             }
         }
@@ -290,7 +291,8 @@ impl LibOS {
 
                 // Return this operation to the scheduling queue by removing the associated key
                 // (which would otherwise cause the operation to be freed).
-                handle.take_key();
+                // FIXME: https://github.com/demikernel/demikernel/issues/593
+                handle.take_token();
             }
 
             // If we have a timeout, check for expiration.

--- a/src/rust/inetstack/mod.rs
+++ b/src/rust/inetstack/mod.rs
@@ -624,7 +624,8 @@ impl InetStack {
 
                 // Return this operation to the scheduling queue by removing the associated key
                 // (which would otherwise cause the operation to be freed).
-                handle.take_key();
+                // FIXME: https://github.com/demikernel/demikernel/issues/593
+                handle.take_token();
             }
         }
     }

--- a/src/rust/scheduler/scheduler.rs
+++ b/src/rust/scheduler/scheduler.rs
@@ -7,9 +7,9 @@
 //! As background tasks are polled, they notify task in our scheduler via the
 //! [crate::page::WakerPage]s.
 
-//==============================================================================
+//======================================================================================================================
 // Imports
-//==============================================================================
+//======================================================================================================================
 
 use crate::scheduler::{
     page::{
@@ -25,12 +25,18 @@ use crate::scheduler::{
     Task,
 };
 use ::bit_iter::BitIter;
+use ::rand::{
+    rngs::SmallRng,
+    RngCore,
+    SeedableRng,
+};
 use ::std::{
     cell::{
         Ref,
         RefCell,
         RefMut,
     },
+    collections::HashMap,
     future::Future,
     pin::Pin,
     ptr::NonNull,
@@ -42,90 +48,125 @@ use ::std::{
     },
 };
 
-//==============================================================================
+//======================================================================================================================
+// Constants
+//======================================================================================================================
+
+/// Seed for the random number generator used to generate tokens.
+/// This value was chosen arbitrarily.
+#[cfg(debug_assertions)]
+const SCHEDULER_SEED: u64 = 42;
+
+//======================================================================================================================
 // Structures
-//==============================================================================
+//======================================================================================================================
 
-/// Actual data used by [Scheduler].
-struct Inner {
-    /// Stores all the tasks that are held by the scheduler.
-    slab: PinSlab<Box<dyn Task>>,
-    /// Holds the status tasks.
-    pages: Vec<WakerPageRef>,
-}
-
-/// Future Scheduler
+/// Task Scheduler
 #[derive(Clone)]
 pub struct Scheduler {
-    inner: Rc<RefCell<Inner>>,
+    /// Stores all the tasks that are held by the scheduler.
+    tasks: Rc<RefCell<PinSlab<Box<dyn Task>>>>,
+    /// Maps between externally meaningful ids and the offset of the task in the slab.
+    task_ids: Rc<RefCell<HashMap<u64, usize>>>,
+    /// Holds the waker bits for controlling task scheduling.
+    pages: Rc<RefCell<Vec<WakerPageRef>>>,
+    /// Small random number generator for tokens.
+    id_gen: Rc<RefCell<SmallRng>>,
 }
 
-//==============================================================================
+//======================================================================================================================
 // Associate Functions
-//==============================================================================
-
-/// Associate Functions for Inner
-impl Inner {
-    /// Computes the [WakerPageRef] and offset of a given task based on its `key`.
-    fn get_page(&self, key: u64) -> (&WakerPageRef, usize) {
-        let key: usize = key as usize;
-        let (page_ix, subpage_ix): (usize, usize) = (key >> WAKER_BIT_LENGTH_SHIFT, key & (WAKER_BIT_LENGTH - 1));
-        (&self.pages[page_ix], subpage_ix)
-    }
-
-    /// Insert a task into our scheduler returning a key that may be used to drive its status.
-    fn insert(&mut self, task: Box<dyn Task>) -> Option<u64> {
-        let key: usize = self.slab.insert(task)?;
-
-        // Add a new page to hold this future's status if the current page is filled.
-        while key >= self.pages.len() << WAKER_BIT_LENGTH_SHIFT {
-            self.pages.push(WakerPageRef::default());
-        }
-        let (page, subpage_ix): (&WakerPageRef, usize) = self.get_page(key as u64);
-        page.initialize(subpage_ix);
-        Some(key as u64)
-    }
-}
+//======================================================================================================================
 
 /// Associate Functions for Scheduler
 impl Scheduler {
     /// Given a handle representing a future, remove the future from the scheduler returning it.
     pub fn take(&self, mut handle: SchedulerHandle) -> Box<dyn Task> {
-        let mut inner: RefMut<Inner> = self.inner.borrow_mut();
-        let key: u64 = handle.take_key().unwrap();
-        let (page, subpage_ix): (&WakerPageRef, usize) = inner.get_page(key);
+        let pages: Ref<Vec<WakerPageRef>> = self.pages.borrow();
+        // We should not have a scheduler handle that refers to an invalid id, so unwrap and expect are safe here.
+        let offset: usize = *self
+            .task_ids
+            .borrow()
+            .get(&handle.take_token().unwrap())
+            .expect("Token should be in the token table");
+        let (page, subpage_ix): (&WakerPageRef, usize) = {
+            let (pages_ix, subpage_ix) = self.get_page_offsets(offset);
+            (&pages[pages_ix], subpage_ix)
+        };
         assert!(!page.was_dropped(subpage_ix));
         page.clear(subpage_ix);
-        inner.slab.remove_unpin(key as usize).unwrap()
+        self.tasks.borrow_mut().remove_unpin(offset).unwrap()
     }
 
-    /// Given the raw `key` representing this future return a proper handle.
-    pub fn from_raw_handle(&self, key: u64) -> Option<SchedulerHandle> {
-        let inner: Ref<Inner> = self.inner.borrow();
-        inner.slab.get(key as usize)?;
-        let (page, _): (&WakerPageRef, usize) = inner.get_page(key);
-        let handle: SchedulerHandle = SchedulerHandle::new(key, page.clone());
+    /// Given the raw `token` representing this future return a proper handle.
+    pub fn from_raw_handle(&self, task_id: u64) -> Option<SchedulerHandle> {
+        let pages: Ref<Vec<WakerPageRef>> = self.pages.borrow();
+        let offset: usize = match self.task_ids.borrow().get(&task_id) {
+            Some(offset) => *offset,
+            None => return None,
+        };
+        self.tasks.borrow().get(offset as usize)?;
+        let page: &WakerPageRef = {
+            let (pages_ix, _) = self.get_page_offsets(offset);
+            &pages[pages_ix]
+        };
+        let handle: SchedulerHandle = SchedulerHandle::new(task_id, offset, page.clone());
         Some(handle)
     }
 
     /// Insert a new task into our scheduler returning a handle corresponding to it.
     pub fn insert<F: Task>(&self, future: F) -> Option<SchedulerHandle> {
-        let mut inner: RefMut<Inner> = self.inner.borrow_mut();
-        let key: u64 = inner.insert(Box::new(future))?;
-        let (page, _): (&WakerPageRef, usize) = inner.get_page(key);
-        Some(SchedulerHandle::new(key, page.clone()))
+        let mut pages: RefMut<Vec<WakerPageRef>> = self.pages.borrow_mut();
+        let mut id_gen: RefMut<SmallRng> = self.id_gen.borrow_mut();
+        // Allocate an offset into the slab and a token for identifying the task.
+        let offset: usize = self.tasks.borrow_mut().insert(Box::new(future))?;
+
+        // Generate a new id. If the id is currently in use, keep generating until we find an unused id.
+        let id: u64 = loop {
+            let id: u64 = id_gen.next_u64();
+            if self.task_ids.borrow_mut().insert(id, offset).is_none() {
+                break id;
+            }
+        };
+
+        trace!(
+            "scheduler::insert() inserting task with id={:?} and offset={:?}",
+            id,
+            offset
+        );
+
+        // Add a new page to hold this future's status if the current page is filled.
+        while offset as usize >= pages.len() << WAKER_BIT_LENGTH_SHIFT {
+            pages.push(WakerPageRef::default());
+        }
+        let (page, subpage_ix): (&WakerPageRef, usize) = {
+            let (pages_ix, subpage_ix) = self.get_page_offsets(offset);
+            (&pages[pages_ix], subpage_ix)
+        };
+        page.initialize(subpage_ix);
+        let (page, _): (&WakerPageRef, usize) = {
+            let (pages_ix, subpage_ix) = self.get_page_offsets(offset);
+            (&pages[pages_ix], subpage_ix)
+        };
+        Some(SchedulerHandle::new(id, offset, page.clone()))
+    }
+
+    /// Computes the page and page offset of a given task based on its total offset.
+    fn get_page_offsets(&self, offset: usize) -> (usize, usize) {
+        (offset >> WAKER_BIT_LENGTH_SHIFT, offset & (WAKER_BIT_LENGTH - 1))
     }
 
     /// Poll all futures which are ready to run again. Tasks in our scheduler are notified when
     /// relevant data or events happen. The relevant event have callback function (the waker) which
     /// they can invoke to notify the scheduler that future should be polled again.
     pub fn poll(&self) {
-        let mut inner: RefMut<Inner> = self.inner.borrow_mut();
+        let mut pages: RefMut<Vec<WakerPageRef>> = self.pages.borrow_mut();
+        let mut tasks: RefMut<PinSlab<Box<dyn Task>>> = self.tasks.borrow_mut();
 
         // Iterate through pages.
-        for page_ix in 0..inner.pages.len() {
+        for page_ix in 0..pages.len() {
             let (notified, dropped): (u64, u64) = {
-                let page: &mut WakerPageRef = &mut inner.pages[page_ix];
+                let page: &mut WakerPageRef = &mut pages[page_ix];
                 (page.take_notified(), page.take_dropped())
             };
             // There is some notified task in this page, so iterate through it.
@@ -135,22 +176,23 @@ impl Scheduler {
                     // Get future using our page indices and poll it!
                     let ix: usize = (page_ix << WAKER_BIT_LENGTH_SHIFT) + subpage_ix;
                     let waker: Waker = unsafe {
-                        let raw_waker: NonNull<u8> = inner.pages[page_ix].into_raw_waker_ref(subpage_ix);
+                        let raw_waker: NonNull<u8> = pages[page_ix].into_raw_waker_ref(subpage_ix);
                         Waker::from_raw(WakerRef::new(raw_waker).into())
                     };
                     let mut sub_ctx: Context = Context::from_waker(&waker);
 
-                    let pinned_ref: Pin<&mut Box<dyn Task>> = inner.slab.get_pin_mut(ix).unwrap();
+                    let pinned_ref: Pin<&mut Box<dyn Task>> = tasks.get_pin_mut(ix).unwrap();
                     let pinned_ptr = unsafe { Pin::into_inner_unchecked(pinned_ref) as *mut _ };
 
                     // Poll future.
-                    drop(inner);
+                    drop(pages);
+                    drop(tasks);
                     let pinned_ref = unsafe { Pin::new_unchecked(&mut *pinned_ptr) };
                     let poll_result: Poll<()> = Future::poll(pinned_ref, &mut sub_ctx);
-                    inner = self.inner.borrow_mut();
-
+                    pages = self.pages.borrow_mut();
+                    tasks = self.tasks.borrow_mut();
                     match poll_result {
-                        Poll::Ready(()) => inner.pages[page_ix].mark_completed(subpage_ix),
+                        Poll::Ready(()) => pages[page_ix].mark_completed(subpage_ix),
                         Poll::Pending => (),
                     }
                 }
@@ -161,8 +203,8 @@ impl Scheduler {
                 for subpage_ix in BitIter::from(dropped) {
                     if subpage_ix != 0 {
                         let ix: usize = (page_ix << WAKER_BIT_LENGTH_SHIFT) + subpage_ix;
-                        inner.slab.remove(ix);
-                        inner.pages[page_ix].clear(subpage_ix);
+                        tasks.remove(ix);
+                        pages[page_ix].clear(subpage_ix);
                     }
                 }
             }
@@ -170,27 +212,29 @@ impl Scheduler {
     }
 }
 
-//==============================================================================
+//======================================================================================================================
 // Trait Implementations
-//==============================================================================
+//======================================================================================================================
 
 /// Default Trait Implementation for Scheduler
 impl Default for Scheduler {
     /// Creates a scheduler with default values.
     fn default() -> Self {
-        let inner: Inner = Inner {
-            slab: PinSlab::new(),
-            pages: vec![],
-        };
         Self {
-            inner: Rc::new(RefCell::new(inner)),
+            tasks: Rc::new(RefCell::new(PinSlab::new())),
+            task_ids: Rc::new(RefCell::new(HashMap::<u64, usize>::new())),
+            pages: Rc::new(RefCell::new(vec![])),
+            #[cfg(debug_assertions)]
+            id_gen: Rc::new(RefCell::new(SmallRng::seed_from_u64(SCHEDULER_SEED))),
+            #[cfg(not(debug_assertions))]
+            id_gen: Rc::new(RefCell::new(SmallRng::from_entropy())),
         }
     }
 }
 
-//==============================================================================
+//======================================================================================================================
 // Unit Tests
-//==============================================================================
+//======================================================================================================================
 
 #[cfg(test)]
 mod tests {
@@ -257,12 +301,36 @@ mod tests {
         });
     }
 
+    /// Tests if when inserting multiple tasks into the scheduler at once each, of them gets a unique identifier.
+    #[test]
+    fn test_scheduler_insert() -> Result<()> {
+        let scheduler: Scheduler = Scheduler::default();
+
+        // Insert a task and make sure the task id is not a simple counter.
+        let task: DummyTask = DummyTask::new(String::from("testing"), Box::pin(DummyCoroutine::new(0)));
+        let handle: SchedulerHandle = match scheduler.insert(task) {
+            Some(handle) => handle,
+            None => anyhow::bail!("insert() failed"),
+        };
+        let task_id: u64 = handle.into_raw();
+
+        // Insert another task and make sure the task id is not sequentially after the previous one.
+        let task2: DummyTask = DummyTask::new(String::from("testing"), Box::pin(DummyCoroutine::new(0)));
+        let handle2: SchedulerHandle = match scheduler.insert(task2) {
+            Some(handle) => handle,
+            None => anyhow::bail!("insert() failed"),
+        };
+        let task_id2: u64 = handle2.into_raw();
+        crate::ensure_neq!(task_id2, task_id + 1);
+
+        Ok(())
+    }
+
     #[test]
     fn scheduler_poll_once() -> Result<()> {
         let scheduler: Scheduler = Scheduler::default();
 
-        // Insert a single future in the scheduler. This future shall complete
-        // with a single pool operation.
+        // Insert a single future in the scheduler. This future shall complete with a single poll operation.
         let task: DummyTask = DummyTask::new(String::from("testing"), Box::pin(DummyCoroutine::new(0)));
         let handle: SchedulerHandle = match scheduler.insert(task) {
             Some(handle) => handle,
@@ -300,6 +368,37 @@ mod tests {
         scheduler.poll();
 
         crate::ensure_eq!(handle.has_completed(), true);
+
+        Ok(())
+    }
+
+    /// Tests if consecutive tasks are not assigned the same task id.
+    #[test]
+    fn test_scheduler_task_ids() -> Result<()> {
+        let scheduler: Scheduler = Scheduler::default();
+
+        // Create and run a task.
+        let task: DummyTask = DummyTask::new(String::from("testing"), Box::pin(DummyCoroutine::new(0)));
+        let handle: SchedulerHandle = match scheduler.insert(task) {
+            Some(handle) => handle,
+            None => anyhow::bail!("insert() failed"),
+        };
+        let task_id: u64 = handle.clone().into_raw();
+        scheduler.poll();
+
+        // Ensure that the first task has completed.
+        crate::ensure_eq!(handle.has_completed(), true);
+
+        // Create another task.
+        let task2: DummyTask = DummyTask::new(String::from("testing"), Box::pin(DummyCoroutine::new(0)));
+        let handle2: SchedulerHandle = match scheduler.insert(task2) {
+            Some(handle) => handle,
+            None => anyhow::bail!("insert() failed"),
+        };
+        let task_id2: u64 = handle2.into_raw();
+
+        // Ensure that the second task has a unique id.
+        crate::ensure_neq!(task_id2, task_id);
 
         Ok(())
     }


### PR DESCRIPTION
This PR closes #624. 

Previously, we used the offset of the Task in the slab data structure as the key for uniquely identifying a scheduled task externally outside the scheduler. This PR changes the key to a token that is randomly allocated for each scheduled task. We introduce a tokens table to map from tokens to offsets (previously keys). Note the changes of variable names and function names, this was done intentionally to enforce the new data structures and to better describe the difference between tokens and offsets. I chose to specifically generate random tokens to keep applications from depending on qtokens in a way that is not opaque.

We chose to use another level of indirection to minimize changes to the scheduler. Eventually we may want to remove the PinSlab data structure. Note that the PinSlab serves an important purpose. First, it packs Tasks without having to move existing Tasks, which is important because the Task data structure holds the Future, which will need to be pinned in place for asynchronous execution. Next, the slab is an intrusive allocators, so the location of the next free spot is held in the space occupied by the current free spot. This enables efficient allocation without data movement and ensures that there are not too many gaps when Tasks are frequently freed and re-used. The offset into the slab also dictates the location of the Waker bits, making is unnecessary for us to track which Waker bits are being used and which are free. So it also makes it easy to find the next free Waker bit because it is in the same offset as the next open slot in the slab. 

I have created issue #723 to track revisiting the issue of keeping the slab in the future. I have also linked to some FIXME references to #593 