### PR TITLE
[collections] Bug Fix: Increasing arbitrary timeout

### DIFF
--- a/src/rust/collections/async_queue.rs
+++ b/src/rust/collections/async_queue.rs
@@ -20,7 +20,7 @@ use ::std::{
 //======================================================================================================================
 
 // The following value was chosen arbitrarily.
-const TIMEOUT_MILLISECONDS: Duration = Duration::from_secs(120);
+const TIMEOUT_SECONDS: Duration = Duration::from_secs(1000);
 
 //======================================================================================================================
 // Structures
@@ -72,7 +72,7 @@ impl<T> AsyncQueue<T> {
                 }
             }
         };
-        conditional_yield_with_timeout(wait_condition, timeout.unwrap_or(TIMEOUT_MILLISECONDS)).await
+        conditional_yield_with_timeout(wait_condition, timeout.unwrap_or(TIMEOUT_SECONDS)).await
     }
 
     /// Try to get the head of the queue.

--- a/src/rust/collections/async_value.rs
+++ b/src/rust/collections/async_value.rs
@@ -19,7 +19,7 @@ use ::std::{
 //======================================================================================================================
 
 /// Default timeout for an AynscQueue This was chosen arbitrarily.
-const TIMEOUT_SECONDS: Duration = Duration::from_secs(120);
+const TIMEOUT_SECONDS: Duration = Duration::from_secs(1000);
 
 //======================================================================================================================
 // Structures


### PR DESCRIPTION
This PR increases an arbitrary timeout in our data structures to keep our slower libOSes from timing out.