### PR TITLE
[inetstack] Add simulator test for out of order FIN

### DIFF
--- a/network_simulator/input/tcp/close/close-out-of-order-fin.pkt
+++ b/network_simulator/input/tcp/close/close-out-of-order-fin.pkt
@@ -1,0 +1,45 @@
+// Tests for remote close with an out of order FIN.
+
+// Establish a connection.
+ +.0 socket(..., SOCK_STREAM, IPPROTO_TCP) = 500
++.2 connect(500, ..., ...) = 0
+
+// Send SYN segment.
++.0 TCP > S seq 0(0) win 65535 <mss 1450, wscale 0>
+// Receive SYN-ACK segment.
++.1 TCP < S. seq 0(0) ack 1 win 65535 <mss 1450, wscale 0>
+// Send ACK on SYN-ACK segment.
++.0 TCP > . seq 1(0) ack 1 win 65535 <nop>
+
+// Succeed to establish connection.
++.0 wait(500, ...) = 0
+
+// Send data.
++.1 write(500, ..., 1000) = 1000
+
+// Send data packet.
++0 TCP > P. seq 1(1000) ack 1 win 65535 <nop>
+
+// Receive out of order FIN segment.
++.1 TCP < F. seq 1001(0) ack 1001 win 65535 <nop>
+
+// Send ACK packet for out of order data.
++.0 TCP > . seq 1001(0) ack 1 win 65535 <nop>
+
+// Receive data packet
++.1 TCP < P. seq 1(1000) ack 1001 win 65535 <nop>
+
+// Send ACK packet for data and FIN.
++.0 TCP > . seq 1001(0) ack 1002 win 64534 <nop>
+
+// Close connection.
++.2 close(500) = 0
+
+// Send FIN segment.
++.0 TCP > F. seq 1001(0) ack 1002 win 64534 <nop>
+
+// Receive ACK on FIN segment.
++.1 TCP < . seq 1002(0) ack 1002 win 64534 <nop>
+
+// Succeed to close connection immediately.
++.0 wait(500, ...) = 0


### PR DESCRIPTION
This PR adds a new test for receiving an out of order FIN. It also fixes a few bugs around our close protocol:

1. Out of order FINs that were not on data carrying packets were not actually being stored for later.
2. When the out of order FIN is stored for later, we should not immediately process the FIN.
3. When the out of order FIN is stored for later, we should check on every arriving packet if the FIN is now ready because it might be by itself without any out of order data.