### PR TITLE
[cleanup] Remove unnecessary code

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@ Contributing
 
 Everyone is welcome to contribute to this project.
 
-Bellow, you find some guidelines to help you on this.
+Here are some guidelines to help you.
 
 Special Branches
 -----------------

--- a/man/demi_init.md
+++ b/man/demi_init.md
@@ -24,7 +24,7 @@ The array of argument strings provides Demikernel with various information that 
 instance, these arguments shall state which LibOSes should be initialized, and whether or not runtime features shall be
 turned on.
 
-All arguments supported by Demikernel are listed in the table bellow. Arguments that are not listed therein are ignored.
+All arguments supported by Demikernel are listed in the table below. Arguments that are not listed therein are ignored.
 
 | ID      | Argument      | Description                       | Supported OS |
 | ------- | ------------- | --------------------------------- | ------------ |

--- a/src/rust/catloop/duplex_pipe.rs
+++ b/src/rust/catloop/duplex_pipe.rs
@@ -57,7 +57,7 @@ impl DuplexPipe {
 
     /// Opens a duplex pipe.
     pub fn open_duplex_pipe(catmem: Rc<RefCell<CatmemLibOS>>, ipv4: &Ipv4Addr, port: u16) -> Result<Self, Fail> {
-        // Note: the rx and tx are intentionally flipped in the formatting string bellow.
+        // Note: the rx and tx are intentionally flipped in the formatting string below.
         let rx: QDesc = catmem.borrow_mut().open_pipe(&format!("{}:{}:tx", ipv4, port))?;
         let tx: QDesc = catmem.borrow_mut().open_pipe(&format!("{}:{}:rx", ipv4, port))?;
         Ok(Self { catmem, rx, tx })

--- a/src/rust/catnapw/futures/accept.rs
+++ b/src/rust/catnapw/futures/accept.rs
@@ -84,7 +84,7 @@ impl Future for AcceptFuture {
                     Ok(_) => {},
                     Err(_) => warn!("cannot set NONBLOCK option"),
                 };
-                // It is ok to have the expect() statement bellow because if
+                // It is ok to have the expect() statement below because if
                 // this is not a SocketAddrV4 something really bad happen.
                 let addr: SocketAddrV4 = saddr.as_socket_ipv4().expect("not a SocketAddrV4");
                 Poll::Ready(Ok((new_socket, addr)))

--- a/src/rust/catpowder/runtime/mod.rs
+++ b/src/rust/catpowder/runtime/mod.rs
@@ -66,7 +66,7 @@ impl LinuxRuntime {
             Some(false),
         );
 
-        // TODO: Make this constructor return a Result and drop expect() calls bellow.
+        // TODO: Make this constructor return a Result and drop expect() calls below.
         let mac_addr: [u8; 6] = [0; 6];
         let ifindex: i32 = Self::get_ifindex(ifname).expect("could not parse ifindex");
         let socket: RawSocket = RawSocket::new().expect("could not create raw socket");

--- a/src/rust/demikernel/bindings.rs
+++ b/src/rust/demikernel/bindings.rs
@@ -743,7 +743,7 @@ fn do_syscall<T>(f: impl FnOnce(&mut LibOS) -> T) -> Result<T, Fail> {
 
 /// Converts a [sockaddr] into a [SocketAddrV4].
 fn sockaddr_to_socketaddrv4(saddr: *const sockaddr) -> Result<SocketAddrV4, Fail> {
-    // TODO: Change the logic bellow and rename this function once we support V6 addresses as well.
+    // TODO: Change the logic below and rename this function once we support V6 addresses as well.
     let sin: SockAddrIn = unsafe { *mem::transmute::<*const sockaddr, *const SockAddrIn>(saddr) };
     if sin.sin_family != AF_INET {
         return Err(Fail::new(libc::ENOTSUP, "communication domain not supported"));

--- a/src/rust/inetstack/protocols/tcp/established/ctrlblk.rs
+++ b/src/rust/inetstack/protocols/tcp/established/ctrlblk.rs
@@ -401,7 +401,7 @@ impl<const N: usize> ControlBlock<N> {
 
     // This is the main TCP receive routine.
     //
-    pub fn receive(&self, mut header: &mut TcpHeader, mut data: DemiBuffer) {
+    pub fn receive(&self, header: &mut TcpHeader, mut data: DemiBuffer) {
         debug!(
             "{:?} Connection Receiving {} bytes + {:?}",
             self.state.get(),

--- a/src/rust/runtime/memory/demibuffer.rs
+++ b/src/rust/runtime/memory/demibuffer.rs
@@ -878,7 +878,7 @@ impl Drop for DemiBuffer {
                 while let Some(mut entry) = next_entry {
                     // Safety: This is safe, as `entry` is aligned, dereferenceable, and the MetaData struct it points
                     // to is initialized.
-                    let mut metadata: &mut MetaData = unsafe { entry.as_mut() };
+                    let metadata: &mut MetaData = unsafe { entry.as_mut() };
 
                     // Remember the next entry in the chain (if any) before we potentially free the current one.
                     next_entry = metadata.next;

--- a/src/rust/scheduler/scheduler.rs
+++ b/src/rust/scheduler/scheduler.rs
@@ -153,10 +153,6 @@ impl Scheduler {
             (&pages[pages_ix], subpage_ix)
         };
         page.initialize(subpage_ix);
-        let (page, _): (&WakerPageRef, usize) = {
-            let (pages_ix, subpage_ix) = self.get_page_indices(index);
-            (&pages[pages_ix], subpage_ix)
-        };
         Some(TaskHandle::new(task_id, index, page.clone()))
     }
 

--- a/src/rust/scheduler/scheduler.rs
+++ b/src/rust/scheduler/scheduler.rs
@@ -83,7 +83,7 @@ impl Scheduler {
     /// Given a handle to a task, remove it from the scheduler
     pub fn remove(&self, mut handle: TaskHandle) -> Box<dyn Task> {
         let pages: Ref<Vec<WakerPageRef>> = self.pages.borrow();
-        // TODO: review why it is safe to unwrap() here and change the statement bellow to an expect().
+        // TODO: review why it is safe to unwrap() here and change the statement below to an expect().
         let task_id: u64 = handle.take_task_id().unwrap();
         // We should not have a scheduler handle that refers to an invalid id, so unwrap and expect are safe here.
         let index: usize = self
@@ -97,7 +97,7 @@ impl Scheduler {
         };
         assert!(!page.was_dropped(subpage_ix));
         page.clear(subpage_ix);
-        // TODO: review why it is safe to unwrap() here and change the statement bellow to an expect().
+        // TODO: review why it is safe to unwrap() here and change the statement below to an expect().
         let task: Box<dyn Task> = self.tasks.borrow_mut().remove_unpin(index).unwrap();
         trace!(
             "remove(): name={:?}, id={:?}, index={:?}",


### PR DESCRIPTION
1. Removed unnecessary call to `get_page_indices()` in the scheduler.
2. Removed unnecessary `mut` keywords from: a) inetstack, b) runtime. These were causing compiler warnings.