### PR TITLE
[shim] Enhancement: Add send qtoken to epoll

### DIFF
--- a/shim/src/epoll.h
+++ b/shim/src/epoll.h
@@ -7,6 +7,7 @@
 #include <sys/epoll.h>
 #include <demi/types.h>
 
+#define SEND_EPFD 0
 #define EPOLL_MAX_FDS 1024
 #define MAX_EVENTS 512
 #define INVALID_EV -1
@@ -18,6 +19,7 @@ struct demi_event
     int sockqd;
     demi_qtoken_t qt;
     demi_qresult_t qr;
+    demi_sgarray_t sga;
     struct epoll_event ev;
     int next_ev;
     int prev_ev;
@@ -25,7 +27,11 @@ struct demi_event
 
 extern void epoll_table_init(void);
 extern int epoll_table_alloc(void);
-extern int epoll_get_ready(int epfd, demi_qtoken_t *qts, struct demi_event **evs);
+extern int epoll_get_ready(int epfd, demi_qtoken_t *qts,
+        struct demi_event **evs, int maxevents);
+extern void epoll_init_event(struct demi_event *ev, demi_qtoken_t qt,
+        int sockfd, demi_sgarray_t *sga);
+extern void epoll_deinit_event(struct demi_event *ev);
 extern struct demi_event *epoll_get_event(int epfd, int i);
 extern struct demi_event *epoll_get_head(int epfd);
 extern struct demi_event *epoll_get_tail(int epfd);

--- a/shim/src/epoll/epoll.c
+++ b/shim/src/epoll/epoll.c
@@ -16,7 +16,11 @@ static struct epoll_table epoll_table[EPOLL_MAX_FDS];
 
 int epoll_table_alloc(void)
 {
-    for (int i = 0; i < EPOLL_MAX_FDS; i++)
+    // We skip the first epfd that is used to keep qtokens
+    // for send requests. This function gets called in epoll_create
+    // so we want to avoid this process overriding the values for
+    // the send epoll table.
+    for (int i = SEND_EPFD + 1; i < EPOLL_MAX_FDS; i++)
     {
         if (epoll_table[i].used == 0)
         {
@@ -32,16 +36,16 @@ void epoll_table_init(void)
 {
     for (int i = 0; i < EPOLL_MAX_FDS; i++)
     {
-        epoll_table[i].used = 0;
         epoll_table[i].head = 0;
         epoll_table[i].tail = 0;
+        epoll_table[i].used = i == SEND_EPFD ? 1 : 0;
+
         for (int j = 0; j < MAX_EVENTS; j++)
         {
             /* We use an empty element in the start of the list, to
                make the checks for insertion and deletion simpler, thus
                mark the first element as being used. */
             epoll_table[i].events[j].used = j == 0? 1 : 0;
-
             epoll_table[i].events[j].id = j;
             epoll_table[i].events[j].qt = -1;
             epoll_table[i].events[j].next_ev = INVALID_EV;
@@ -50,24 +54,43 @@ void epoll_table_init(void)
     }
 }
 
-int epoll_get_ready(int epfd, demi_qtoken_t *qts, struct demi_event **evs)
+int epoll_get_ready(int epfd, demi_qtoken_t *qts, struct demi_event **evs, int maxevents)
 {
-    int nevents = 0;
-
-    struct demi_event *ev = epoll_get_head(epfd);
-    while (ev != NULL)
+    int nready = 0;
+    for (struct demi_event *ev = epoll_get_head(epfd);
+            ev != NULL && (nready < maxevents);
+            ev = epoll_get_next(epfd, ev))
     {
         if ((ev->used) && (ev->qt != (demi_qtoken_t)-1))
         {
-            qts[nevents] = ev->qt;
-            evs[nevents] = ev;
-            nevents++;
+            qts[nready] = ev->qt;
+            evs[nready] = ev;
+            nready++;
         }
-
-        ev = epoll_get_next(epfd, ev);
     }
 
-    return nevents;
+    return nready;
+}
+
+void epoll_init_event(struct demi_event *ev, demi_qtoken_t qt,
+        int sockfd, demi_sgarray_t *sga)
+{
+    ev->used = 1;
+    ev->qt = qt;
+    ev->sockqd = sockfd;
+    ev->next_ev = INVALID_EV;
+    ev->prev_ev = INVALID_EV;
+    if (sga != NULL)
+        ev->sga = *sga;
+}
+
+void epoll_deinit_event(struct demi_event *ev)
+{
+    ev->used = 0;
+    ev->qt = (demi_qtoken_t)-1;
+    ev->sockqd = -1;
+    ev->next_ev = INVALID_EV;
+    ev->prev_ev = INVALID_EV;
 }
 
 struct demi_event *epoll_get_event(int epfd, int i)

--- a/shim/src/epoll/epoll_ctl.c
+++ b/shim/src/epoll/epoll_ctl.c
@@ -42,11 +42,7 @@ static int __do_demi_epoll_ctl_add(int epfd, int fd, struct epoll_event *event)
         if (ev->used == 0)
         {
             memcpy(&ev->ev, event, sizeof(struct epoll_event));
-            ev->used = 1;
-            ev->qt = -1;
-            ev->sockqd = fd;
-            ev->next_ev = INVALID_EV;
-            ev->prev_ev = INVALID_EV;
+            epoll_init_event(ev, -1, fd, NULL);
 
             struct demi_event *tail = epoll_get_tail(epfd);
             ev->prev_ev = tail->id;
@@ -153,11 +149,7 @@ static int __do_demi_epoll_ctl_del(int epfd, int fd)
                 next->prev_ev = ev->prev_ev;
 
             queue_man_unlink_fd_epfd(fd);
-            ev->used = 0;
-            ev->sockqd = -1;
-            ev->qt = (demi_qtoken_t)-1;
-            ev->next_ev = INVALID_EV;
-            ev->prev_ev = INVALID_EV;
+            epoll_deinit_event(ev);
 
             return (0);
         }


### PR DESCRIPTION
Changes the way we interpose send in the shim. Before we did a blocking send, but this caused the latency to spike because the Demikernel only returns from demi_wait on a push operation when it receives back an ACK from the receiver. To improve latency this PR does an async send and adds the qtoken for the send operation to a special epoll table. This table gets checked any time epoll_wait is called.