### PR TITLE
[testing] Add support for multiple ops to simulator and add new test

### DIFF
--- a/network_simulator/input/tcp/push/push-retransmission-2.pkt
+++ b/network_simulator/input/tcp/push/push-retransmission-2.pkt
@@ -1,0 +1,48 @@
+// Test for blocking push with 2 lost packets and retransmission.
+
+// Accept a connection.
++.0 socket(..., SOCK_STREAM, IPPROTO_TCP) = 500
++.0 bind(500, ..., ...) = 0
++.0 listen(500, 1) = 0
++.2 accept(500, ..., ...) = 0
+
+// Receive SYN packet.
++.2 TCP < S seq 0(0) win 65535 <mss 1450,wscale 0>
+// Send SYN-ACK packet.
++.0 TCP > S. seq 0(0) ack 1 win 65535 <mss 1450,wscale 0>
+// Receive ACK on SYN-ACK packet.
++.2 TCP < . seq 1(0) ack 1 win 65535 <nop>
+
+// Succeed to accept connection.
++.0 wait(500, ...) = 0
+
+// Send data.
++.1 write(501, ..., 1000) = 1000
+
+// Send data packet.
++0 TCP > P. seq 1(1000) ack 1 win 65535 <nop>
+
+
+// Send more data.
++.1 write(501, ..., 1000) = 1000
+
+// Send data packet.
++0 TCP > P. seq 1001(1000) ack 1 win 65535 <nop>
+
+// Retransmit first data packet.
++4 TCP > P. seq 1(1000) ack 1 win 65535 <nop>
+
+// Receive ACK on first data packet.
++.1 TCP < . seq 1(0) ack 1001 win 65535 <nop>
+
+// Data sent.
++.0 wait(501, ...) = 0
+
+// Retransmit second data packet.
++.1 TCP > P. seq 1001(1000) ack 1 win 65535 <nop>
+
+// Receive ACK on second data packet.
++.1 TCP < . seq 1(0) ack 2001 win 65535 <nop>
+
+// Data sent.
++.0 wait(501, ...) = 0


### PR DESCRIPTION
This PR adds:
1. Support for multiple ops in the simulator. It assumes that the waits are in the order that the ops are issued. Closes #1427 
2. A new test for PR #1428 and issue #202 