### PR TITLE
[demikernel] Enhancement: prepare to publish new versions on crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "demikernel"
-version = "1.5.13"
+version = "1.5.14"
 authors = ["Microsoft Corporation"]
 edition = "2021"
 description = "Kernel-Bypass LibOS Architecture"

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ maintainers of the project:
 
 - [Irene Zhang](https://github.com/iyzhang) - [irene.zhang@microsoft.com](mailto:irene.zhang@microsoft.com)
 - [Anand Bonde](https://github.com/anandbonde) - [abonde@microsoft.com](mailto:abonde@microsoft.com)
-- [Pedro Henrique Penna](https://github.com/ppenna) - [ppenna@microsoft.com](mailto:ppenna@microsoft.com)
 
 > By sending feedback, you are consenting that it may be used  in the further
 > development of this project.

--- a/dpdk_bindings/Cargo.toml
+++ b/dpdk_bindings/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "demikernel-dpdk-bindings"
-version = "1.1.6"
+version = "1.1.7"
 authors = ["Microsoft Corporation"]
 edition = "2021"
 description = "Rust Bindings for Libdpdk"

--- a/dpdk_bindings/README.md
+++ b/dpdk_bindings/README.md
@@ -7,6 +7,7 @@ We have tested this crate on Windows and Linux.
 
 ## Prerequisites
 - Install DPDK.
+- Set the env. var CFLAGS to add include path to DPDK installation for header files. (-I<path_to_dpdk_headers>)
 - Set the env. var LIBDPDK_PATH to point to the root of the DPDK installation.
 
 ## Related crates:
@@ -14,6 +15,16 @@ https://crates.io/search?q=demikernel
 
 We welcome comments and feedback. By sending feedback, you are consenting that
 it may be used in the further development of this project.
+
+## Usage Statement
+
+This project is a prototype. As such, we provide no guarantees that it will
+work and you are assuming any risks with using the code. We welcome comments
+and feedback. Please send any questions or comments to one of the following
+maintainers of the project:
+
+- [Irene Zhang](https://github.com/iyzhang) - [irene.zhang@microsoft.com](mailto:irene.zhang@microsoft.com)
+- [Anand Bonde](https://github.com/anandbonde) - [abonde@microsoft.com](mailto:abonde@microsoft.com)
 
 ## Trademark Notice
 

--- a/network_simulator/Cargo.toml
+++ b/network_simulator/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "demikernel-network-simulator"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Microsoft Corporation"]
 edition = "2021"
 description = "Network Testing Tool for Demikernel"
@@ -20,6 +20,7 @@ lrlex = "0.13.7"
 lrpar = "0.13.7"
 
 [dependencies]
+anyhow = "1.0.89"
 clap = "4.5.15"
 
 [[bin]]

--- a/network_simulator/README.md
+++ b/network_simulator/README.md
@@ -11,6 +11,16 @@ https://crates.io/search?q=demikernel
 We welcome comments and feedback. By sending feedback, you are consenting that
 it may be used in the further development of this project.
 
+## Usage Statement
+
+This project is a prototype. As such, we provide no guarantees that it will
+work and you are assuming any risks with using the code. We welcome comments
+and feedback. Please send any questions or comments to one of the following
+maintainers of the project:
+
+- [Irene Zhang](https://github.com/iyzhang) - [irene.zhang@microsoft.com](mailto:irene.zhang@microsoft.com)
+- [Anand Bonde](https://github.com/anandbonde) - [abonde@microsoft.com](mailto:abonde@microsoft.com)
+
 ## Trademark Notice
 
 This project may contain trademarks or logos for projects, products, or

--- a/xdp_bindings/Cargo.toml
+++ b/xdp_bindings/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "demikernel-xdp-bindings"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Microsoft Corporation"]
 edition = "2021"
 description = "Rust Bindings for XDP"

--- a/xdp_bindings/README.md
+++ b/xdp_bindings/README.md
@@ -15,6 +15,16 @@ https://crates.io/search?q=demikernel
 We welcome comments and feedback. By sending feedback, you are consenting that
 it may be used in the further development of this project.
 
+## Usage Statement
+
+This project is a prototype. As such, we provide no guarantees that it will
+work and you are assuming any risks with using the code. We welcome comments
+and feedback. Please send any questions or comments to one of the following
+maintainers of the project:
+
+- [Irene Zhang](https://github.com/iyzhang) - [irene.zhang@microsoft.com](mailto:irene.zhang@microsoft.com)
+- [Anand Bonde](https://github.com/anandbonde) - [abonde@microsoft.com](mailto:abonde@microsoft.com)
+
 ## Trademark Notice
 
 This project may contain trademarks or logos for projects, products, or


### PR DESCRIPTION
This PR covers the following changes to prepare for publishing to crates.io:

* Increment versions for all `Demikernel` crates.
* Update readme files so that they are reflected on crates.io.
* Ensure stand-alone build-ability for the `network_simulator`.
* Will publish all crates on crates.io with new versions.
* Will push `dev` to `unstable` and `main` branches.
