### PR TITLE
[runtime] Make `RECEIVE_BATCH_SIZE` Generic

### DIFF
--- a/src/rust/catcollar/runtime/network.rs
+++ b/src/rust/catcollar/runtime/network.rs
@@ -9,7 +9,6 @@ use super::IoUringRuntime;
 use crate::runtime::{
     memory::DemiBuffer,
     network::{
-        consts::RECEIVE_BATCH_SIZE,
         NetworkRuntime,
         PacketBuf,
     },
@@ -21,14 +20,14 @@ use ::arrayvec::ArrayVec;
 //==============================================================================
 
 /// Network Runtime Trait Implementation for I/O User Ring Runtime
-impl NetworkRuntime for IoUringRuntime {
+impl<const N: usize> NetworkRuntime<N> for IoUringRuntime {
     // TODO: Rely on a default implementation for this.
     fn transmit(&self, _pkt: Box<dyn PacketBuf>) {
         unreachable!()
     }
 
     // TODO: Rely on a default implementation for this.
-    fn receive(&self) -> ArrayVec<DemiBuffer, RECEIVE_BATCH_SIZE> {
+    fn receive(&self) -> ArrayVec<DemiBuffer, N> {
         unreachable!()
     }
 }

--- a/src/rust/catnip/mod.rs
+++ b/src/rust/catnip/mod.rs
@@ -20,6 +20,7 @@ use crate::{
         fail::Fail,
         libdpdk::load_mlx_driver,
         memory::MemoryRuntime,
+        network::consts::RECEIVE_BATCH_SIZE,
         timer::{
             Timer,
             TimerRc,
@@ -57,7 +58,7 @@ use crate::timer;
 /// Catnip LibOS
 pub struct CatnipLibOS {
     scheduler: Scheduler,
-    inetstack: InetStack,
+    inetstack: InetStack<RECEIVE_BATCH_SIZE>,
     rt: Rc<DPDKRuntime>,
 }
 
@@ -84,7 +85,7 @@ impl CatnipLibOS {
         let clock: TimerRc = TimerRc(Rc::new(Timer::new(now)));
         let scheduler: Scheduler = Scheduler::default();
         let rng_seed: [u8; 32] = [0; 32];
-        let inetstack: InetStack = InetStack::new(
+        let inetstack: InetStack<RECEIVE_BATCH_SIZE> = InetStack::new(
             rt.clone(),
             scheduler.clone(),
             clock,
@@ -177,7 +178,7 @@ impl CatnipLibOS {
 
 /// De-Reference Trait Implementation for Catnip LibOS
 impl Deref for CatnipLibOS {
-    type Target = InetStack;
+    type Target = InetStack<RECEIVE_BATCH_SIZE>;
 
     fn deref(&self) -> &Self::Target {
         &self.inetstack

--- a/src/rust/catpowder/mod.rs
+++ b/src/rust/catpowder/mod.rs
@@ -19,6 +19,7 @@ use crate::{
     runtime::{
         fail::Fail,
         memory::MemoryRuntime,
+        network::consts::RECEIVE_BATCH_SIZE,
         timer::{
             Timer,
             TimerRc,
@@ -57,7 +58,7 @@ use crate::timer;
 /// Catpowder LibOS
 pub struct CatpowderLibOS {
     scheduler: Scheduler,
-    inetstack: InetStack,
+    inetstack: InetStack<RECEIVE_BATCH_SIZE>,
     rt: Rc<LinuxRuntime>,
 }
 
@@ -79,7 +80,7 @@ impl CatpowderLibOS {
         let scheduler: Scheduler = Scheduler::default();
         let clock: TimerRc = TimerRc(Rc::new(Timer::new(now)));
         let rng_seed: [u8; 32] = [0; 32];
-        let inetstack: InetStack = InetStack::new(
+        let inetstack: InetStack<RECEIVE_BATCH_SIZE> = InetStack::new(
             rt.clone(),
             scheduler.clone(),
             clock,
@@ -172,7 +173,7 @@ impl CatpowderLibOS {
 
 /// De-Reference Trait Implementation for Catpowder LibOS
 impl Deref for CatpowderLibOS {
-    type Target = InetStack;
+    type Target = InetStack<RECEIVE_BATCH_SIZE>;
 
     fn deref(&self) -> &Self::Target {
         &self.inetstack

--- a/src/rust/inetstack/protocols/arp/tests.rs
+++ b/src/rust/inetstack/protocols/arp/tests.rs
@@ -8,9 +8,15 @@ use super::packet::{
 use crate::{
     inetstack::{
         protocols::ethernet2::Ethernet2Header,
-        test_helpers::{self,},
+        test_helpers::{
+            self,
+            Engine,
+        },
     },
-    runtime::network::types::MacAddress,
+    runtime::network::{
+        consts::RECEIVE_BATCH_SIZE,
+        types::MacAddress,
+    },
 };
 use ::anyhow::Result;
 use ::futures::{
@@ -38,9 +44,9 @@ use ::std::{
 fn immediate_reply() -> Result<()> {
     // tests to ensure that an are request results in a reply.
     let now = Instant::now();
-    let mut alice = test_helpers::new_alice(now);
-    let mut bob = test_helpers::new_bob(now);
-    let mut carrie = test_helpers::new_carrie(now);
+    let mut alice: Engine<RECEIVE_BATCH_SIZE> = test_helpers::new_alice(now);
+    let mut bob: Engine<RECEIVE_BATCH_SIZE> = test_helpers::new_bob(now);
+    let mut carrie: Engine<RECEIVE_BATCH_SIZE> = test_helpers::new_carrie(now);
 
     crate::ensure_eq!(alice.rt.arp_options.get_request_timeout(), Duration::from_secs(1));
 
@@ -90,9 +96,9 @@ fn immediate_reply() -> Result<()> {
 fn slow_reply() -> Result<()> {
     // tests to ensure that an are request results in a reply.
     let mut now = Instant::now();
-    let mut alice = test_helpers::new_alice(now);
-    let mut bob = test_helpers::new_bob(now);
-    let mut carrie = test_helpers::new_carrie(now);
+    let mut alice: Engine<RECEIVE_BATCH_SIZE> = test_helpers::new_alice(now);
+    let mut bob: Engine<RECEIVE_BATCH_SIZE> = test_helpers::new_bob(now);
+    let mut carrie: Engine<RECEIVE_BATCH_SIZE> = test_helpers::new_carrie(now);
 
     // this test is written based on certain assumptions.
     crate::ensure_eq!(alice.rt.arp_options.get_retry_count() > 0, true);
@@ -153,7 +159,7 @@ fn slow_reply() -> Result<()> {
 fn no_reply() -> Result<()> {
     // tests to ensure that an are request results in a reply.
     let mut now = Instant::now();
-    let alice = test_helpers::new_alice(now);
+    let alice: Engine<RECEIVE_BATCH_SIZE> = test_helpers::new_alice(now);
 
     crate::ensure_eq!(alice.rt.arp_options.get_retry_count(), 2);
     crate::ensure_eq!(alice.rt.arp_options.get_request_timeout(), Duration::from_secs(1));

--- a/src/rust/inetstack/protocols/icmpv4/tests.rs
+++ b/src/rust/inetstack/protocols/icmpv4/tests.rs
@@ -1,7 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-use crate::inetstack::test_helpers;
+use crate::{
+    inetstack::test_helpers::{
+        self,
+        Engine,
+    },
+    runtime::network::consts::RECEIVE_BATCH_SIZE,
+};
 use ::anyhow::Result;
 use ::futures::task::{
     noop_waker_ref,
@@ -26,9 +32,9 @@ fn ipv4_ping() -> Result<()> {
     let mut ctx = Context::from_waker(noop_waker_ref());
     let mut now = Instant::now();
 
-    let mut alice = test_helpers::new_alice2(now);
+    let mut alice: Engine<RECEIVE_BATCH_SIZE> = test_helpers::new_alice2(now);
 
-    let mut bob = test_helpers::new_bob2(now);
+    let mut bob: Engine<RECEIVE_BATCH_SIZE> = test_helpers::new_bob2(now);
 
     // Alice pings Bob.
     let mut ping_fut = Box::pin(alice.ipv4_ping(test_helpers::BOB_IPV4, None));
@@ -68,9 +74,9 @@ fn ipv4_ping_loop() -> Result<()> {
     let mut ctx = Context::from_waker(noop_waker_ref());
     let mut now = Instant::now();
 
-    let mut alice = test_helpers::new_alice2(now);
+    let mut alice: Engine<RECEIVE_BATCH_SIZE> = test_helpers::new_alice2(now);
 
-    let mut bob = test_helpers::new_bob2(now);
+    let mut bob: Engine<RECEIVE_BATCH_SIZE> = test_helpers::new_bob2(now);
 
     for _ in 1..1000 {
         // Alice pings Bob.

--- a/src/rust/inetstack/protocols/peer.rs
+++ b/src/rust/inetstack/protocols/peer.rs
@@ -39,28 +39,28 @@ use ::std::{
 #[cfg(test)]
 use crate::runtime::QDesc;
 
-pub struct Peer {
+pub struct Peer<const N: usize> {
     local_ipv4_addr: Ipv4Addr,
-    icmpv4: Icmpv4Peer,
-    pub tcp: TcpPeer,
-    pub udp: UdpPeer,
+    icmpv4: Icmpv4Peer<N>,
+    pub tcp: TcpPeer<N>,
+    pub udp: UdpPeer<N>,
 }
 
-impl Peer {
+impl<const N: usize> Peer<N> {
     pub fn new(
-        rt: Rc<dyn NetworkRuntime>,
+        rt: Rc<dyn NetworkRuntime<N>>,
         scheduler: Scheduler,
-        qtable: Rc<RefCell<IoQueueTable<InetQueue>>>,
+        qtable: Rc<RefCell<IoQueueTable<InetQueue<N>>>>,
         clock: TimerRc,
         local_link_addr: MacAddress,
         local_ipv4_addr: Ipv4Addr,
         udp_config: UdpConfig,
         tcp_config: TcpConfig,
-        arp: ArpPeer,
+        arp: ArpPeer<N>,
         rng_seed: [u8; 32],
-    ) -> Result<Peer, Fail> {
+    ) -> Result<Self, Fail> {
         let udp_offload_checksum: bool = udp_config.get_tx_checksum_offload();
-        let udp: UdpPeer = UdpPeer::new(
+        let udp: UdpPeer<N> = UdpPeer::new(
             rt.clone(),
             scheduler.clone(),
             qtable.clone(),
@@ -70,7 +70,7 @@ impl Peer {
             udp_offload_checksum,
             arp.clone(),
         )?;
-        let icmpv4: Icmpv4Peer = Icmpv4Peer::new(
+        let icmpv4: Icmpv4Peer<N> = Icmpv4Peer::new(
             rt.clone(),
             scheduler.clone(),
             clock.clone(),
@@ -79,7 +79,7 @@ impl Peer {
             arp.clone(),
             rng_seed,
         )?;
-        let tcp: TcpPeer = TcpPeer::new(
+        let tcp: TcpPeer<N> = TcpPeer::new(
             rt.clone(),
             scheduler.clone(),
             qtable.clone(),
@@ -122,7 +122,7 @@ impl Peer {
 }
 
 #[cfg(test)]
-impl Peer {
+impl<const N: usize> Peer<N> {
     pub fn tcp_mss(&self, fd: QDesc) -> Result<usize, Fail> {
         self.tcp.remote_mss(fd)
     }

--- a/src/rust/inetstack/protocols/queue.rs
+++ b/src/rust/inetstack/protocols/queue.rs
@@ -8,12 +8,12 @@ use crate::runtime::queue::{
 };
 
 /// Per-queue metadata: Inet stack Control Block
-pub enum InetQueue {
+pub enum InetQueue<const N: usize> {
     Udp(UdpQueue),
-    Tcp(TcpQueue),
+    Tcp(TcpQueue<N>),
 }
 
-impl IoQueue for InetQueue {
+impl<const N: usize> IoQueue for InetQueue<N> {
     fn get_qtype(&self) -> QType {
         match self {
             Self::Udp(_) => QType::UdpSocket,

--- a/src/rust/inetstack/protocols/tcp/established/background/acknowledger.rs
+++ b/src/rust/inetstack/protocols/tcp/established/background/acknowledger.rs
@@ -12,7 +12,7 @@ use ::futures::{
 };
 use ::std::rc::Rc;
 
-pub async fn acknowledger(cb: Rc<ControlBlock>) -> Result<!, Fail> {
+pub async fn acknowledger<const N: usize>(cb: Rc<ControlBlock<N>>) -> Result<!, Fail> {
     loop {
         // TODO: Implement TCP delayed ACKs, subject to restrictions from RFC 1122
         // - TCP should implement a delayed ACK

--- a/src/rust/inetstack/protocols/tcp/established/background/retransmitter.rs
+++ b/src/rust/inetstack/protocols/tcp/established/background/retransmitter.rs
@@ -18,7 +18,7 @@ use ::std::{
     },
 };
 
-pub async fn retransmitter(cb: Rc<ControlBlock>) -> Result<!, Fail> {
+pub async fn retransmitter<const N: usize>(cb: Rc<ControlBlock<N>>) -> Result<!, Fail> {
     loop {
         // Pin future for timeout retransmission.
         let (rtx_deadline, rtx_deadline_changed) = cb.watch_retransmit_deadline();

--- a/src/rust/inetstack/protocols/tcp/established/background/sender.rs
+++ b/src/rust/inetstack/protocols/tcp/established/background/sender.rs
@@ -22,7 +22,7 @@ use ::std::{
     time::Duration,
 };
 
-pub async fn sender(cb: Rc<ControlBlock>) -> Result<!, Fail> {
+pub async fn sender<const N: usize>(cb: Rc<ControlBlock<N>>) -> Result<!, Fail> {
     'top: loop {
         // First, check to see if there's any unsent data.
         // TODO: Change this to just look at the unsent queue to see if it is empty or not.

--- a/src/rust/inetstack/protocols/tcp/operations.rs
+++ b/src/rust/inetstack/protocols/tcp/operations.rs
@@ -23,18 +23,18 @@ use ::std::{
     },
 };
 
-pub struct ConnectFuture {
+pub struct ConnectFuture<const N: usize> {
     pub qd: QDesc,
-    pub inner: Rc<RefCell<Inner>>,
+    pub inner: Rc<RefCell<Inner<N>>>,
 }
 
-impl fmt::Debug for ConnectFuture {
+impl<const N: usize> fmt::Debug for ConnectFuture<N> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "ConnectFuture({:?})", self.qd)
     }
 }
 
-impl Future for ConnectFuture {
+impl<const N: usize> Future for ConnectFuture<N> {
     type Output = Result<(), Fail>;
 
     fn poll(self: Pin<&mut Self>, context: &mut Context) -> Poll<Self::Output> {
@@ -44,39 +44,39 @@ impl Future for ConnectFuture {
 }
 
 /// Accept Operation Descriptor
-pub struct AcceptFuture {
+pub struct AcceptFuture<const N: usize> {
     /// Queue descriptor of listening socket.
     qd: QDesc,
     // Pre-booked queue descriptor for incoming connection.
     new_qd: QDesc,
     // Reference to associated inner TCP peer.
-    inner: Rc<RefCell<Inner>>,
+    inner: Rc<RefCell<Inner<N>>>,
 }
 
 /// Associated Functions for Accept Operation Descriptors
-impl AcceptFuture {
+impl<const N: usize> AcceptFuture<N> {
     /// Creates a descriptor for an accept operation.
-    pub fn new(qd: QDesc, new_qd: QDesc, inner: Rc<RefCell<Inner>>) -> Self {
+    pub fn new(qd: QDesc, new_qd: QDesc, inner: Rc<RefCell<Inner<N>>>) -> Self {
         Self { qd, new_qd, inner }
     }
 }
 
 /// Debug Trait Implementation for Accept Operation Descriptors
-impl fmt::Debug for AcceptFuture {
+impl<const N: usize> fmt::Debug for AcceptFuture<N> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "AcceptFuture({:?})", self.qd)
     }
 }
 
 /// Future Trait Implementation for Accept Operation Descriptors
-impl Future for AcceptFuture {
+impl<const N: usize> Future for AcceptFuture<N> {
     type Output = Result<(QDesc, SocketAddrV4), Fail>;
 
     /// Polls the underlying accept operation.
     fn poll(self: Pin<&mut Self>, context: &mut Context) -> Poll<Self::Output> {
-        let self_: &mut AcceptFuture = self.get_mut();
+        let self_: &mut AcceptFuture<N> = self.get_mut();
         // TODO: The following design pattern looks ugly. We should move poll_accept to the inner structure.
-        let peer: TcpPeer = TcpPeer {
+        let peer: TcpPeer<N> = TcpPeer {
             inner: self_.inner.clone(),
         };
         peer.poll_accept(self_.qd, self_.new_qd, context)
@@ -105,19 +105,19 @@ impl Future for PushFuture {
     }
 }
 
-pub struct PopFuture {
+pub struct PopFuture<const N: usize> {
     pub qd: QDesc,
     pub size: Option<usize>,
-    pub inner: Rc<RefCell<Inner>>,
+    pub inner: Rc<RefCell<Inner<N>>>,
 }
 
-impl fmt::Debug for PopFuture {
+impl<const N: usize> fmt::Debug for PopFuture<N> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "PopFuture({:?})", self.qd)
     }
 }
 
-impl Future for PopFuture {
+impl<const N: usize> Future for PopFuture<N> {
     type Output = Result<DemiBuffer, Fail>;
 
     fn poll(self: Pin<&mut Self>, ctx: &mut Context) -> Poll<Self::Output> {
@@ -130,18 +130,18 @@ impl Future for PopFuture {
     }
 }
 
-pub struct CloseFuture {
+pub struct CloseFuture<const N: usize> {
     pub qd: QDesc,
-    pub inner: Rc<RefCell<Inner>>,
+    pub inner: Rc<RefCell<Inner<N>>>,
 }
 
-impl fmt::Debug for CloseFuture {
+impl<const N: usize> fmt::Debug for CloseFuture<N> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "CloseFuture({:?})", self.qd)
     }
 }
 
-impl Future for CloseFuture {
+impl<const N: usize> Future for CloseFuture<N> {
     type Output = Result<(), Fail>;
 
     fn poll(self: Pin<&mut Self>, ctx: &mut Context) -> Poll<Self::Output> {

--- a/src/rust/inetstack/protocols/tcp/queue.rs
+++ b/src/rust/inetstack/protocols/tcp/queue.rs
@@ -16,15 +16,15 @@ use crate::runtime::{
 //======================================================================================================================
 
 /// Per-queue metadata for the TCP socket.
-pub struct TcpQueue {
-    socket: Socket,
+pub struct TcpQueue<const N: usize> {
+    socket: Socket<N>,
 }
 
 //======================================================================================================================
 // Associated Functions
 //======================================================================================================================
 
-impl TcpQueue {
+impl<const N: usize> TcpQueue<N> {
     pub fn new() -> Self {
         Self {
             socket: Socket::Inactive(None),
@@ -32,17 +32,17 @@ impl TcpQueue {
     }
 
     /// Get/borrow reference to underlying TCP socket data structure.
-    pub fn get_socket(&self) -> &Socket {
+    pub fn get_socket(&self) -> &Socket<N> {
         &self.socket
     }
 
     /// Get/borrow mutable reference to underlying TCP socket data structure.
-    pub fn get_mut_socket(&mut self) -> &mut Socket {
+    pub fn get_mut_socket(&mut self) -> &mut Socket<N> {
         &mut self.socket
     }
 
     /// Set underlying TCP socket data structure.
-    pub fn set_socket(&mut self, s: Socket) {
+    pub fn set_socket(&mut self, s: Socket<N>) {
         self.socket = s;
     }
 }
@@ -51,7 +51,7 @@ impl TcpQueue {
 // Trait implementation
 //======================================================================================================================
 
-impl IoQueue for TcpQueue {
+impl<const N: usize> IoQueue for TcpQueue<N> {
     fn get_qtype(&self) -> QType {
         QType::TcpSocket
     }

--- a/src/rust/inetstack/protocols/udp/tests.rs
+++ b/src/rust/inetstack/protocols/udp/tests.rs
@@ -8,6 +8,7 @@ use crate::{
     },
     runtime::{
         memory::DemiBuffer,
+        network::consts::RECEIVE_BATCH_SIZE,
         QDesc,
     },
 };
@@ -45,7 +46,7 @@ fn udp_bind_udp_close() -> Result<()> {
     let mut now = Instant::now();
 
     // Setup Alice.
-    let mut alice = test_helpers::new_alice2(now);
+    let mut alice: Engine<RECEIVE_BATCH_SIZE> = test_helpers::new_alice2(now);
     let alice_port = 80;
     let alice_addr = SocketAddrV4::new(test_helpers::ALICE_IPV4, alice_port);
     let alice_fd: QDesc = match alice.udp_socket() {
@@ -55,7 +56,7 @@ fn udp_bind_udp_close() -> Result<()> {
     alice.udp_bind(alice_fd, alice_addr)?;
 
     // Setup Bob.
-    let mut bob = test_helpers::new_bob2(now);
+    let mut bob: Engine<RECEIVE_BATCH_SIZE> = test_helpers::new_bob2(now);
     let bob_port = 80;
     let bob_addr = SocketAddrV4::new(test_helpers::BOB_IPV4, bob_port);
     let bob_fd: QDesc = match bob.udp_socket() {
@@ -83,14 +84,14 @@ fn udp_push_pop() -> Result<()> {
     let mut now: Instant = Instant::now();
 
     // Setup Alice.
-    let mut alice: Engine = test_helpers::new_alice2(now);
+    let mut alice: Engine<RECEIVE_BATCH_SIZE> = test_helpers::new_alice2(now);
     let alice_port: u16 = 80;
     let alice_addr: SocketAddrV4 = SocketAddrV4::new(test_helpers::ALICE_IPV4, alice_port);
     let alice_fd: QDesc = alice.udp_socket()?;
     alice.udp_bind(alice_fd, alice_addr)?;
 
     // Setup Bob.
-    let mut bob: Engine = test_helpers::new_bob2(now);
+    let mut bob: Engine<RECEIVE_BATCH_SIZE> = test_helpers::new_bob2(now);
     let bob_port: u16 = 80;
     let bob_addr: SocketAddrV4 = SocketAddrV4::new(test_helpers::BOB_IPV4, bob_port);
     let bob_fd: QDesc = bob.udp_socket()?;
@@ -130,14 +131,14 @@ fn udp_push_pop_wildcard_address() -> Result<()> {
     let mut now: Instant = Instant::now();
 
     // Setup Alice.
-    let mut alice: Engine = test_helpers::new_alice2(now);
+    let mut alice: Engine<RECEIVE_BATCH_SIZE> = test_helpers::new_alice2(now);
     let alice_port: u16 = 80;
     let alice_addr: SocketAddrV4 = SocketAddrV4::new(test_helpers::ALICE_IPV4, alice_port);
     let alice_fd: QDesc = alice.udp_socket()?;
     alice.udp_bind(alice_fd, alice_addr)?;
 
     // Setup Bob.
-    let mut bob: Engine = test_helpers::new_bob2(now);
+    let mut bob: Engine<RECEIVE_BATCH_SIZE> = test_helpers::new_bob2(now);
     let bob_port: u16 = 80;
     let bob_addr: SocketAddrV4 = SocketAddrV4::new(test_helpers::BOB_IPV4, bob_port);
     let bob_fd: QDesc = bob.udp_socket()?;
@@ -177,14 +178,14 @@ fn udp_ping_pong() -> Result<()> {
     let mut now = Instant::now();
 
     // Setup Alice.
-    let mut alice = test_helpers::new_alice2(now);
+    let mut alice: Engine<RECEIVE_BATCH_SIZE> = test_helpers::new_alice2(now);
     let alice_port = 80;
     let alice_addr = SocketAddrV4::new(test_helpers::ALICE_IPV4, alice_port);
     let alice_fd: QDesc = alice.udp_socket()?;
     alice.udp_bind(alice_fd, alice_addr)?;
 
     // Setup Bob.
-    let mut bob = test_helpers::new_bob2(now);
+    let mut bob: Engine<RECEIVE_BATCH_SIZE> = test_helpers::new_bob2(now);
     let bob_port = 80;
     let bob_addr = SocketAddrV4::new(test_helpers::BOB_IPV4, bob_port);
     let bob_fd: QDesc = bob.udp_socket()?;
@@ -252,12 +253,12 @@ fn udp_loop2_bind_udp_close() -> Result<()> {
     let mut now = Instant::now();
 
     // Alice.
-    let mut alice = test_helpers::new_alice2(now);
+    let mut alice: Engine<RECEIVE_BATCH_SIZE> = test_helpers::new_alice2(now);
     let alice_port = 80;
     let alice_addr = SocketAddrV4::new(test_helpers::ALICE_IPV4, alice_port);
 
     // Bob.
-    let mut bob = test_helpers::new_bob2(now);
+    let mut bob: Engine<RECEIVE_BATCH_SIZE> = test_helpers::new_bob2(now);
     let bob_port = 80;
     let bob_addr = SocketAddrV4::new(test_helpers::BOB_IPV4, bob_port);
 
@@ -301,14 +302,14 @@ fn udp_loop2_push_pop() -> Result<()> {
     let mut now = Instant::now();
 
     // Setup Alice.
-    let mut alice = test_helpers::new_alice2(now);
+    let mut alice: Engine<RECEIVE_BATCH_SIZE> = test_helpers::new_alice2(now);
     let alice_port = 80;
     let alice_addr = SocketAddrV4::new(test_helpers::ALICE_IPV4, alice_port);
     let alice_fd: QDesc = alice.udp_socket()?;
     alice.udp_bind(alice_fd, alice_addr)?;
 
     // Setup Bob.
-    let mut bob = test_helpers::new_bob2(now);
+    let mut bob: Engine<RECEIVE_BATCH_SIZE> = test_helpers::new_bob2(now);
     let bob_port = 80;
     let bob_addr = SocketAddrV4::new(test_helpers::BOB_IPV4, bob_port);
     let bob_fd: QDesc = bob.udp_socket()?;
@@ -360,14 +361,14 @@ fn udp_loop2_ping_pong() -> Result<()> {
     let mut now = Instant::now();
 
     // Setup Alice.
-    let mut alice = test_helpers::new_alice2(now);
+    let mut alice: Engine<RECEIVE_BATCH_SIZE> = test_helpers::new_alice2(now);
     let alice_port = 80;
     let alice_addr = SocketAddrV4::new(test_helpers::ALICE_IPV4, alice_port);
     let alice_fd: QDesc = alice.udp_socket()?;
     alice.udp_bind(alice_fd, alice_addr)?;
 
     // Setup Bob.
-    let mut bob = test_helpers::new_bob2(now);
+    let mut bob: Engine<RECEIVE_BATCH_SIZE> = test_helpers::new_bob2(now);
     let bob_port = 80;
     let bob_addr = SocketAddrV4::new(test_helpers::BOB_IPV4, bob_port);
     let bob_fd: QDesc = bob.udp_socket()?;
@@ -428,7 +429,7 @@ fn udp_bind_address_in_use() -> Result<()> {
     let now = Instant::now();
 
     // Setup Alice.
-    let mut alice = test_helpers::new_alice2(now);
+    let mut alice: Engine<RECEIVE_BATCH_SIZE> = test_helpers::new_alice2(now);
     let alice_port = 80;
     let alice_addr = SocketAddrV4::new(test_helpers::ALICE_IPV4, alice_port);
     let alice_fd: QDesc = alice.udp_socket()?;
@@ -451,7 +452,7 @@ fn udp_bind_bad_file_descriptor() -> Result<()> {
     let now = Instant::now();
 
     // Setup Alice.
-    let mut alice: Engine = test_helpers::new_alice2(now);
+    let mut alice: Engine<RECEIVE_BATCH_SIZE> = test_helpers::new_alice2(now);
     let alice_port: u16 = 80;
     let alice_addr: SocketAddrV4 = SocketAddrV4::new(test_helpers::ALICE_IPV4, alice_port);
     let alice_fd: QDesc = QDesc::try_from(u32::MAX)?;
@@ -474,7 +475,7 @@ fn udp_udp_close_bad_file_descriptor() -> Result<()> {
     let now = Instant::now();
 
     // Setup Alice.
-    let mut alice: Engine = test_helpers::new_alice2(now);
+    let mut alice: Engine<RECEIVE_BATCH_SIZE> = test_helpers::new_alice2(now);
     let alice_fd: QDesc = alice.udp_socket()?;
     let alice_port: u16 = 80;
     let alice_addr: SocketAddrV4 = SocketAddrV4::new(test_helpers::ALICE_IPV4, alice_port);
@@ -505,14 +506,14 @@ fn udp_pop_not_bound() -> Result<()> {
     let mut now = Instant::now();
 
     // Setup Alice.
-    let mut alice = test_helpers::new_alice2(now);
+    let mut alice: Engine<RECEIVE_BATCH_SIZE> = test_helpers::new_alice2(now);
     let alice_port = 80;
     let alice_addr = SocketAddrV4::new(test_helpers::ALICE_IPV4, alice_port);
     let alice_fd: QDesc = alice.udp_socket()?;
     alice.udp_bind(alice_fd, alice_addr)?;
 
     // Setup Bob.
-    let mut bob = test_helpers::new_bob2(now);
+    let mut bob: Engine<RECEIVE_BATCH_SIZE> = test_helpers::new_bob2(now);
     let bob_port = 80;
     let bob_addr = SocketAddrV4::new(test_helpers::BOB_IPV4, bob_port);
     // Bob does not create a socket.
@@ -546,14 +547,14 @@ fn udp_push_bad_file_descriptor() -> Result<()> {
     let mut now = Instant::now();
 
     // Setup Alice.
-    let mut alice: Engine = test_helpers::new_alice2(now);
+    let mut alice: Engine<RECEIVE_BATCH_SIZE> = test_helpers::new_alice2(now);
     let alice_port: u16 = 80;
     let alice_addr: SocketAddrV4 = SocketAddrV4::new(test_helpers::ALICE_IPV4, alice_port);
     let alice_fd: QDesc = alice.udp_socket()?;
     alice.udp_bind(alice_fd, alice_addr)?;
 
     // Setup Bob.
-    let mut bob: Engine = test_helpers::new_bob2(now);
+    let mut bob: Engine<RECEIVE_BATCH_SIZE> = test_helpers::new_bob2(now);
     let bob_port: u16 = 80;
     let bob_addr: SocketAddrV4 = SocketAddrV4::new(test_helpers::BOB_IPV4, bob_port);
     let bob_fd: QDesc = bob.udp_socket()?;

--- a/src/rust/inetstack/test_helpers/engine.rs
+++ b/src/rust/inetstack/test_helpers/engine.rs
@@ -43,15 +43,15 @@ use ::std::{
 
 use super::TestRuntime;
 
-pub struct Engine {
+pub struct Engine<const N: usize> {
     pub rt: Rc<TestRuntime>,
     pub clock: TimerRc,
-    pub arp: ArpPeer,
-    pub ipv4: Peer,
-    pub qtable: Rc<RefCell<IoQueueTable<InetQueue>>>,
+    pub arp: ArpPeer<N>,
+    pub ipv4: Peer<N>,
+    pub qtable: Rc<RefCell<IoQueueTable<InetQueue<N>>>>,
 }
 
-impl Engine {
+impl<const N: usize> Engine<N> {
     pub fn new(rt: TestRuntime, scheduler: Scheduler, clock: TimerRc) -> Result<Self, Fail> {
         let rt = Rc::new(rt);
         let link_addr = rt.link_addr;
@@ -59,7 +59,7 @@ impl Engine {
         let arp_options = rt.arp_options.clone();
         let udp_config = rt.udp_config.clone();
         let tcp_config = rt.tcp_config.clone();
-        let qtable = Rc::new(RefCell::new(IoQueueTable::<InetQueue>::new()));
+        let qtable = Rc::new(RefCell::new(IoQueueTable::<InetQueue<N>>::new()));
         let arp = ArpPeer::new(
             rt.clone(),
             scheduler.clone(),
@@ -135,7 +135,7 @@ impl Engine {
         self.ipv4.tcp.do_socket()
     }
 
-    pub fn tcp_connect(&mut self, socket_fd: QDesc, remote_endpoint: SocketAddrV4) -> ConnectFuture {
+    pub fn tcp_connect(&mut self, socket_fd: QDesc, remote_endpoint: SocketAddrV4) -> ConnectFuture<N> {
         self.ipv4.tcp.connect(socket_fd, remote_endpoint).unwrap()
     }
 
@@ -143,7 +143,7 @@ impl Engine {
         self.ipv4.tcp.bind(socket_fd, endpoint)
     }
 
-    pub fn tcp_accept(&mut self, fd: QDesc) -> AcceptFuture {
+    pub fn tcp_accept(&mut self, fd: QDesc) -> AcceptFuture<N> {
         let (_, future) = self.ipv4.tcp.do_accept(fd);
         future
     }
@@ -152,7 +152,7 @@ impl Engine {
         self.ipv4.tcp.push(socket_fd, buf)
     }
 
-    pub fn tcp_pop(&mut self, socket_fd: QDesc) -> PopFuture {
+    pub fn tcp_pop(&mut self, socket_fd: QDesc) -> PopFuture<N> {
         self.ipv4.tcp.pop(socket_fd, None)
     }
 

--- a/src/rust/inetstack/test_helpers/mod.rs
+++ b/src/rust/inetstack/test_helpers/mod.rs
@@ -46,7 +46,7 @@ pub const CARRIE_IPV4: Ipv4Addr = Ipv4Addr::new(192, 168, 1, 3);
 // Standalone Functions
 //==============================================================================
 
-pub fn new_alice(now: Instant) -> Engine {
+pub fn new_alice<const N: usize>(now: Instant) -> Engine<N> {
     let arp_options = ArpConfig::new(
         Some(Duration::from_secs(600)),
         Some(Duration::from_secs(1)),
@@ -62,7 +62,7 @@ pub fn new_alice(now: Instant) -> Engine {
     Engine::new(rt, scheduler, clock).unwrap()
 }
 
-pub fn new_bob(now: Instant) -> Engine {
+pub fn new_bob<const N: usize>(now: Instant) -> Engine<N> {
     let arp_options = ArpConfig::new(
         Some(Duration::from_secs(600)),
         Some(Duration::from_secs(1)),
@@ -78,7 +78,7 @@ pub fn new_bob(now: Instant) -> Engine {
     Engine::new(rt, scheduler, clock).unwrap()
 }
 
-pub fn new_alice2(now: Instant) -> Engine {
+pub fn new_alice2<const N: usize>(now: Instant) -> Engine<N> {
     let mut arp: HashMap<Ipv4Addr, MacAddress> = HashMap::<Ipv4Addr, MacAddress>::new();
     arp.insert(ALICE_IPV4, ALICE_MAC);
     arp.insert(BOB_IPV4, BOB_MAC);
@@ -97,7 +97,7 @@ pub fn new_alice2(now: Instant) -> Engine {
     Engine::new(rt, scheduler, clock).unwrap()
 }
 
-pub fn new_bob2(now: Instant) -> Engine {
+pub fn new_bob2<const N: usize>(now: Instant) -> Engine<N> {
     let mut arp: HashMap<Ipv4Addr, MacAddress> = HashMap::<Ipv4Addr, MacAddress>::new();
     arp.insert(BOB_IPV4, BOB_MAC);
     arp.insert(ALICE_IPV4, ALICE_MAC);
@@ -116,7 +116,7 @@ pub fn new_bob2(now: Instant) -> Engine {
     Engine::new(rt, scheduler, clock).unwrap()
 }
 
-pub fn new_carrie(now: Instant) -> Engine {
+pub fn new_carrie<const N: usize>(now: Instant) -> Engine<N> {
     let arp_options = ArpConfig::new(
         Some(Duration::from_secs(600)),
         Some(Duration::from_secs(1)),

--- a/src/rust/inetstack/test_helpers/runtime.rs
+++ b/src/rust/inetstack/test_helpers/runtime.rs
@@ -11,7 +11,6 @@ use crate::{
                 TcpConfig,
                 UdpConfig,
             },
-            consts::RECEIVE_BATCH_SIZE,
             types::MacAddress,
             NetworkRuntime,
             PacketBuf,
@@ -114,7 +113,7 @@ impl TestRuntime {
 // Trait Implementations
 //==============================================================================
 
-impl NetworkRuntime for TestRuntime {
+impl<const N: usize> NetworkRuntime<N> for TestRuntime {
     fn transmit(&self, pkt: Box<dyn PacketBuf>) {
         let header_size: usize = pkt.header_size();
         let body_size: usize = pkt.body_size();
@@ -131,7 +130,7 @@ impl NetworkRuntime for TestRuntime {
         self.inner.borrow_mut().outgoing.push_back(buf);
     }
 
-    fn receive(&self) -> ArrayVec<DemiBuffer, RECEIVE_BATCH_SIZE> {
+    fn receive(&self) -> ArrayVec<DemiBuffer, N> {
         let mut out = ArrayVec::new();
         if let Some(buf) = self.inner.borrow_mut().incoming.pop_front() {
             out.push(buf);

--- a/src/rust/runtime/network/mod.rs
+++ b/src/rust/runtime/network/mod.rs
@@ -5,10 +5,7 @@
 // Imports
 //==============================================================================
 
-use crate::runtime::{
-    memory::DemiBuffer,
-    network::consts::RECEIVE_BATCH_SIZE,
-};
+use crate::runtime::memory::DemiBuffer;
 use ::arrayvec::ArrayVec;
 
 //==============================================================================
@@ -36,10 +33,10 @@ pub trait PacketBuf {
 }
 
 /// Network Runtime
-pub trait NetworkRuntime {
+pub trait NetworkRuntime<const N: usize> {
     /// Transmits a single [PacketBuf].
     fn transmit(&self, pkt: Box<dyn PacketBuf>);
 
     /// Receives a batch of [DemiBuffer].
-    fn receive(&self) -> ArrayVec<DemiBuffer, RECEIVE_BATCH_SIZE>;
+    fn receive(&self) -> ArrayVec<DemiBuffer, N>;
 }

--- a/tests/rust/common/libos.rs
+++ b/tests/rust/common/libos.rs
@@ -27,7 +27,10 @@ use crossbeam_channel::{
     Receiver,
     Sender,
 };
-use demikernel::scheduler::scheduler::Scheduler;
+use demikernel::{
+    runtime::network::consts::RECEIVE_BATCH_SIZE,
+    scheduler::scheduler::Scheduler,
+};
 use std::{
     collections::HashMap,
     net::Ipv4Addr,
@@ -56,7 +59,7 @@ impl DummyLibOS {
         tx: Sender<DemiBuffer>,
         rx: Receiver<DemiBuffer>,
         arp: HashMap<Ipv4Addr, MacAddress>,
-    ) -> Result<InetStack, Fail> {
+    ) -> Result<InetStack<RECEIVE_BATCH_SIZE>, Fail> {
         let now: Instant = Instant::now();
         let rt: Rc<DummyRuntime> = Rc::new(DummyRuntime::new(now, rx, tx));
         let arp_options: ArpConfig = ArpConfig::new(

--- a/tests/rust/common/runtime.rs
+++ b/tests/rust/common/runtime.rs
@@ -11,7 +11,6 @@ use ::demikernel::{
     runtime::{
         memory::DemiBuffer,
         network::{
-            consts::RECEIVE_BATCH_SIZE,
             NetworkRuntime,
             PacketBuf,
         },
@@ -76,7 +75,7 @@ impl DummyRuntime {
 //==============================================================================
 
 /// Network Runtime Trait Implementation for Dummy Runtime
-impl NetworkRuntime for DummyRuntime {
+impl<const N: usize> NetworkRuntime<N> for DummyRuntime {
     fn transmit(&self, pkt: Box<dyn PacketBuf>) {
         let header_size: usize = pkt.header_size();
         let body_size: usize = pkt.body_size();
@@ -93,7 +92,7 @@ impl NetworkRuntime for DummyRuntime {
         self.inner.borrow_mut().outgoing.try_send(buf).unwrap();
     }
 
-    fn receive(&self) -> ArrayVec<DemiBuffer, RECEIVE_BATCH_SIZE> {
+    fn receive(&self) -> ArrayVec<DemiBuffer, N> {
         let mut out = ArrayVec::new();
         if let Some(buf) = self.inner.borrow_mut().incoming.try_recv().ok() {
             out.push(buf);


### PR DESCRIPTION
## Description

This PR closes https://github.com/demikernel/demikernel/issues/177

## Summary of Changes

- Introduced constant parameter to `NetworkRuntime` trait.
- Changed code base accordingly.

Note that making the network runtime generic over a constant for the `RECEIVE_BATCH_SIZE` enables us to effectively have each LibOS having its own value for that constant, while enabling multiple LibOses to coexist.

This commit addresses
https://github.com/demikernel/demikernel/issues/177