### PR TITLE
[demikernel] Enhancement: remove unstable rustfmt options

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -9,13 +9,3 @@ use_field_init_shorthand = false
 use_try_shorthand = true
 reorder_imports = true
 match_block_trailing_comma = true
-
-# Unstable Options
-unstable_features = true
-comment_width = 120
-condense_wildcard_suffixes = false
-format_strings = true
-imports_granularity="Crate"
-reorder_impl_items = true
-empty_item_single_line = true
-indent_style = "Block"


### PR DESCRIPTION
These options had no effect on the source code format, so it's better to get rid of the unstable features/options.