### PR TITLE
[Runtime] Rename scheduler handle to task handle and other things to more useful things

### DIFF
--- a/src/rust/catloop/futures/accept.rs
+++ b/src/rust/catloop/futures/accept.rs
@@ -19,7 +19,7 @@ use crate::{
             demi_qresult_t,
         },
     },
-    scheduler::SchedulerHandle,
+    scheduler::TaskHandle,
     QToken,
 };
 use ::std::{
@@ -144,7 +144,7 @@ impl Future for AcceptFuture {
 //   - The completed I/O queue operation associated to the queue token qt
 //   concerns a pop() operation that has completed.
 //   - The payload received from that pop() operation is a valid and legit MAGIC_CONNECT message.
-fn check_connect_request(catmem: &Rc<RefCell<CatmemLibOS>>, handle: SchedulerHandle, qt: QToken) -> Result<(), Fail> {
+fn check_connect_request(catmem: &Rc<RefCell<CatmemLibOS>>, handle: TaskHandle, qt: QToken) -> Result<(), Fail> {
     // Parse and check request.
     let passed: bool = {
         let qr: demi_qresult_t = catmem.borrow_mut().pack_result(handle, qt)?;

--- a/src/rust/catnip/mod.rs
+++ b/src/rust/catnip/mod.rs
@@ -35,7 +35,7 @@ use crate::{
     },
     scheduler::{
         Scheduler,
-        SchedulerHandle,
+        TaskHandle,
     },
 };
 use ::std::{
@@ -117,11 +117,11 @@ impl CatnipLibOS {
                     return Err(Fail::new(libc::EINVAL, "zero-length buffer"));
                 }
                 let future = self.do_push(qd, buf)?;
-                let handle: SchedulerHandle = match self.scheduler.insert(future) {
+                let handle: TaskHandle = match self.scheduler.insert(future) {
                     Some(handle) => handle,
                     None => return Err(Fail::new(libc::EAGAIN, "cannot schedule co-routine")),
                 };
-                let qt: QToken = handle.into_raw().into();
+                let qt: QToken = handle.get_task_id().into();
                 Ok(qt)
             },
             Err(e) => Err(e),
@@ -138,25 +138,25 @@ impl CatnipLibOS {
                     return Err(Fail::new(libc::EINVAL, "zero-length buffer"));
                 }
                 let future = self.do_pushto(qd, buf, to)?;
-                let handle: SchedulerHandle = match self.scheduler.insert(future) {
+                let handle: TaskHandle = match self.scheduler.insert(future) {
                     Some(handle) => handle,
                     None => return Err(Fail::new(libc::EAGAIN, "cannot schedule co-routine")),
                 };
-                let qt: QToken = handle.into_raw().into();
+                let qt: QToken = handle.get_task_id().into();
                 Ok(qt)
             },
             Err(e) => Err(e),
         }
     }
 
-    pub fn schedule(&mut self, qt: QToken) -> Result<SchedulerHandle, Fail> {
-        match self.scheduler.from_raw_handle(qt.into()) {
+    pub fn schedule(&mut self, qt: QToken) -> Result<TaskHandle, Fail> {
+        match self.scheduler.from_task_id(qt.into()) {
             Some(handle) => Ok(handle),
             None => return Err(Fail::new(libc::EINVAL, "invalid queue token")),
         }
     }
 
-    pub fn pack_result(&mut self, handle: SchedulerHandle, qt: QToken) -> Result<demi_qresult_t, Fail> {
+    pub fn pack_result(&mut self, handle: TaskHandle, qt: QToken) -> Result<demi_qresult_t, Fail> {
         let (qd, r): (QDesc, OperationResult) = self.take_operation(handle);
         Ok(pack_result(self.rt.clone(), r, qd, qt.into()))
     }

--- a/src/rust/demikernel/libos/memory.rs
+++ b/src/rust/demikernel/libos/memory.rs
@@ -15,7 +15,7 @@ use crate::{
         QDesc,
         QToken,
     },
-    scheduler::SchedulerHandle,
+    scheduler::TaskHandle,
 };
 
 #[cfg(feature = "catmem-libos")]
@@ -109,7 +109,7 @@ impl MemoryLibOS {
 
     /// Waits for any operation in an I/O queue.
     #[allow(unreachable_patterns, unused_variables)]
-    pub fn schedule(&mut self, qt: QToken) -> Result<SchedulerHandle, Fail> {
+    pub fn schedule(&mut self, qt: QToken) -> Result<TaskHandle, Fail> {
         match self {
             #[cfg(feature = "catmem-libos")]
             MemoryLibOS::Catmem(libos) => libos.schedule(qt),
@@ -118,7 +118,7 @@ impl MemoryLibOS {
     }
 
     #[allow(unreachable_patterns, unused_variables)]
-    pub fn pack_result(&mut self, handle: SchedulerHandle, qt: QToken) -> Result<demi_qresult_t, Fail> {
+    pub fn pack_result(&mut self, handle: TaskHandle, qt: QToken) -> Result<demi_qresult_t, Fail> {
         match self {
             #[cfg(feature = "catmem-libos")]
             MemoryLibOS::Catmem(libos) => libos.pack_result(handle, qt),

--- a/src/rust/demikernel/libos/network.rs
+++ b/src/rust/demikernel/libos/network.rs
@@ -15,7 +15,7 @@ use crate::{
         QDesc,
         QToken,
     },
-    scheduler::SchedulerHandle,
+    scheduler::TaskHandle,
 };
 use ::std::net::SocketAddrV4;
 
@@ -276,7 +276,7 @@ impl NetworkLibOS {
     }
 
     /// Waits for any operation in an I/O queue.
-    pub fn schedule(&mut self, qt: QToken) -> Result<SchedulerHandle, Fail> {
+    pub fn schedule(&mut self, qt: QToken) -> Result<TaskHandle, Fail> {
         match self {
             #[cfg(feature = "catpowder-libos")]
             NetworkLibOS::Catpowder(libos) => libos.schedule(qt),
@@ -293,7 +293,7 @@ impl NetworkLibOS {
         }
     }
 
-    pub fn pack_result(&mut self, handle: SchedulerHandle, qt: QToken) -> Result<demi_qresult_t, Fail> {
+    pub fn pack_result(&mut self, handle: TaskHandle, qt: QToken) -> Result<demi_qresult_t, Fail> {
         match self {
             #[cfg(feature = "catpowder-libos")]
             NetworkLibOS::Catpowder(libos) => libos.pack_result(handle, qt),

--- a/src/rust/inetstack/protocols/arp/peer.rs
+++ b/src/rust/inetstack/protocols/arp/peer.rs
@@ -30,7 +30,7 @@ use crate::{
     },
     scheduler::{
         Scheduler,
-        SchedulerHandle,
+        TaskHandle,
     },
 };
 use ::futures::{
@@ -80,7 +80,7 @@ pub struct ArpPeer<const N: usize> {
     /// The background co-routine cleans up the ARP cache from time to time.
     /// We annotate it as unused because the compiler believes that it is never called which is not the case.
     #[allow(unused)]
-    background: Rc<SchedulerHandle>,
+    background: Rc<TaskHandle>,
 }
 
 //==============================================================================
@@ -108,7 +108,7 @@ impl<const N: usize> ArpPeer<N> {
             String::from("Inetstack::arp::background"),
             Box::pin(Self::background(clock.clone(), cache.clone())),
         );
-        let handle: SchedulerHandle = match scheduler.insert(task) {
+        let handle: TaskHandle = match scheduler.insert(task) {
             Some(handle) => handle,
             None => {
                 return Err(Fail::new(

--- a/src/rust/inetstack/protocols/icmpv4/peer.rs
+++ b/src/rust/inetstack/protocols/icmpv4/peer.rs
@@ -35,7 +35,7 @@ use crate::{
     },
     scheduler::{
         Scheduler,
-        SchedulerHandle,
+        TaskHandle,
     },
 };
 use ::futures::{
@@ -134,7 +134,7 @@ pub struct Icmpv4Peer<const N: usize> {
     /// The background co-routine relies to incoming PING requests.
     /// We annotate it as unused because the compiler believes that it is never called which is not the case.
     #[allow(unused)]
-    background: SchedulerHandle,
+    background: TaskHandle,
 }
 
 impl<const N: usize> Icmpv4Peer<N> {
@@ -161,7 +161,7 @@ impl<const N: usize> Icmpv4Peer<N> {
                 rx,
             )),
         );
-        let handle: SchedulerHandle = match scheduler.insert(task) {
+        let handle: TaskHandle = match scheduler.insert(task) {
             Some(handle) => handle,
             None => {
                 let message: String = format!("failed to schedule background co-routine for ICMPv4 module");

--- a/src/rust/inetstack/protocols/tcp/active_open.rs
+++ b/src/rust/inetstack/protocols/tcp/active_open.rs
@@ -39,7 +39,7 @@ use crate::{
     },
     scheduler::{
         Scheduler,
-        SchedulerHandle,
+        TaskHandle,
     },
 };
 use ::libc::{
@@ -78,7 +78,7 @@ pub struct ActiveOpenSocket<const N: usize> {
     arp: ArpPeer<N>,
 
     #[allow(unused)]
-    handle: SchedulerHandle,
+    handle: TaskHandle,
     result: Rc<RefCell<ConnectResult<N>>>,
 }
 
@@ -114,7 +114,7 @@ impl<const N: usize> ActiveOpenSocket<N> {
         let task: BackgroundTask =
             BackgroundTask::new(String::from("Inetstack::TCP::activeopen::background"), Box::pin(future));
 
-        let handle: SchedulerHandle = match scheduler.insert(task) {
+        let handle: TaskHandle = match scheduler.insert(task) {
             Some(handle) => handle,
             None => panic!("failed to insert task in the scheduler"),
         };

--- a/src/rust/inetstack/protocols/tcp/established/mod.rs
+++ b/src/rust/inetstack/protocols/tcp/established/mod.rs
@@ -20,7 +20,7 @@ use crate::{
         queue::BackgroundTask,
         QDesc,
     },
-    scheduler::SchedulerHandle,
+    scheduler::TaskHandle,
 };
 use ::futures::channel::mpsc;
 use ::std::{
@@ -39,7 +39,7 @@ pub struct EstablishedSocket<const N: usize> {
     /// The background co-routines handles various tasks, such as retransmission and acknowledging.
     /// We annotate it as unused because the compiler believes that it is never called which is not the case.
     #[allow(unused)]
-    background: Rc<SchedulerHandle>,
+    background: Rc<TaskHandle>,
 }
 
 impl<const N: usize> EstablishedSocket<N> {
@@ -50,8 +50,8 @@ impl<const N: usize> EstablishedSocket<N> {
             String::from("Inetstack::TCP::established::background"),
             Box::pin(background::background(cb.clone(), qd, dead_socket_tx)),
         );
-        let handle: Rc<SchedulerHandle> = match cb.scheduler.insert(task) {
-            Some(handle) => Rc::<SchedulerHandle>::new(handle),
+        let handle: Rc<TaskHandle> = match cb.scheduler.insert(task) {
+            Some(handle) => Rc::<TaskHandle>::new(handle),
             None => panic!("failed to insert task in the scheduler"),
         };
         Self {

--- a/src/rust/inetstack/protocols/tcp/passive_open.rs
+++ b/src/rust/inetstack/protocols/tcp/passive_open.rs
@@ -40,7 +40,7 @@ use crate::{
     },
     scheduler::{
         Scheduler,
-        SchedulerHandle,
+        TaskHandle,
     },
 };
 use ::libc::{
@@ -75,7 +75,7 @@ struct InflightAccept {
     mss: usize,
 
     #[allow(unused)]
-    handle: SchedulerHandle,
+    handle: TaskHandle,
 }
 
 struct ReadySockets<const N: usize> {
@@ -276,7 +276,7 @@ impl<const N: usize> PassiveSocket<N> {
             String::from("Inetstack::TCP::passiveopen::background"),
             Box::pin(future),
         );
-        let handle: SchedulerHandle = match self.scheduler.insert(task) {
+        let handle: TaskHandle = match self.scheduler.insert(task) {
             Some(handle) => handle,
             None => panic!("failed to insert task in the scheduler"),
         };

--- a/src/rust/inetstack/protocols/udp/peer.rs
+++ b/src/rust/inetstack/protocols/udp/peer.rs
@@ -46,7 +46,7 @@ use crate::{
     },
     scheduler::{
         Scheduler,
-        SchedulerHandle,
+        TaskHandle,
     },
 };
 use ::rand::{
@@ -109,7 +109,7 @@ pub struct UdpPeer<const N: usize> {
     /// The background co-routine sends unset UDP packets.
     /// We annotate it as unused because the compiler believes that it is never called which is not the case.
     #[allow(unused)]
-    background: SchedulerHandle,
+    background: TaskHandle,
 }
 
 //======================================================================================================================
@@ -140,7 +140,7 @@ impl<const N: usize> UdpPeer<N> {
             send_queue.clone(),
         );
         let task: BackgroundTask = BackgroundTask::new(String::from("Inetstack::UDP::background"), Box::pin(future));
-        let handle: SchedulerHandle = match scheduler.insert(task) {
+        let handle: TaskHandle = match scheduler.insert(task) {
             Some(handle) => handle,
             None => {
                 return Err(Fail::new(

--- a/src/rust/scheduler/mod.rs
+++ b/src/rust/scheduler/mod.rs
@@ -44,7 +44,7 @@ pub mod yielder;
 
 pub use self::{
     handle::{
-        SchedulerHandle,
+        TaskHandle,
         YielderHandle,
     },
     scheduler::Scheduler,


### PR DESCRIPTION
This PR closes #174. It renames the following variables to be more meaningful:
* SchedulerHandle -> TaskHandle
* id -> task_id
* offset -> index