### PR TITLE
[catnap] Implement drop for cleanup on exit

### DIFF
--- a/src/rust/catnap/mod.rs
+++ b/src/rust/catnap/mod.rs
@@ -694,6 +694,25 @@ impl CatnapLibOS {
     }
 }
 
+//======================================================================================================================
+// Trait Implementations
+//======================================================================================================================
+
+impl Drop for CatnapLibOS {
+    // Releases all sockets allocated by Catnap.
+    fn drop(&mut self) {
+        for (_, queue) in self.qtable.borrow().get_values() {
+            if let Some(fd) = queue.get_fd() {
+                if unsafe { libc::close(fd) } != 0 {
+                    let errno: libc::c_int = unsafe { *libc::__errno_location() };
+                    error!("close() failed (error={:?}", errno);
+                    warn!("leaking fd={:?}", fd);
+                }
+            }
+        }
+    }
+}
+
 //==============================================================================
 // Standalone Functions
 //==============================================================================


### PR DESCRIPTION
This PR close #668. I explicitly close each socket with a valid file descriptor. As an aside, we may want to move any code that only deals with a single queue or socket into the CatnapQueue or Socket data structure. For example, the RawFd associated with the socket should probably be stored inside the socket.