### PR TITLE
[pdpix] Fix Network Types to be Compatible With Each Other

### DIFF
--- a/src/rust/catcollar/futures/connect.rs
+++ b/src/rust/catcollar/futures/connect.rs
@@ -30,7 +30,7 @@ pub struct ConnectFuture {
     // Underlying file descriptor.
     fd: RawFd,
     /// Connect address.
-    sockaddr: libc::sockaddr_in,
+    saddr: libc::sockaddr,
 }
 
 //==============================================================================
@@ -43,7 +43,7 @@ impl ConnectFuture {
     pub fn new(fd: RawFd, addr: SocketAddrV4) -> Self {
         Self {
             fd,
-            sockaddr: linux::socketaddrv4_to_sockaddr_in(&addr),
+            saddr: linux::socketaddrv4_to_sockaddr(&addr),
         }
     }
 }
@@ -62,13 +62,13 @@ impl Future for ConnectFuture {
         match unsafe {
             libc::connect(
                 self_.fd,
-                (&self_.sockaddr as *const libc::sockaddr_in) as *const libc::sockaddr,
+                &self_.saddr as *const libc::sockaddr,
                 mem::size_of::<libc::sockaddr_in>() as libc::socklen_t,
             )
         } {
             // Operation completed.
             stats if stats == 0 => {
-                trace!("connection established ({:?})", self_.sockaddr);
+                trace!("connection established ({:?})", self_.saddr);
                 Poll::Ready(Ok(()))
             },
 

--- a/src/rust/catcollar/futures/connect.rs
+++ b/src/rust/catcollar/futures/connect.rs
@@ -63,7 +63,7 @@ impl Future for ConnectFuture {
             libc::connect(
                 self_.fd,
                 (&self_.sockaddr as *const libc::sockaddr_in) as *const libc::sockaddr,
-                mem::size_of_val(&self_.sockaddr) as u32,
+                mem::size_of::<libc::sockaddr_in>() as libc::socklen_t,
             )
         } {
             // Operation completed.

--- a/src/rust/catcollar/iouring.rs
+++ b/src/rust/catcollar/iouring.rs
@@ -118,7 +118,8 @@ impl IoUring {
         let len: usize = buf.len();
         let data_ptr: *const u8 = buf.as_ptr();
         let saddr: libc::sockaddr_in = linux::socketaddrv4_to_sockaddr_in(&addr);
-        let (sockaddr, addrlen): (&libc::sockaddr_in, socklen_t) = (&saddr, mem::size_of_val(&saddr) as u32);
+        let (sockaddr, addrlen): (&libc::sockaddr_in, socklen_t) =
+            (&saddr, mem::size_of::<libc::sockaddr_in>() as libc::socklen_t);
         let sockaddr_ptr: *const libc::sockaddr_in = sockaddr as *const libc::sockaddr_in;
         let io_uring: &mut liburing::io_uring = &mut self.io_uring;
 

--- a/src/rust/catcollar/iouring.rs
+++ b/src/rust/catcollar/iouring.rs
@@ -117,10 +117,10 @@ impl IoUring {
     ) -> Result<*mut liburing::msghdr, Fail> {
         let len: usize = buf.len();
         let data_ptr: *const u8 = buf.as_ptr();
-        let saddr: libc::sockaddr_in = linux::socketaddrv4_to_sockaddr_in(&addr);
-        let (sockaddr, addrlen): (&libc::sockaddr_in, socklen_t) =
+        let saddr: libc::sockaddr = linux::socketaddrv4_to_sockaddr(&addr);
+        let (saddr_ref, addrlen): (&libc::sockaddr, socklen_t) =
             (&saddr, mem::size_of::<libc::sockaddr_in>() as libc::socklen_t);
-        let sockaddr_ptr: *const libc::sockaddr_in = sockaddr as *const libc::sockaddr_in;
+        let saddr_ptr: *const libc::sockaddr = saddr_ref as *const libc::sockaddr;
         let io_uring: &mut liburing::io_uring = &mut self.io_uring;
 
         unsafe {
@@ -139,7 +139,7 @@ impl IoUring {
             });
             let iov_ptr: *mut liburing::iovec = Box::into_raw(iov);
             let msg: Box<liburing::msghdr> = Box::new(liburing::msghdr {
-                msg_name: sockaddr_ptr as *mut c_void,
+                msg_name: saddr_ptr as *mut c_void,
                 msg_namelen: addrlen as u32,
                 msg_iov: iov_ptr,
                 msg_iovlen: 1,

--- a/src/rust/catcollar/mod.rs
+++ b/src/rust/catcollar/mod.rs
@@ -185,11 +185,11 @@ impl CatcollarLibOS {
         let fd: RawFd = queue.get_fd().expect("queue should have a file descriptor");
 
         // Bind underlying socket.
-        let sockaddr: libc::sockaddr_in = linux::socketaddrv4_to_sockaddr_in(&local);
+        let saddr: libc::sockaddr = linux::socketaddrv4_to_sockaddr(&local);
         match unsafe {
             libc::bind(
                 fd,
-                (&sockaddr as *const libc::sockaddr_in) as *const libc::sockaddr,
+                &saddr as *const libc::sockaddr,
                 mem::size_of::<libc::sockaddr_in>() as libc::socklen_t,
             )
         } {
@@ -540,10 +540,7 @@ fn pack_result(rt: &IoUringRuntime, result: OperationResult, qd: QDesc, qt: u64)
             qr_value: unsafe { mem::zeroed() },
         },
         OperationResult::Accept((new_qd, addr)) => {
-            let saddr: libc::sockaddr = {
-                let sin: libc::sockaddr_in = linux::socketaddrv4_to_sockaddr_in(&addr);
-                unsafe { mem::transmute::<libc::sockaddr_in, libc::sockaddr>(sin) }
-            };
+            let saddr: libc::sockaddr = linux::socketaddrv4_to_sockaddr(&addr);
             let qr_value: demi_qr_value_t = demi_qr_value_t {
                 ares: demi_accept_result_t {
                     qd: new_qd.into(),
@@ -567,9 +564,8 @@ fn pack_result(rt: &IoUringRuntime, result: OperationResult, qd: QDesc, qt: u64)
         },
         OperationResult::Pop(addr, bytes) => match rt.into_sgarray(bytes) {
             Ok(mut sga) => {
-                if let Some(endpoint) = addr {
-                    let saddr: libc::sockaddr_in = linux::socketaddrv4_to_sockaddr_in(&endpoint);
-                    sga.sga_addr = unsafe { mem::transmute::<libc::sockaddr_in, libc::sockaddr>(saddr) };
+                if let Some(addr) = addr {
+                    sga.sga_addr = linux::socketaddrv4_to_sockaddr(&addr);
                 }
                 let qr_value: demi_qr_value_t = demi_qr_value_t { sga };
                 demi_qresult_t {

--- a/src/rust/catcollar/mod.rs
+++ b/src/rust/catcollar/mod.rs
@@ -190,7 +190,7 @@ impl CatcollarLibOS {
             libc::bind(
                 fd,
                 (&sockaddr as *const libc::sockaddr_in) as *const libc::sockaddr,
-                mem::size_of_val(&sockaddr) as u32,
+                mem::size_of::<libc::sockaddr_in>() as libc::socklen_t,
             )
         } {
             stats if stats == 0 => {

--- a/src/rust/catcollar/runtime/mod.rs
+++ b/src/rust/catcollar/runtime/mod.rs
@@ -27,7 +27,6 @@ use ::std::{
         HashMap,
         HashSet,
     },
-    mem,
     net::SocketAddrV4,
     os::unix::prelude::RawFd,
     rc::Rc,
@@ -120,9 +119,7 @@ impl IoUringRuntime {
                             None
                         } else {
                             let saddr: *const libc::sockaddr = msg.msg_name as *const libc::sockaddr;
-                            let sin: libc::sockaddr_in =
-                                unsafe { *mem::transmute::<*const libc::sockaddr, *const libc::sockaddr_in>(saddr) };
-                            Some(linux::sockaddr_in_to_socketaddrv4(&sin))
+                            Some(linux::sockaddr_to_socketaddrv4(unsafe { &*saddr }))
                         };
 
                         // This is not the request that we are waiting for.

--- a/src/rust/catloop/mod.rs
+++ b/src/rust/catloop/mod.rs
@@ -636,10 +636,7 @@ fn pack_result(result: OperationResult, qd: QDesc, qt: u64) -> demi_qresult_t {
             qr_value: unsafe { mem::zeroed() },
         },
         OperationResult::Accept(new_qd, addr) => {
-            let saddr: libc::sockaddr = {
-                let sin: libc::sockaddr_in = linux::socketaddrv4_to_sockaddr_in(&addr);
-                unsafe { mem::transmute::<libc::sockaddr_in, libc::sockaddr>(sin) }
-            };
+            let saddr: libc::sockaddr = linux::socketaddrv4_to_sockaddr(&addr);
             let qr_value: demi_qr_value_t = demi_qr_value_t {
                 ares: demi_accept_result_t {
                     qd: new_qd.into(),

--- a/src/rust/catnap/coroutines/connect.rs
+++ b/src/rust/catnap/coroutines/connect.rs
@@ -19,11 +19,11 @@ use ::std::{
 /// This function polls connect on a socket file descriptor until the connection is established (or returns an error).
 pub async fn connect_coroutine(fd: RawFd, addr: SocketAddrV4, yielder: Yielder) -> Result<(), Fail> {
     loop {
-        let sockaddr: libc::sockaddr_in = linux::socketaddrv4_to_sockaddr_in(&addr);
+        let saddr: libc::sockaddr = linux::socketaddrv4_to_sockaddr(&addr);
         match unsafe {
             libc::connect(
                 fd,
-                (&sockaddr as *const libc::sockaddr_in) as *const libc::sockaddr,
+                &saddr as *const libc::sockaddr,
                 mem::size_of::<libc::sockaddr_in>() as libc::socklen_t,
             )
         } {

--- a/src/rust/catnap/coroutines/connect.rs
+++ b/src/rust/catnap/coroutines/connect.rs
@@ -24,7 +24,7 @@ pub async fn connect_coroutine(fd: RawFd, addr: SocketAddrV4, yielder: Yielder) 
             libc::connect(
                 fd,
                 (&sockaddr as *const libc::sockaddr_in) as *const libc::sockaddr,
-                mem::size_of_val(&sockaddr) as u32,
+                mem::size_of::<libc::sockaddr_in>() as libc::socklen_t,
             )
         } {
             // Operation completed.

--- a/src/rust/catnap/coroutines/pop.rs
+++ b/src/rust/catnap/coroutines/pop.rs
@@ -32,7 +32,7 @@ pub async fn pop_coroutine(
 ) -> Result<(Option<SocketAddrV4>, DemiBuffer), Fail> {
     let size: usize = size.unwrap_or(limits::RECVBUF_SIZE_MAX);
     let mut buf: DemiBuffer = DemiBuffer::new(size as u16);
-    let mut sockaddr: libc::sockaddr_in = unsafe { mem::zeroed() };
+    let mut saddr: libc::sockaddr = unsafe { mem::zeroed() };
     let mut addrlen: libc::socklen_t = mem::size_of::<libc::sockaddr_in>() as u32;
 
     // Check that we allocated a DemiBuffer that is big enough.
@@ -46,7 +46,7 @@ pub async fn pop_coroutine(
                 (buf.as_mut_ptr() as *mut u8) as *mut libc::c_void,
                 size,
                 libc::MSG_DONTWAIT,
-                (&mut sockaddr as *mut libc::sockaddr_in) as *mut libc::sockaddr,
+                &mut saddr as *mut libc::sockaddr,
                 &mut addrlen as *mut u32,
             )
         } {
@@ -54,7 +54,7 @@ pub async fn pop_coroutine(
             nbytes if nbytes >= 0 => {
                 trace!("data received ({:?}/{:?} bytes)", nbytes, limits::RECVBUF_SIZE_MAX);
                 buf.trim(size - nbytes as usize)?;
-                let addr: SocketAddrV4 = linux::sockaddr_in_to_socketaddrv4(&sockaddr);
+                let addr: SocketAddrV4 = linux::sockaddr_to_socketaddrv4(&saddr);
                 return Ok((Some(addr), buf.clone()));
             },
 

--- a/src/rust/catnap/coroutines/push.rs
+++ b/src/rust/catnap/coroutines/push.rs
@@ -27,15 +27,16 @@ pub async fn push_coroutine(
     addr: Option<SocketAddrV4>,
     yielder: Yielder,
 ) -> Result<(), Fail> {
-    let dest_addr: Option<libc::sockaddr_in> = if let Some(addr_) = addr.as_ref() {
-        Some(linux::socketaddrv4_to_sockaddr_in(addr_))
+    let saddr: Option<libc::sockaddr> = if let Some(addr) = addr.as_ref() {
+        Some(linux::socketaddrv4_to_sockaddr(addr))
     } else {
         None
     };
 
-    let (sockaddr_ptr, sockaddr_len) = if let Some(sockaddr) = dest_addr.as_ref() {
+    // Note that we use references here, so as we don't end up constructing a dangling pointer.
+    let (saddr_ptr, sockaddr_len) = if let Some(saddr_ref) = saddr.as_ref() {
         (
-            (sockaddr as *const libc::sockaddr_in) as *const libc::sockaddr,
+            saddr_ref as *const libc::sockaddr,
             mem::size_of::<libc::sockaddr_in>() as libc::socklen_t,
         )
     } else {
@@ -48,7 +49,7 @@ pub async fn push_coroutine(
                 (buf.as_ptr() as *const u8) as *const libc::c_void,
                 buf.len(),
                 libc::MSG_DONTWAIT,
-                sockaddr_ptr,
+                saddr_ptr,
                 sockaddr_len,
             )
         } {

--- a/src/rust/catnap/coroutines/push.rs
+++ b/src/rust/catnap/coroutines/push.rs
@@ -36,7 +36,7 @@ pub async fn push_coroutine(
     let (sockaddr_ptr, sockaddr_len) = if let Some(sockaddr) = dest_addr.as_ref() {
         (
             (sockaddr as *const libc::sockaddr_in) as *const libc::sockaddr,
-            mem::size_of_val(sockaddr) as u32,
+            mem::size_of::<libc::sockaddr_in>() as libc::socklen_t,
         )
     } else {
         (ptr::null(), 0)

--- a/src/rust/catnap/mod.rs
+++ b/src/rust/catnap/mod.rs
@@ -214,11 +214,11 @@ impl CatnapLibOS {
         };
 
         // Bind underlying socket.
-        let sockaddr: libc::sockaddr_in = linux::socketaddrv4_to_sockaddr_in(&local);
+        let saddr: libc::sockaddr = linux::socketaddrv4_to_sockaddr(&local);
         match unsafe {
             libc::bind(
                 fd,
-                (&sockaddr as *const libc::sockaddr_in) as *const libc::sockaddr,
+                &saddr as *const libc::sockaddr,
                 mem::size_of::<libc::sockaddr_in>() as libc::socklen_t,
             )
         } {
@@ -773,10 +773,7 @@ fn pack_result(rt: &PosixRuntime, result: OperationResult, qd: QDesc, qt: u64) -
             qr_value: unsafe { mem::zeroed() },
         },
         OperationResult::Accept((new_qd, addr)) => {
-            let saddr: libc::sockaddr = {
-                let sin: libc::sockaddr_in = linux::socketaddrv4_to_sockaddr_in(&addr);
-                unsafe { mem::transmute::<libc::sockaddr_in, libc::sockaddr>(sin) }
-            };
+            let saddr: libc::sockaddr = linux::socketaddrv4_to_sockaddr(&addr);
             let qr_value: demi_qr_value_t = demi_qr_value_t {
                 ares: demi_accept_result_t {
                     qd: new_qd.into(),
@@ -800,9 +797,8 @@ fn pack_result(rt: &PosixRuntime, result: OperationResult, qd: QDesc, qt: u64) -
         },
         OperationResult::Pop(addr, bytes) => match rt.into_sgarray(bytes) {
             Ok(mut sga) => {
-                if let Some(endpoint) = addr {
-                    let saddr: libc::sockaddr_in = linux::socketaddrv4_to_sockaddr_in(&endpoint);
-                    sga.sga_addr = unsafe { mem::transmute::<libc::sockaddr_in, libc::sockaddr>(saddr) };
+                if let Some(addr) = addr {
+                    sga.sga_addr = linux::socketaddrv4_to_sockaddr(&addr);
                 }
                 let qr_value: demi_qr_value_t = demi_qr_value_t { sga };
                 demi_qresult_t {

--- a/src/rust/catnap/mod.rs
+++ b/src/rust/catnap/mod.rs
@@ -219,7 +219,7 @@ impl CatnapLibOS {
             libc::bind(
                 fd,
                 (&sockaddr as *const libc::sockaddr_in) as *const libc::sockaddr,
-                mem::size_of_val(&sockaddr) as u32,
+                mem::size_of::<libc::sockaddr_in>() as libc::socklen_t,
             )
         } {
             stats if stats == 0 => {

--- a/src/rust/catpowder/interop.rs
+++ b/src/rust/catpowder/interop.rs
@@ -31,10 +31,7 @@ pub fn pack_result(rt: Rc<LinuxRuntime>, result: OperationResult, qd: QDesc, qt:
             qr_value: unsafe { mem::zeroed() },
         },
         OperationResult::Accept((new_qd, addr)) => {
-            let saddr: libc::sockaddr = {
-                let sin: libc::sockaddr_in = linux::socketaddrv4_to_sockaddr_in(&addr);
-                unsafe { mem::transmute::<libc::sockaddr_in, libc::sockaddr>(sin) }
-            };
+            let saddr: libc::sockaddr = linux::socketaddrv4_to_sockaddr(&addr);
             let qr_value: demi_qr_value_t = demi_qr_value_t {
                 ares: demi_accept_result_t {
                     qd: new_qd.into(),
@@ -58,9 +55,8 @@ pub fn pack_result(rt: Rc<LinuxRuntime>, result: OperationResult, qd: QDesc, qt:
         },
         OperationResult::Pop(addr, bytes) => match rt.into_sgarray(bytes) {
             Ok(mut sga) => {
-                if let Some(endpoint) = addr {
-                    let saddr: libc::sockaddr_in = linux::socketaddrv4_to_sockaddr_in(&endpoint);
-                    sga.sga_addr = unsafe { mem::transmute::<libc::sockaddr_in, libc::sockaddr>(saddr) };
+                if let Some(addr) = addr {
+                    sga.sga_addr = linux::socketaddrv4_to_sockaddr(&addr)
                 }
                 let qr_value = demi_qr_value_t { sga };
                 demi_qresult_t {

--- a/src/rust/pal/linux/mod.rs
+++ b/src/rust/pal/linux/mod.rs
@@ -68,7 +68,7 @@ pub unsafe fn set_nonblock(fd: RawFd) -> i32 {
 }
 
 /// Converts a [std::net::SocketAddrV4] to a [libc::sockaddr_in].
-pub fn socketaddrv4_to_sockaddr_in(addr: &SocketAddrV4) -> libc::sockaddr_in {
+fn socketaddrv4_to_sockaddr_in(addr: &SocketAddrV4) -> libc::sockaddr_in {
     libc::sockaddr_in {
         sin_family: libc::AF_INET as libc::sa_family_t,
         sin_port: u16::to_be(addr.port()),
@@ -85,9 +85,21 @@ pub fn socketaddrv4_to_sockaddr_in(addr: &SocketAddrV4) -> libc::sockaddr_in {
 }
 
 /// Converts a [std::net::SocketAddrV4] to a [libc::sockaddr_in].
-pub fn sockaddr_in_to_socketaddrv4(sin: &libc::sockaddr_in) -> SocketAddrV4 {
+fn sockaddr_in_to_socketaddrv4(sin: &libc::sockaddr_in) -> SocketAddrV4 {
     SocketAddrV4::new(
         Ipv4Addr::from(u32::from_be(sin.sin_addr.s_addr)),
         u16::from_be(sin.sin_port),
     )
+}
+
+/// Converts a [std::net::SocketAddrV4] to a [libc::sockaddr].
+pub fn socketaddrv4_to_sockaddr(addr: &SocketAddrV4) -> libc::sockaddr {
+    let sin: libc::sockaddr_in = socketaddrv4_to_sockaddr_in(addr);
+    unsafe { mem::transmute::<libc::sockaddr_in, libc::sockaddr>(sin) }
+}
+
+/// Converts a [libc::sockaddr] to a [std::net::SocketAddrV4].
+pub fn sockaddr_to_socketaddrv4(saddr: &libc::sockaddr) -> SocketAddrV4 {
+    let sin: libc::sockaddr_in = unsafe { mem::transmute::<libc::sockaddr, libc::sockaddr_in>(saddr.to_owned()) };
+    sockaddr_in_to_socketaddrv4(&sin)
 }


### PR DESCRIPTION
## Description

This PR closes https://github.com/demikernel/demikernel/issues/134.

# Summary of Changes

- Introduced utility function `socketaddrv4_to_sockaddr()`
- Introduced utility function `sockaddr_to_socketaddrv4()`
- Changed concerned code to only perform conversions from/to `SocketAddrV4` and `libc::sockaddr`