### PR TITLE
[testing] Enhancement: Two new tests for pop

### DIFF
--- a/network_simulator/input/tcp/pop/pop-reordering.pkt
+++ b/network_simulator/input/tcp/pop/pop-reordering.pkt
@@ -1,0 +1,41 @@
+// Test for a packet received out of order.
+
+// Accept a connection.
+ +.0 socket(..., SOCK_STREAM, IPPROTO_TCP) = 500
++.0 bind(500, ..., ...) = 0
++.0 listen(500, 1) = 0
++.2 accept(500, ..., ...) = 0
+
+// Receive SYN packet.
++.2 TCP < S seq 0(0) win 65535 <mss 1450,wscale 0>
+// Send SYN-ACK packet.
++.0 TCP > S. seq 0(0) ack 1 win 65535 <mss 1450,wscale 0>
+// Receive ACK on SYN-ACK packet.
++.2 TCP < . seq 1(0) ack 1 win 65535 <nop>
+
+// Succeed to accept connection.
++.0 wait(500, ...) = 0
+
+// Read data.
++.1 read(501, ..., 1000) = 1000
+
+// Receive out of order data packet.
++.1 TCP < P. seq 1001(1000) ack 1 win 65535 <nop>
+
+// Send ACK packet.
++.0 TCP > . seq 1(0) ack 1 win 65535 <nop>
+
+// Receive in order data packet.
++.1 TCP < P. seq 1(1000) ack 1 win 65535 <nop>
+
+// Data read.
++.0 wait(501, ...) = 0
+
+// Send ACK packet
++.6 TCP > . seq 1(0) ack 2001 win 63535 <nop>
+
+// Read data.
++.1 read(501, ..., 1000) = 1000
+
+// Data read.
++.0 wait(501, ...) = 0

--- a/network_simulator/input/tcp/pop/pop-retransmission.pkt
+++ b/network_simulator/input/tcp/pop/pop-retransmission.pkt
@@ -1,0 +1,33 @@
+// Test for blocking pop with duplicate packet.
+
+// Accept a connection.
+ +.0 socket(..., SOCK_STREAM, IPPROTO_TCP) = 500
++.0 bind(500, ..., ...) = 0
++.0 listen(500, 1) = 0
++.2 accept(500, ..., ...) = 0
+
+// Receive SYN packet.
++.2 TCP < S seq 0(0) win 65535 <mss 1450,wscale 0>
+// Send SYN-ACK packet.
++.0 TCP > S. seq 0(0) ack 1 win 65535 <mss 1450,wscale 0>
+// Receive ACK on SYN-ACK packet.
++.2 TCP < . seq 1(0) ack 1 win 65535 <nop>
+
+// Succeed to accept connection.
++.0 wait(500, ...) = 0
+
+// Read data.
++.1 read(501, ..., 1000) = 1000
+
+// Receive data packet.
++.1 TCP < P. seq 1(1000) ack 1 win 65535 <nop>
+
+// Data read.
++.0 wait(501, ...) = 0
+
+// Receive data packet again.
++.1 TCP < P. seq 1(1000) ack 1 win 65535 <nop>
+
+// Send ACK packet.
++.0 TCP > . seq 1(0) ack 1001 win 65535 <nop>
+


### PR DESCRIPTION
This PR adds two basic tests for pop:
1. A duplicate packet arrives before the ack goes out.
2. A packet arrives out of order before the previous packet or the ack (and causing an ack).