### PR TITLE
[inetstack] Enhancement: Move ephemeral port allocator

### DIFF
--- a/src/rust/demikernel/libos/mod.rs
+++ b/src/rust/demikernel/libos/mod.rs
@@ -86,7 +86,6 @@ impl LibOS {
             LibOSName::Catnap => Self::NetworkLibOS(NetworkLibOSWrapper::Catnap(SharedNetworkLibOS::<
                 SharedCatnapTransport,
             >::new(
-                config.local_ipv4_addr()?,
                 runtime.clone(),
                 SharedCatnapTransport::new(&config, &mut runtime)?,
             ))),
@@ -98,7 +97,7 @@ impl LibOS {
                 let inetstack: SharedInetStack =
                     SharedInetStack::new(&config, runtime.clone(), layer1_endpoint).unwrap();
                 Self::NetworkLibOS(NetworkLibOSWrapper::Catpowder(
-                    SharedNetworkLibOS::<SharedInetStack>::new(config.local_ipv4_addr()?, runtime, inetstack),
+                    SharedNetworkLibOS::<SharedInetStack>::new(runtime, inetstack),
                 ))
             },
             #[cfg(feature = "catnip-libos")]
@@ -109,9 +108,7 @@ impl LibOS {
                     SharedInetStack::new(&config, runtime.clone(), layer1_endpoint).unwrap();
 
                 Self::NetworkLibOS(NetworkLibOSWrapper::Catnip(SharedNetworkLibOS::<SharedInetStack>::new(
-                    config.local_ipv4_addr()?,
-                    runtime,
-                    inetstack,
+                    runtime, inetstack,
                 )))
             },
             _ => panic!("unsupported libos"),

--- a/src/rust/demikernel/libos/network/libos.rs
+++ b/src/rust/demikernel/libos/network/libos.rs
@@ -28,11 +28,10 @@ use ::futures::FutureExt;
 use ::socket2::{Domain, Protocol, Type};
 use ::std::{
     mem,
-    net::{SocketAddr, SocketAddrV4},
+    net::{Ipv4Addr, SocketAddr, SocketAddrV4},
     ops::{Deref, DerefMut},
     time::Duration,
 };
-use std::net::Ipv4Addr;
 
 //======================================================================================================================
 // Structures

--- a/src/rust/inetstack/protocols/layer3/mod.rs
+++ b/src/rust/inetstack/protocols/layer3/mod.rs
@@ -160,7 +160,6 @@ impl SharedLayer3Endpoint {
         self.layer2_endpoint.transmit_ipv4_packet(remote_link_addr, pkt)
     }
 
-    #[cfg(test)]
     pub fn get_local_addr(&self) -> Ipv4Addr {
         self.local_ipv4_addr
     }

--- a/src/rust/inetstack/protocols/layer4/ephemeral.rs
+++ b/src/rust/inetstack/protocols/layer4/ephemeral.rs
@@ -104,7 +104,9 @@ impl Default for EphemeralPorts {
 
 #[cfg(test)]
 mod test {
-    use crate::runtime::network::ephemeral::{EphemeralPorts, FIRST_PRIVATE_PORT_NUMBER, LAST_PRIVATE_PORT_NUMBER};
+    use crate::inetstack::protocols::layer4::ephemeral::{
+        EphemeralPorts, FIRST_PRIVATE_PORT_NUMBER, LAST_PRIVATE_PORT_NUMBER,
+    };
     use ::anyhow::Result;
 
     #[test]

--- a/src/rust/inetstack/protocols/layer4/tcp/peer.rs
+++ b/src/rust/inetstack/protocols/layer4/tcp/peer.rs
@@ -146,19 +146,14 @@ impl SharedTcpPeer {
     }
 
     /// Runs until the connect to remote is made or times out.
-    pub async fn connect(&mut self, socket: &mut SharedTcpSocket, remote: SocketAddrV4) -> Result<(), Fail> {
-        // Check whether we need to allocate an ephemeral port.
-        let local: SocketAddrV4 = match socket.local() {
-            Some(addr) => {
-                // If socket is already bound to a local address, use it but remove the old binding.
-                self.addresses.remove(&SocketId::Passive(addr));
-                addr
-            },
-            None => {
-                let local_port: u16 = self.runtime.alloc_ephemeral_port()?;
-                SocketAddrV4::new(self.local_ipv4_addr, local_port)
-            },
-        };
+    pub async fn connect(
+        &mut self,
+        socket: &mut SharedTcpSocket,
+        local: SocketAddrV4,
+        remote: SocketAddrV4,
+    ) -> Result<(), Fail> {
+        // If socket is already bound to a local address, use it but remove the old binding.
+        self.addresses.remove(&SocketId::Passive(local));
         // Insert the connection to receive incoming packets for this address pair.
         // Should we remove the passive entry for the local address if the socket was previously bound?
         if self
@@ -204,30 +199,12 @@ impl SharedTcpPeer {
         Ok((None, incoming))
     }
 
-    /// Frees an ephemeral port (if any) allocated to a given socket.
-    fn free_ephemeral_port(&mut self, socket_id: &SocketId) {
-        let local: &SocketAddrV4 = match socket_id {
-            SocketId::Active(local, _) => local,
-            SocketId::Passive(local) => local,
-        };
-        // Rollback ephemeral port allocation.
-        if SharedDemiRuntime::is_private_ephemeral_port(local.port()) {
-            if self.runtime.free_ephemeral_port(local.port()).is_err() {
-                // We fail if and only if we attempted to free a port that was not allocated.
-                // This is unexpected, but if it happens, issue a warning and keep going,
-                // otherwise we would leave the queue in a dangling state.
-                warn!("bind(): leaking ephemeral port (port={})", local.port());
-            }
-        }
-    }
-
     /// Closes a TCP socket.
     pub async fn close(&mut self, socket: &mut SharedTcpSocket) -> Result<(), Fail> {
         // Wait for close to complete.
         // Handle result: If unsuccessful, free the new queue descriptor.
         if let Some(socket_id) = socket.close().await? {
             self.addresses.remove(&socket_id);
-            self.free_ephemeral_port(&socket_id);
         }
         Ok(())
     }
@@ -235,7 +212,6 @@ impl SharedTcpPeer {
     pub fn hard_close(&mut self, socket: &mut SharedTcpSocket) -> Result<(), Fail> {
         if let Some(socket_id) = socket.hard_close()? {
             self.addresses.remove(&socket_id);
-            self.free_ephemeral_port(&socket_id);
         }
         Ok(())
     }

--- a/src/rust/inetstack/test_helpers/engine.rs
+++ b/src/rust/inetstack/test_helpers/engine.rs
@@ -40,7 +40,7 @@ impl SharedEngine {
         let transport: SharedInetStack = SharedInetStack::new_test(&config, runtime.clone(), layer1_endpoint.clone())?;
 
         Ok(Self(SharedObject::new(Engine {
-            libos: SharedNetworkLibOS::<SharedInetStack>::new(config.local_ipv4_addr()?, runtime, transport),
+            libos: SharedNetworkLibOS::<SharedInetStack>::new(runtime, transport),
             layer1_endpoint,
         })))
     }

--- a/src/rust/runtime/network/mod.rs
+++ b/src/rust/runtime/network/mod.rs
@@ -7,7 +7,6 @@
 
 pub mod config;
 pub mod consts;
-pub mod ephemeral;
 pub mod ring;
 pub mod socket;
 pub mod transport;

--- a/tests/rust/common/libos.rs
+++ b/tests/rust/common/libos.rs
@@ -51,11 +51,7 @@ impl DummyLibOS {
 
         logging::initialize();
         let transport = SharedInetStack::new_test(&config, runtime.clone(), network)?;
-        Ok(Self(SharedNetworkLibOS::<SharedInetStack>::new(
-            config.local_ipv4_addr()?,
-            runtime,
-            transport,
-        )))
+        Ok(Self(SharedNetworkLibOS::<SharedInetStack>::new(runtime, transport)))
     }
 
     pub fn prepare_dummy_buffer(&self, size: usize) -> Result<demi_sgarray_t, Fail> {


### PR DESCRIPTION
This PR moves the ephemeral port allocator into the inetstack since it is not needed for the other libOSes.