### PR TITLE
[catpowder] Support NetVSC/VF dual NIC in hyper-V VMs

### DIFF
--- a/scripts/config/default.yaml
+++ b/scripts/config/default.yaml
@@ -7,6 +7,8 @@ demikernel:
 raw_socket:
   linux_interface_name: "abcde"
   xdp_interface_index: 0
+  # Enable the following line if you have a VF interface
+  # xdp_vf_interface_index: 0
 dpdk:
   eal_init: ["", "-c", "0xff", "-n", "4", "-a", "WW:WW.W","--proc-type=auto"]
 tcp_socket_options:

--- a/src/rust/demikernel/config.rs
+++ b/src/rust/demikernel/config.rs
@@ -60,8 +60,15 @@ mod raw_socket_config {
     pub const SECTION_NAME: &str = "raw_socket";
     #[cfg(target_os = "linux")]
     pub const LOCAL_INTERFACE_NAME: &str = "linux_interface_name";
+
+    // The primary interface index. This should be the virtualized interface for VMs.
     #[cfg(target_os = "windows")]
     pub const LOCAL_INTERFACE_INDEX: &str = "xdp_interface_index";
+
+    // N.B. hyper-V VMs can have both NetVSC and VF interfaces working in tandem, in which case
+    // we need to listen to the corresponding VF interface as well.
+    #[cfg(target_os = "windows")]
+    pub const LOCAL_VF_INTERFACE_INDEX: &str = "xdp_vf_interface_index";
 }
 
 //======================================================================================================================
@@ -289,6 +296,18 @@ impl Config {
             Ok(addr)
         } else {
             Self::get_int_option(self.get_raw_socket_config()?, raw_socket_config::LOCAL_INTERFACE_INDEX)
+        }
+    }
+
+    #[cfg(all(feature = "catpowder-libos", target_os = "windows"))]
+    pub fn local_vf_interface_index(&self) -> Result<u32, Fail> {
+        if let Some(addr) = Self::get_typed_env_option(raw_socket_config::LOCAL_VF_INTERFACE_INDEX)? {
+            Ok(addr)
+        } else {
+            Self::get_int_option(
+                self.get_raw_socket_config()?,
+                raw_socket_config::LOCAL_VF_INTERFACE_INDEX,
+            )
         }
     }
 


### PR DESCRIPTION
### Motivation
On certain Hyper-V provisioned VMs, there're two NICs, one NetVSC, another VF. They can share same MAC address to act as single device from external point of view. Because VF is faster, it may be used to optimize data plane performance, while NetVSC is used for control plane. This is transparent to application layer if networking stack is done within the kernel. However, XDP bypasses the kernel, so we have to deal with it manually. This change would allow user to configure two interfaces for XDP to attach to and poll, as incoming packets could come from either the VF or the NetVSC.