### PR TITLE
[shim] Enhancement: Use demi_wait_any instead of demi_wait in shim ep…

### DIFF
--- a/shim/src/epoll.h
+++ b/shim/src/epoll.h
@@ -25,6 +25,7 @@ struct demi_event
 
 extern void epoll_table_init(void);
 extern int epoll_table_alloc(void);
+extern int epoll_get_ready(int epfd, demi_qtoken_t *qts, struct demi_event **evs);
 extern struct demi_event *epoll_get_event(int epfd, int i);
 extern struct demi_event *epoll_get_head(int epfd);
 extern struct demi_event *epoll_get_tail(int epfd);

--- a/shim/src/epoll/epoll.c
+++ b/shim/src/epoll/epoll.c
@@ -43,10 +43,31 @@ void epoll_table_init(void)
             epoll_table[i].events[j].used = j == 0? 1 : 0;
 
             epoll_table[i].events[j].id = j;
+            epoll_table[i].events[j].qt = -1;
             epoll_table[i].events[j].next_ev = INVALID_EV;
             epoll_table[i].events[j].prev_ev = INVALID_EV;
         }
     }
+}
+
+int epoll_get_ready(int epfd, demi_qtoken_t *qts, struct demi_event **evs)
+{
+    int nevents = 0;
+
+    struct demi_event *ev = epoll_get_head(epfd);
+    while (ev != NULL)
+    {
+        if ((ev->used) && (ev->qt != (demi_qtoken_t)-1))
+        {
+            qts[nevents] = ev->qt;
+            evs[nevents] = ev;
+            nevents++;
+        }
+
+        ev = epoll_get_next(epfd, ev);
+    }
+
+    return nevents;
 }
 
 struct demi_event *epoll_get_event(int epfd, int i)

--- a/shim/src/epoll/epoll_wait.c
+++ b/shim/src/epoll/epoll_wait.c
@@ -55,6 +55,7 @@ int __epoll_wait(int epfd, struct epoll_event *events, int maxevents, int timeou
 
     int nevents = epoll_get_ready(demikernel_epfd, qts, evs);
 
+    int nret = 0;
     if (nevents > 0)
     {
         int ret = __demi_wait_any(&qr, &ready_offset, qts, nevents, &abstime);
@@ -70,10 +71,10 @@ int __epoll_wait(int epfd, struct epoll_event *events, int maxevents, int timeou
                 case DEMI_OPC_ACCEPT:
                 {
                     // Fill in event.
-                    events[nevents].events = evs[ready_offset]->ev.events;
-                    events[nevents].data.fd = evs[ready_offset]->sockqd;
+                    events[nret].events = evs[ready_offset]->ev.events;
+                    events[nret].data.fd = evs[ready_offset]->sockqd;
                     evs[ready_offset]->qt = -1;
-                    nevents++;
+                    nret++;
 
                     // Store I/O queue operation result.
                     queue_man_set_accept_result(evs[ready_offset]->sockqd, evs[ready_offset]);
@@ -89,12 +90,12 @@ int __epoll_wait(int epfd, struct epoll_event *events, int maxevents, int timeou
                 {
 
                     // Fill in event.
-                    events[nevents].events = evs[ready_offset]->ev.events;
-                    events[nevents].data.fd = evs[ready_offset]->sockqd;
-                    events[nevents].data.ptr = evs[ready_offset]->ev.data.ptr;
-                    events[nevents].data.u32 = evs[ready_offset]->ev.data.u32;
+                    events[nret].events = evs[ready_offset]->ev.events;
+                    events[nret].data.fd = evs[ready_offset]->sockqd;
+                    events[nret].data.ptr = evs[ready_offset]->ev.data.ptr;
+                    events[nret].data.u32 = evs[ready_offset]->ev.data.u32;
                     evs[ready_offset]->qt = -1;
-                    nevents++;
+                    nret++;
 
                     // Store I/O queue operation result.
                     queue_man_set_pop_result(evs[ready_offset]->sockqd, evs[ready_offset]);
@@ -151,5 +152,5 @@ int __epoll_wait(int epfd, struct epoll_event *events, int maxevents, int timeou
             }
     }
 
-    return (nevents);
+    return (nret);
 }


### PR DESCRIPTION
Reducing the number of demi calls and background tasks run by using demi_wait_any instead of demi_wait.