### PR TITLE
[demikernel] Enhancement: cleanup comments, rename

### DIFF
--- a/examples/tcp-echo/client.rs
+++ b/examples/tcp-echo/client.rs
@@ -67,7 +67,6 @@ pub struct TcpEchoClient {
 //======================================================================================================================
 
 impl TcpEchoClient {
-    /// Instantiates a new TCP echo client.
     pub fn new(libos: LibOS, bufsize: usize, remote: SocketAddr) -> Result<Self> {
         return Ok(Self {
             libos,

--- a/src/rust/catpowder/win/ring/buffer.rs
+++ b/src/rust/catpowder/win/ring/buffer.rs
@@ -17,9 +17,7 @@ use ::std::{
 // Structures
 //======================================================================================================================
 
-/// A structure that represents a buffer in the UMEM region.
 pub struct XdpBuffer {
-    /// A pointer to the buffer descriptor.
     b: *mut libxdp::XSK_BUFFER_DESCRIPTOR,
     /// UMEM region that contains the buffer.
     umemreg: Rc<RefCell<UmemReg>>,
@@ -30,24 +28,20 @@ pub struct XdpBuffer {
 //======================================================================================================================
 
 impl XdpBuffer {
-    /// Instantiates a buffer.
     pub(super) fn new(b: *mut libxdp::XSK_BUFFER_DESCRIPTOR, umemreg: Rc<RefCell<UmemReg>>) -> Self {
         Self { b, umemreg }
     }
 
-    /// Sets the length of the target buffer.
     pub(super) fn set_len(&mut self, len: usize) {
         unsafe {
             (*self.b).Length = len as u32;
         }
     }
 
-    /// Gets the length of the target buffer.
     fn len(&self) -> usize {
         unsafe { (*self.b).Length as usize }
     }
 
-    /// Gets the relative base address of the target buffer.
     unsafe fn relative_base_address(&self) -> u64 {
         (*self.b).Address.__bindgen_anon_1.BaseAddress()
     }
@@ -56,7 +50,6 @@ impl XdpBuffer {
         (*self.b).Address.__bindgen_anon_1.Offset()
     }
 
-    /// Computes the address of the target buffer.
     unsafe fn compute_address(&self) -> *mut core::ffi::c_void {
         let mut ptr: *mut u8 = self.umemreg.borrow_mut().address() as *mut u8;
         ptr = ptr.add(self.relative_base_address() as usize);
@@ -64,7 +57,6 @@ impl XdpBuffer {
         ptr as *mut core::ffi::c_void
     }
 
-    /// Creates a vector with the contents of the target buffer.
     fn to_vector(&self) -> Vec<u8> {
         let mut out: Vec<u8> = Vec::with_capacity(self.len());
         self[..].clone_into(&mut out);

--- a/src/rust/collections/hashttlcache.rs
+++ b/src/rust/collections/hashttlcache.rs
@@ -19,14 +19,11 @@ use std::{
 ///
 /// Values may be assigned to an expiration time or not.
 struct Record<V> {
-    /// Stored Value
     value: V,
-    /// Expiration Time
     expiration: Option<Instant>,
 }
 
 impl<V> Record<V> {
-    /// Asserts if the target cache entry has expired.
     fn has_expired(&self, now: Instant) -> bool {
         if let Some(e) = self.expiration {
             return now >= e;
@@ -45,9 +42,7 @@ pub struct HashTtlCache<K, V> {
     map: HashMap<K, Record<V>>,
     /// Dead values.
     graveyard: HashMap<K, V>,
-    /// Default expiration.
     default_ttl: Option<Duration>,
-    /// Current time.
     clock: Instant,
 }
 
@@ -59,7 +54,6 @@ impl<K, V> HashTtlCache<K, V>
 where
     K: Eq + Hash + Clone,
 {
-    /// Instantiates an TTL cache.
     pub fn new(now: Instant, default_ttl: Option<Duration>) -> HashTtlCache<K, V> {
         if let Some(ttl) = default_ttl {
             assert!(ttl > Duration::new(0, 0));
@@ -73,14 +67,12 @@ where
         }
     }
 
-    // Cleanups the cache.
     pub fn clear(&mut self) {
         self.graveyard.clear();
         self.map.clear();
     }
 
     #[cfg(test)]
-    // Advances the internal clock of the cache.
     pub fn advance_clock(&mut self, now: Instant) {
         assert!(now >= self.clock);
         self.clock = now;
@@ -118,7 +110,6 @@ where
     }
 
     #[cfg(test)]
-    /// Removes an entry from the cache.
     pub fn remove(&mut self, key: &K) -> Option<V> {
         match self.get(key) {
             Some(_) => {
@@ -134,13 +125,11 @@ where
         }
     }
 
-    // Gets an entry from the cache.
     pub fn get(&self, key: &K) -> Option<&V> {
         return self.map.get(key).map(|r| &r.value);
     }
 
     #[cfg(test)]
-    // Iterator.
     pub fn iter(&self) -> impl Iterator<Item = (&K, &V)> {
         let clock = self.clock;
         self.map.iter().flat_map(move |(key, record)| {
@@ -152,7 +141,6 @@ where
         })
     }
 
-    /// Collect dead entries in the cache.
     pub fn cleanup(&mut self) {
         let mut dead_entries: Vec<K> = Vec::new();
 

--- a/src/rust/inetstack/protocols/layer3/ipv4/header.rs
+++ b/src/rust/inetstack/protocols/layer3/ipv4/header.rs
@@ -84,9 +84,7 @@ pub struct Ipv4Header {
 // Associated Functions
 //======================================================================================================================
 
-/// Associated Functions for IPv4 Headers
 impl Ipv4Header {
-    /// Instantiates an empty IPv4 header.
     pub fn new(src_addr: Ipv4Addr, dst_addr: Ipv4Addr, protocol: IpProtocol) -> Self {
         Self {
             version: IPV4_VERSION,
@@ -105,7 +103,6 @@ impl Ipv4Header {
         }
     }
 
-    /// Computes the size of the target IPv4 header.
     pub fn compute_size(&self) -> usize {
         (self.ihl as usize) << 2
     }
@@ -117,7 +114,6 @@ impl Ipv4Header {
             return Err(Fail::new(EBADMSG, "ipv4 datagram too small"));
         }
 
-        // IP version number.
         let version: u8 = buf[0] >> 4;
         if version != IPV4_VERSION {
             return Err(Fail::new(ENOTSUP, "unsupported IP version"));
@@ -146,7 +142,6 @@ impl Ipv4Header {
             warn!("ignoring ecn field (ecn={:?})", ecn);
         }
 
-        // Total length.
         let total_length: u16 = u16::from_be_bytes([hdr_buf[2], hdr_buf[3]]);
         if total_length < hdr_size {
             return Err(Fail::new(EBADMSG, "ipv4 datagram smaller than header"));
@@ -182,7 +177,6 @@ impl Ipv4Header {
             return Err(Fail::new(ENOTSUP, "ipv4 fragmentation is not supported"));
         }
 
-        // Fragment offset.
         let fragment_offset: u16 = u16::from_be_bytes([hdr_buf[6], hdr_buf[7]]) & 0x1fff;
         // TODO: drop this check once we support fragmentation.
         if fragment_offset != 0 {
@@ -190,16 +184,13 @@ impl Ipv4Header {
             return Err(Fail::new(ENOTSUP, "ipv4 fragmentation is not supported"));
         }
 
-        // Time to live.
         let time_to_live: u8 = hdr_buf[8];
         if time_to_live == 0 {
             return Err(Fail::new(EBADMSG, "ipv4 datagram too old"));
         }
 
-        // Protocol.
         let protocol: IpProtocol = IpProtocol::try_from(hdr_buf[9])?;
 
-        // Header checksum.
         let header_checksum: u16 = u16::from_be_bytes([hdr_buf[10], hdr_buf[11]]);
         if header_checksum == 0xffff {
             return Err(Fail::new(EBADMSG, "ipv4 checksum invalid"));
@@ -208,10 +199,7 @@ impl Ipv4Header {
             return Err(Fail::new(EBADMSG, "ipv4 checksum mismatch"));
         }
 
-        // Source address.
         let src_addr: Ipv4Addr = Ipv4Addr::new(hdr_buf[12], hdr_buf[13], hdr_buf[14], hdr_buf[15]);
-
-        // Destination address.
         let dst_addr: Ipv4Addr = Ipv4Addr::new(hdr_buf[16], hdr_buf[17], hdr_buf[18], hdr_buf[19]);
 
         // Truncate datagram.
@@ -277,28 +265,23 @@ impl Ipv4Header {
         buf[10..12].copy_from_slice(&checksum.to_be_bytes());
     }
 
-    /// Returns the source address field stored in the target IPv4 header.
     pub fn get_src_addr(&self) -> Ipv4Addr {
         self.src_addr
     }
 
-    /// Returns the destination address field stored in the target IPv4 header.
     pub fn get_dest_addr(&self) -> Ipv4Addr {
         self.dst_addr
     }
 
-    /// Returns the protocol field stored in the target IPv4 header.
     pub fn get_protocol(&self) -> IpProtocol {
         self.protocol
     }
 
-    /// Computes the checksum of the target IPv4 header.
     pub fn compute_checksum(buf: &[u8]) -> u16 {
         let mut state: u32 = 0xffff;
 
-        // Do not compute checksum if buffer is too small.
         if buf.len() < IPV4_HEADER_MIN_SIZE as usize {
-            // This should not happen by construction. If it does, log it.
+            // This should not happen by construction.
             warn!("compute_checksum: buffer is too small (len={})", buf.len());
             return 0;
         }

--- a/src/rust/inetstack/protocols/layer3/ipv4/tests.rs
+++ b/src/rust/inetstack/protocols/layer3/ipv4/tests.rs
@@ -18,7 +18,6 @@ use ::anyhow::Result;
 // Helper Functions
 //======================================================================================================================
 
-/// Builds an IPv4 header.
 /// NOTE: that we can use this function to create invalid IPv4 headers
 fn build_ipv4_header(
     buf: &mut [u8],
@@ -109,7 +108,6 @@ fn test_ipv4_header_parse_good() -> Result<()> {
         // Payload
         buf[header_size..datagram_size].copy_from_slice(&data);
 
-        // Do it.
         let mut buf: DemiBuffer = match DemiBuffer::from_slice(&buf[..datagram_size]) {
             Ok(buf) => buf,
             Err(e) => anyhow::bail!("'buf' should fit: {:?}", e),
@@ -160,7 +158,6 @@ fn test_ipv4_header_parse_invalid_version() -> Result<()> {
             None,
         );
 
-        // Do it.
         let mut buf: DemiBuffer = match DemiBuffer::from_slice(&buf) {
             Ok(buf) => buf,
             Err(e) => anyhow::bail!("'buf' should fit: {:?}", e),
@@ -201,7 +198,6 @@ fn test_ipv4_header_parse_invalid_ihl() -> Result<()> {
             None,
         );
 
-        // Do it.
         let mut buf: DemiBuffer = match DemiBuffer::from_slice(&buf) {
             Ok(buf) => buf,
             Err(e) => anyhow::bail!("'buf' should fit: {:?}", e),
@@ -243,7 +239,6 @@ fn test_ipv4_header_parse_invalid_total_length() -> Result<()> {
             None,
         );
 
-        // Do it.
         let mut buf: DemiBuffer = match DemiBuffer::from_slice(&buf) {
             Ok(buf) => buf,
             Err(e) => anyhow::bail!("'buf' should fit in a DemiBuffer: {:?}", e),
@@ -285,7 +280,6 @@ fn test_ipv4_header_parse_invalid_flags() -> Result<()> {
         None,
     );
 
-    // Do it.
     let mut buf: DemiBuffer = match DemiBuffer::from_slice(&buf) {
         Ok(buf) => buf,
         Err(e) => anyhow::bail!("'buf' should fit: {:?}", e),
@@ -324,7 +318,6 @@ fn test_ipv4_header_parse_invalid_ttl() -> Result<()> {
         None,
     );
 
-    // Do it.
     let mut buf: DemiBuffer = match DemiBuffer::from_slice(&buf) {
         Ok(buf) => buf,
         Err(e) => anyhow::bail!("'buf' should fit: {:?}", e),
@@ -363,7 +356,6 @@ fn test_ipv4_header_parse_invalid_protocol() -> Result<()> {
             None,
         );
 
-        // Do it.
         let mut buf: DemiBuffer = match DemiBuffer::from_slice(&buf) {
             Ok(buf) => buf,
             Err(e) => anyhow::bail!("'buf' should fit: {:?}", e),
@@ -405,7 +397,6 @@ fn test_ipv4_header_parse_invalid_header_checksum() -> Result<()> {
         Some(hdr_checksum),
     );
 
-    // Do it.
     let mut buf: DemiBuffer = match DemiBuffer::from_slice(&buf) {
         Ok(buf) => buf,
         Err(e) => anyhow::bail!("'buf' should fit: {:?}", e),
@@ -448,7 +439,6 @@ fn test_ipv4_header_parse_unsupported_dscp() -> Result<()> {
             None,
         );
 
-        // Do it.
         let mut buf: DemiBuffer = match DemiBuffer::from_slice(&buf) {
             Ok(buf) => buf,
             Err(e) => anyhow::bail!("'buf' should fit: {:?}", e),
@@ -490,7 +480,6 @@ fn test_ipv4_header_parse_unsupported_ecn() -> Result<()> {
             None,
         );
 
-        // Do it.
         let mut buf: DemiBuffer = match DemiBuffer::from_slice(&buf) {
             Ok(buf) => buf,
             Err(e) => anyhow::bail!("'buf' should fit: {:?}", e),
@@ -535,7 +524,6 @@ fn test_ipv4_header_parse_unsupported_fragmentation() -> Result<()> {
         None,
     );
 
-    // Do it.
     let mut buf: DemiBuffer = match DemiBuffer::from_slice(&buf) {
         Ok(buf) => buf,
         Err(e) => anyhow::bail!("'buf' should fit: {:?}", e),
@@ -566,7 +554,6 @@ fn test_ipv4_header_parse_unsupported_fragmentation() -> Result<()> {
         None,
     );
 
-    // Do it.
     let mut buf: DemiBuffer = match DemiBuffer::from_slice(&buf) {
         Ok(buf) => buf,
         Err(e) => anyhow::bail!("'buf' should fit: {:?}", e),
@@ -614,7 +601,6 @@ fn test_ipv4_header_parse_unsupported_protocol() -> Result<()> {
                     None,
                 );
 
-                // Do it.
                 let mut buf: DemiBuffer = match DemiBuffer::from_slice(&buf) {
                     Ok(buf) => buf,
                     Err(e) => anyhow::bail!("'buf' should fit: {:?}", e),

--- a/src/rust/inetstack/protocols/layer4/udp/header.rs
+++ b/src/rust/inetstack/protocols/layer4/udp/header.rs
@@ -203,7 +203,6 @@ mod test {
     use ::anyhow::Result;
     use ::std::net::Ipv4Addr;
 
-    /// Tets UDP serialization.
     #[test]
     fn test_udp_header_serialization() -> Result<()> {
         const UDP_HEADER_SIZE: usize = 8;
@@ -216,18 +215,15 @@ mod test {
         let checksum_offload: bool = true;
         let udp_hdr: UdpHeader = UdpHeader::new(src_port, dest_port);
 
-        // Payload.
-        let data: [u8; 8] = [0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1];
-        let mut buf: DemiBuffer = DemiBuffer::from_slice_with_headroom(&data, UDP_HEADER_SIZE)?;
+        let payload_data: [u8; 8] = [0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1];
+        let mut buf: DemiBuffer = DemiBuffer::from_slice_with_headroom(&payload_data, UDP_HEADER_SIZE)?;
 
-        // Do it.
         udp_hdr.serialize_and_attach(&mut buf, &src_addr, &dst_addr, checksum_offload);
         crate::ensure_eq!(buf[..UDP_HEADER_SIZE], [0x0, 0x32, 0x0, 0x45, 0x0, 0x10, 0x0, 0x0]);
 
         Ok(())
     }
 
-    /// Tests UDP parsing.
     #[test]
     fn test_udp_header_parsing() -> Result<()> {
         // Build fake IPv4 header.
@@ -240,13 +236,9 @@ mod test {
         let dest_port: u16 = 0x45;
         let hdr: [u8; 8] = [0x0, 0x32, 0x0, 0x45, 0x0, 0x10, 0x0, 0x0];
 
-        // Payload.
-        let data: [u8; 8] = [0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1];
+        let payload_data: [u8; 8] = [0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1];
+        let mut buf: DemiBuffer = DemiBuffer::from_slice(&[hdr, payload_data].concat())?;
 
-        // Input buffer.
-        let mut buf: DemiBuffer = DemiBuffer::from_slice(&[hdr, data].concat())?;
-
-        // Do it.
         match UdpHeader::parse_and_strip(&src_addr, &dst_addr, &mut buf, checksum_offload) {
             Ok(udp_hdr) => {
                 crate::ensure_eq!(udp_hdr.src_port(), src_port);

--- a/src/rust/runtime/network/types/portnum.rs
+++ b/src/rust/runtime/network/types/portnum.rs
@@ -21,9 +21,7 @@ pub struct Port16(NonZeroU16);
 // Associate Functions
 //======================================================================================================================
 
-/// Associate Functions for Port Numbers
 impl Port16 {
-    /// Instantiates a port number.
     pub fn new(num: NonZeroU16) -> Self {
         Self { 0: num }
     }
@@ -33,19 +31,15 @@ impl Port16 {
 // Trait Implementations
 //======================================================================================================================
 
-/// From Trait Implementation for Port Numbers
 impl From<Port16> for u16 {
-    /// Converts the target [Port16] into a [u16].
     fn from(val: Port16) -> Self {
         u16::from(val.0)
     }
 }
 
-/// Try From Trait Implementation for Port Numbers
 impl TryFrom<u16> for Port16 {
     type Error = Fail;
 
-    /// Tries to convert the target [Port16] into a [u16].
     fn try_from(n: u16) -> Result<Self, Fail> {
         Ok(Port16(
             NonZeroU16::new(n).ok_or(Fail::new(ERANGE, "port number may not be zero"))?,


### PR DESCRIPTION
Cleaned up unnecessary and redundant comments which just explain what the accompanying code does. Such comments only add to visual clutter and more lines to the source code files.

Renamed a few variables for clarity and better code flow while reading.