### PR TITLE
[inetstack] renamed disable_arp() to is_enabled() to avoid double negatives

### DIFF
--- a/src/rust/inetstack/protocols/layer3/arp/cache/mod.rs
+++ b/src/rust/inetstack/protocols/layer3/arp/cache/mod.rs
@@ -55,12 +55,11 @@ impl ArpCache {
         now: Instant,
         default_ttl: Option<Duration>,
         values: Option<&HashMap<Ipv4Addr, MacAddress>>,
-        disable: bool,
+        is_enabled: bool,
     ) -> ArpCache {
-        ArpCache(if disable {
-            None
-        } else {
-            let mut cache: HashTtlCache<Ipv4Addr, Record> = HashTtlCache::<Ipv4Addr, Record>::new(now, default_ttl);
+        ArpCache(if is_enabled {
+            let hash_ttl_cache = HashTtlCache::<Ipv4Addr, Record>::new(now, default_ttl);
+            let mut cache: HashTtlCache<Ipv4Addr, Record> = hash_ttl_cache;
             if let Some(values) = values {
                 for (&k, &v) in values {
                     if let Some(record) = cache.insert(k, Record { link_addr: v }) {
@@ -73,6 +72,8 @@ impl ArpCache {
                 }
             };
             Some(cache)
+        } else {
+            None
         })
     }
 

--- a/src/rust/inetstack/protocols/layer3/arp/cache/tests.rs
+++ b/src/rust/inetstack/protocols/layer3/arp/cache/tests.rs
@@ -24,7 +24,7 @@ fn evict_with_default_ttl() -> Result<()> {
     let later = now + ttl;
 
     // Insert an IPv4 address in the ARP Cache.
-    let mut cache = ArpCache::new(now, Some(ttl), None, false);
+    let mut cache = ArpCache::new(now, Some(ttl), None, true);
     cache.insert(test_helpers::ALICE_IPV4, test_helpers::ALICE_MAC);
     crate::ensure_eq!(cache.get(test_helpers::ALICE_IPV4), Some(&test_helpers::ALICE_MAC));
 
@@ -50,7 +50,7 @@ fn import() -> Result<()> {
     map.insert(test_helpers::ALICE_IPV4, test_helpers::ALICE_MAC);
 
     // Create an ARP Cache and import address resolution map.
-    let cache = ArpCache::new(now, Some(ttl), Some(&map), false);
+    let cache = ArpCache::new(now, Some(ttl), Some(&map), true);
 
     // Check if address resolutions are in the ARP Cache.
     crate::ensure_eq!(cache.get(test_helpers::ALICE_IPV4), Some(&test_helpers::ALICE_MAC));
@@ -65,7 +65,7 @@ fn export() -> Result<()> {
     let ttl = Duration::from_secs(1);
 
     // Insert an IPv4 address in the ARP Cache.
-    let mut cache = ArpCache::new(now, Some(ttl), None, false);
+    let mut cache = ArpCache::new(now, Some(ttl), None, true);
     cache.insert(test_helpers::ALICE_IPV4, test_helpers::ALICE_MAC);
     crate::ensure_eq!(cache.get(test_helpers::ALICE_IPV4), Some(&test_helpers::ALICE_MAC));
 

--- a/src/rust/inetstack/protocols/layer3/arp/peer.rs
+++ b/src/rust/inetstack/protocols/layer3/arp/peer.rs
@@ -90,7 +90,7 @@ impl SharedArpPeer {
             runtime.get_now(),
             Some(arp_config.get_cache_ttl()),
             Some(arp_config.get_initial_values()),
-            arp_config.get_disable_arp(),
+            arp_config.is_enabled(),
         );
 
         let peer: SharedArpPeer = Self(SharedObject::new(ArpPeer {

--- a/src/rust/runtime/network/config/arp.rs
+++ b/src/rust/runtime/network/config/arp.rs
@@ -28,7 +28,7 @@ pub struct ArpConfig {
     request_timeout: Duration,
     retry_count: usize,
     initial_values: HashMap<Ipv4Addr, MacAddress>,
-    disable_arp: bool,
+    is_enabled: bool,
 }
 
 //======================================================================================================================
@@ -43,7 +43,7 @@ impl ArpConfig {
                 request_timeout: config.arp_request_timeout()?,
                 retry_count: config.arp_request_retries()?,
                 initial_values,
-                disable_arp: false,
+                is_enabled: true,
             })
         } else {
             warn!("disabling arp");
@@ -52,7 +52,7 @@ impl ArpConfig {
                 request_timeout: Duration::ZERO,
                 retry_count: 0,
                 initial_values: HashMap::new(),
-                disable_arp: true,
+                is_enabled: false,
             })
         }
     }
@@ -73,8 +73,8 @@ impl ArpConfig {
         &self.initial_values
     }
 
-    pub fn get_disable_arp(&self) -> bool {
-        self.disable_arp
+    pub fn is_enabled(&self) -> bool {
+        self.is_enabled
     }
 }
 
@@ -89,7 +89,7 @@ impl Default for ArpConfig {
             request_timeout: Duration::from_secs(20),
             retry_count: 5,
             initial_values: HashMap::new(),
-            disable_arp: false,
+            is_enabled: true,
         }
     }
 }
@@ -114,7 +114,7 @@ mod tests {
         crate::ensure_eq!(config.get_request_timeout(), Duration::from_secs(20));
         crate::ensure_eq!(config.get_retry_count(), 5);
         crate::ensure_eq!(config.get_initial_values(), &HashMap::new());
-        crate::ensure_eq!(config.get_disable_arp(), false);
+        crate::ensure_eq!(config.is_enabled(), true);
 
         Ok(())
     }


### PR DESCRIPTION
renamed disable_arp() to is_enabled() to avoid double negatives