### PR TITLE
[catnip] Remove header pool

### DIFF
--- a/src/rust/catnip/runtime/memory/config.rs
+++ b/src/rust/catnip/runtime/memory/config.rs
@@ -8,8 +8,6 @@
 use crate::catnip::runtime::memory::consts::{
     DEFAULT_BODY_POOL_SIZE,
     DEFAULT_CACHE_SIZE,
-    DEFAULT_HEADER_POOL_SIZE,
-    DEFAULT_INLINE_BODY_SIZE,
     DEFAULT_MAX_BODY_SIZE,
 };
 
@@ -20,14 +18,6 @@ use crate::catnip::runtime::memory::consts::{
 //// Memory Configuration Descriptor
 #[derive(Debug)]
 pub struct MemoryConfig {
-    /// What is the cutoff point for copying application buffers into reserved body space within a
-    /// header `mbuf`? Smaller values copy less but incur the fixed cost of chaining together
-    /// `mbuf`s earlier.
-    inline_body_size: usize,
-
-    /// How many buffers are within the header pool?
-    header_pool_size: usize,
-
     /// What is the maximum body size? This should effectively be the MSS + RTE_PKTMBUF_HEADROOM.
     max_body_size: usize,
 
@@ -44,24 +34,8 @@ pub struct MemoryConfig {
 
 /// Associate Functions for Memory Configuration Descriptors
 impl MemoryConfig {
-    pub fn new(
-        inline_body_size: Option<usize>,
-        header_pool_size: Option<usize>,
-        max_body_size: Option<usize>,
-        body_pool_size: Option<usize>,
-        cache_size: Option<usize>,
-    ) -> Self {
+    pub fn new(max_body_size: Option<usize>, body_pool_size: Option<usize>, cache_size: Option<usize>) -> Self {
         let mut config: Self = Self::default();
-
-        // Sets the inline body size config option.
-        if let Some(inline_body_size) = inline_body_size {
-            config.inline_body_size = inline_body_size;
-        }
-
-        // Sets the header pool size config option.
-        if let Some(header_pool_size) = header_pool_size {
-            config.header_pool_size = header_pool_size;
-        }
 
         // Sets the max body pool size config option.
         if let Some(max_body_size) = max_body_size {
@@ -79,16 +53,6 @@ impl MemoryConfig {
         }
 
         config
-    }
-
-    /// Returns the inline body size config stored in the target [MemoryConfig].
-    pub fn get_inline_body_size(&self) -> usize {
-        self.inline_body_size
-    }
-
-    /// Returns the header pool size config stored in the target [MemoryConfig].
-    pub fn get_header_pool_size(&self) -> usize {
-        self.header_pool_size
     }
 
     /// Returns the max body size config stored in the target [MemoryConfig].
@@ -115,8 +79,6 @@ impl MemoryConfig {
 impl Default for MemoryConfig {
     fn default() -> Self {
         Self {
-            inline_body_size: DEFAULT_INLINE_BODY_SIZE,
-            header_pool_size: DEFAULT_HEADER_POOL_SIZE,
             max_body_size: DEFAULT_MAX_BODY_SIZE,
             body_pool_size: DEFAULT_BODY_POOL_SIZE,
             cache_size: DEFAULT_CACHE_SIZE,

--- a/src/rust/catnip/runtime/memory/consts.rs
+++ b/src/rust/catnip/runtime/memory/consts.rs
@@ -14,12 +14,6 @@ use crate::runtime::libdpdk::{
 // Constants
 //==============================================================================
 
-/// Default size for inline body buffers.
-pub const DEFAULT_INLINE_BODY_SIZE: usize = 1024;
-
-/// Default number of buffers in the header pool.
-pub const DEFAULT_HEADER_POOL_SIZE: usize = 8192 - 1;
-
 /// Default number of buffers in the body pool.
 pub const DEFAULT_BODY_POOL_SIZE: usize = 8192 - 1;
 

--- a/src/rust/catnip/runtime/memory/manager.rs
+++ b/src/rust/catnip/runtime/memory/manager.rs
@@ -7,12 +7,7 @@
 
 use crate::{
     catnip::runtime::memory::mempool::MemoryPool,
-    inetstack::protocols::{
-        ethernet2::ETHERNET2_HEADER_SIZE,
-        ipv4::IPV4_HEADER_MAX_SIZE,
-        tcp::MAX_TCP_HEADER_SIZE,
-        MAX_HEADER_SIZE,
-    },
+    inetstack::protocols::MAX_HEADER_SIZE,
     runtime::{
         fail::Fail,
         libdpdk::{
@@ -54,10 +49,6 @@ pub use crate::catnip::runtime::memory::config::MemoryConfig;
 pub struct MemoryManager {
     config: MemoryConfig,
 
-    // Used by networking stack for protocol headers + inline bodies. These buffers are only used
-    // internally within the network stack.
-    header_pool: MemoryPool,
-
     // Large body pool for buffers given to the application for zero-copy.
     body_pool: MemoryPool,
 }
@@ -70,18 +61,7 @@ pub struct MemoryManager {
 impl MemoryManager {
     /// Instantiates a memory manager.
     pub fn new(max_body_size: usize) -> Result<Self, Error> {
-        let config: MemoryConfig = MemoryConfig::new(None, None, Some(max_body_size), None, None);
-        let header_size: usize = ETHERNET2_HEADER_SIZE + (IPV4_HEADER_MAX_SIZE as usize) + MAX_TCP_HEADER_SIZE;
-        let header_mbuf_size: usize = header_size + config.get_inline_body_size();
-
-        // Create memory pool for holding packet headers.
-        let header_pool: MemoryPool = MemoryPool::new(
-            CString::new("header_pool")?,
-            header_mbuf_size,
-            config.get_header_pool_size(),
-            config.get_cache_size(),
-        )?;
-
+        let config: MemoryConfig = MemoryConfig::new(Some(max_body_size), None, None);
         // Create memory pool for holding packet bodies.
         let body_pool: MemoryPool = MemoryPool::new(
             CString::new("body_pool")?,
@@ -90,11 +70,7 @@ impl MemoryManager {
             config.get_cache_size(),
         )?;
 
-        Ok(Self {
-            config,
-            header_pool,
-            body_pool,
-        })
+        Ok(Self { config, body_pool })
     }
 
     /// Converts a runtime buffer into a scatter-gather array.
@@ -113,13 +89,6 @@ impl MemoryManager {
             sga_segs: [sga_seg],
             sga_addr: unsafe { mem::zeroed() },
         })
-    }
-
-    /// Allocates a header mbuf.
-    /// TODO: Review the need of this function after we are done with the refactor of the DPDK runtime.
-    pub fn alloc_header_mbuf(&self) -> Result<DemiBuffer, Fail> {
-        let mbuf_ptr: *mut rte_mbuf = self.header_pool.alloc_mbuf(None)?;
-        Ok(unsafe { DemiBuffer::from_mbuf(mbuf_ptr) })
     }
 
     /// Allocates a body mbuf.
@@ -146,7 +115,7 @@ impl MemoryManager {
         }
 
         // First allocate the underlying DemiBuffer.
-        let buf: DemiBuffer = if size > self.config.get_inline_body_size() && size <= self.config.get_max_body_size() {
+        let buf: DemiBuffer = if size <= self.config.get_max_body_size() {
             // Allocate a DPDK-managed buffer.
             let mbuf_ptr: *mut rte_mbuf = self.body_pool.alloc_mbuf(Some(size))?;
             // Safety: `mbuf_ptr` is a valid pointer to a properly initialized `rte_mbuf` struct.


### PR DESCRIPTION
Since we now prepend our headers, there is no need for a header pool separate from the pool for holding packet bodies. This PR removes them. This PR depends on PR #1375 because otherwise we fail the system tests when running out of memory.