### PR TITLE
[shim] Enhancement: Add initialization that executes at program load

### DIFF
--- a/shim/src/Makefile
+++ b/shim/src/Makefile
@@ -14,7 +14,7 @@ all: all-libs
 
 all-libs:
 	mkdir -p $(LIBDIR)
-	$(CC) $(CFLAGS) $(SRC) -fPIC -shared -o $(LIBDIR)/$(SHIM_LIB) -L $(LIBDIR)/ -ldemikernel
+	$(CC) $(CFLAGS) $(SRC) -fPIC -shared -o $(LIBDIR)/$(SHIM_LIB) -L $(LIBDIR)/ -ldemikernel -z initfirst
 
 clean:
 	rm -f $(LIBDIR)/$(SHIM_LIB)


### PR DESCRIPTION
This pull request adds an attribute keyword to the initialization function and passes a flag to gcc so that the initialization function in the shim shared library executes before everything else. This significantly simplifies the initialization code, so that we don't have to worry abount concurrent access in the initialization phase. It also removes the need to check if libc and the demikernel have been initialized in the interposed calls, also simplifying the interposed code and possibly reducing overheads.