### PR TITLE
[catpowder] Enhancement: bind to all available receive queues in XDP

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ windows = { version = "0.57.0", features = [
     "Win32_Storage_FileSystem",
     "Win32_System_IO",
     "Win32_System_Pipes",
+    "Win32_System_SystemInformation",
     "Win32_System_Threading",
 ] }
 demikernel-xdp-bindings = { version = "1.0.0", optional = true }

--- a/src/rust/catpowder/win/ring/umemreg.rs
+++ b/src/rust/catpowder/win/ring/umemreg.rs
@@ -8,9 +8,11 @@ use crate::runtime::libxdp;
 //======================================================================================================================
 
 /// A wrapper structure for a XDP user memory region.
-#[repr(C)]
-#[derive(Clone)]
-pub struct UmemReg(libxdp::XSK_UMEM_REG);
+pub struct UmemReg
+{
+    _buffer: Vec<u8>,
+    umem: libxdp::XSK_UMEM_REG
+}
 
 //======================================================================================================================
 // Implementations
@@ -22,23 +24,23 @@ impl UmemReg {
         let total_size: u64 = count as u64 * chunk_size as u64;
         let mut buffer: Vec<u8> = Vec::<u8>::with_capacity(total_size as usize);
 
-        let mem: libxdp::XSK_UMEM_REG = libxdp::XSK_UMEM_REG {
+        let umem: libxdp::XSK_UMEM_REG = libxdp::XSK_UMEM_REG {
             TotalSize: total_size,
             ChunkSize: chunk_size,
             Headroom: 0,
             Address: buffer.as_mut_ptr() as *mut core::ffi::c_void,
         };
 
-        Self(mem)
+        Self{ _buffer: buffer, umem }
     }
 
     /// Gets a reference to the underlying XDP user memory region.
     pub fn as_ref(&self) -> &libxdp::XSK_UMEM_REG {
-        &self.0
+        &self.umem
     }
 
     /// Returns a raw pointer to the the start address of the user memory region.
     pub fn address(&self) -> *mut core::ffi::c_void {
-        self.0.Address
+        self.umem.Address
     }
 }


### PR DESCRIPTION
Update XDP to bind to all receive queues. Receive queues are always a zero-based contiguous sequence of indices.

This approach is a little problematic because it could ignore other errors instantiating a socket on the non-zeroth queue, such as out of memory, etc. Alternatives get complex quickly. Looking at MsQuic, that platform uses a similar approach in a separate round of socket creation: it creates sockets for the express purposes of validating queues and observing CPU identity of each queue. Alternatively, the software could query the `MSFT_NetAdapterRssSettingData` WMI data source to determine this info (more info [here](https://learn.microsoft.com/en-us/windows/win32/fwp/wmi/netadaptercimprov/msft-netadapterrsssettingdata).

This also fixes a bug in UmemReg which dropped the allocated user memory after the constructor.

See also #1429 