### PR TITLE
[inetstack] Enhancement: replace immediate send

### DIFF
--- a/src/rust/inetstack/protocols/layer4/tcp/established/ctrlblk.rs
+++ b/src/rust/inetstack/protocols/layer4/tcp/established/ctrlblk.rs
@@ -802,7 +802,8 @@ impl SharedControlBlock {
     }
 
     pub async fn push(&mut self, buf: DemiBuffer) -> Result<(), Fail> {
-        self.sender.push(buf).await
+        let cb: Self = self.clone();
+        self.sender.push(buf, cb).await
     }
 
     pub async fn pop(&mut self, size: Option<usize>) -> Result<DemiBuffer, Fail> {


### PR DESCRIPTION
This PR places back the immediate send path that use to exist for inlining a send if the send window is open.