### PR TITLE
[inetstack] Enhancement: Move rto and retransmit into Sender

### DIFF
--- a/src/rust/inetstack/protocols/layer4/mod.rs
+++ b/src/rust/inetstack/protocols/layer4/mod.rs
@@ -305,10 +305,6 @@ impl Peer {
 
 #[cfg(test)]
 impl Peer {
-    pub fn tcp_rto(&self, socket: &SharedTcpSocket) -> Result<Duration, Fail> {
-        socket.current_rto()
-    }
-
     pub async fn ping(&mut self, addr: Ipv4Addr, timeout: Option<Duration>) -> Result<Duration, Fail> {
         self.layer3_endpoint.ping(addr, timeout).await
     }

--- a/src/rust/inetstack/protocols/layer4/tcp/established/mod.rs
+++ b/src/rust/inetstack/protocols/layer4/tcp/established/mod.rs
@@ -120,10 +120,6 @@ impl EstablishedSocket {
         self.cb.close().await
     }
 
-    pub fn current_rto(&self) -> Duration {
-        self.cb.rto()
-    }
-
     pub fn endpoints(&self) -> (SocketAddrV4, SocketAddrV4) {
         (self.cb.get_local(), self.cb.get_remote())
     }

--- a/src/rust/inetstack/protocols/layer4/tcp/socket.rs
+++ b/src/rust/inetstack/protocols/layer4/tcp/socket.rs
@@ -33,7 +33,6 @@ use ::std::{
     fmt::Debug,
     net::{Ipv4Addr, SocketAddrV4},
     ops::{Deref, DerefMut},
-    time::Duration,
 };
 
 //======================================================================================================================
@@ -295,13 +294,6 @@ impl SharedTcpSocket {
             },
             SocketState::Bound(addr) => Ok(Some(SocketId::Passive(addr))),
             SocketState::Unbound => Ok(None),
-        }
-    }
-
-    pub fn current_rto(&self) -> Result<Duration, Fail> {
-        match self.state {
-            SocketState::Established(ref socket) => Ok(socket.current_rto()),
-            _ => return Err(Fail::new(libc::ENOTCONN, "connection not established")),
         }
     }
 


### PR DESCRIPTION
This PR moves the RTO calculator and retransmit timer out of the ctrl block and into the sender. The sender now updates these values as part of processing an incoming ack, instead of the ctrl block managing them.