### PR TITLE
[catloop] Warn msg correction

### DIFF
--- a/src/rust/catloop/mod.rs
+++ b/src/rust/catloop/mod.rs
@@ -370,7 +370,7 @@ impl CatloopLibOS {
                     if Into::<u64>::into(qt) >= Self::QTOKEN_SHIFT {
                         // This queue token may colide with a queue token in the Catmem LibOS. Warn and keep going.
                         let message: String = format!("too many pending operations in Catloop");
-                        warn!("accept(): {}", &message);
+                        warn!("connect(): {}", &message);
                     }
 
                     Ok(qt)


### PR DESCRIPTION
The message was misleading us to think that the client was invoking `accept()` in the logs.