### PR TITLE
[catloop] Connection Establishment Does Not Cancel Inflight Pop Correctly

### DIFF
--- a/src/rust/catloop/duplex_pipe.rs
+++ b/src/rust/catloop/duplex_pipe.rs
@@ -102,12 +102,4 @@ impl DuplexPipe {
 
         Ok(Some(handle))
     }
-
-    /// Drops a pending operation on a duplex pipe.
-    pub fn drop(catmem: &Rc<RefCell<CatmemLibOS>>, qt: QToken) -> Result<(), Fail> {
-        // Retrieve a handle to the concerned co-routine and execute its destructor.
-        let handle: TaskHandle = catmem.borrow_mut().schedule(qt)?;
-        drop(handle);
-        Ok(())
-    }
 }


### PR DESCRIPTION
## Description

This PR is a workaround for https://github.com/demikernel/demikernel/issues/769