### PR TITLE
[runtime] Enhancement: Add some reasonable defaults

### DIFF
--- a/src/rust/collections/async_queue.rs
+++ b/src/rust/collections/async_queue.rs
@@ -14,14 +14,6 @@ use ::std::{
     ops::{Deref, DerefMut},
     time::Duration,
 };
-
-//======================================================================================================================
-// Constants
-//======================================================================================================================
-
-// The following value was chosen arbitrarily.
-const TIMEOUT_SECONDS: Duration = Duration::from_secs(1000);
-
 //======================================================================================================================
 // Structures
 //======================================================================================================================
@@ -72,7 +64,10 @@ impl<T> AsyncQueue<T> {
                 }
             }
         };
-        conditional_yield_with_timeout(wait_condition, timeout.unwrap_or(TIMEOUT_SECONDS)).await
+        match timeout {
+            Some(timeout) => conditional_yield_with_timeout(wait_condition, timeout).await,
+            None => Ok(wait_condition.await),
+        }
     }
 
     /// Try to get the head of the queue.

--- a/src/rust/collections/async_queue.rs
+++ b/src/rust/collections/async_queue.rs
@@ -14,6 +14,14 @@ use ::std::{
     ops::{Deref, DerefMut},
     time::Duration,
 };
+
+//======================================================================================================================
+// Constants
+//======================================================================================================================
+
+// The following value was chosen arbitrarily.
+const DEFAULT_QUEUE_SIZE: usize = 1024;
+
 //======================================================================================================================
 // Structures
 //======================================================================================================================
@@ -124,7 +132,7 @@ impl<T> SharedAsyncQueue<T> {
 impl<T> Default for AsyncQueue<T> {
     fn default() -> Self {
         Self {
-            queue: VecDeque::<T>::default(),
+            queue: VecDeque::<T>::with_capacity(DEFAULT_QUEUE_SIZE),
             cond_var: SharedConditionVariable::default(),
         }
     }

--- a/src/rust/collections/async_value.rs
+++ b/src/rust/collections/async_value.rs
@@ -15,13 +15,6 @@ use ::std::{
 };
 
 //======================================================================================================================
-// Constants
-//======================================================================================================================
-
-/// Default timeout for an AynscQueue This was chosen arbitrarily.
-const TIMEOUT_SECONDS: Duration = Duration::from_secs(1000);
-
-//======================================================================================================================
 // Structures
 //======================================================================================================================
 
@@ -69,7 +62,11 @@ impl<T: Clone> AsyncValue<T> {
     }
 
     pub async fn wait_for_change(&mut self, timeout: Option<Duration>) -> Result<T, Fail> {
-        conditional_yield_with_timeout(self.cond_var.wait(), timeout.unwrap_or(TIMEOUT_SECONDS)).await?;
+        match timeout {
+            Some(timeout) => conditional_yield_with_timeout(self.cond_var.wait(), timeout).await?,
+            None => self.cond_var.wait().await,
+        };
+
         Ok(self.value.clone())
     }
 

--- a/src/rust/runtime/network/socket/state.rs
+++ b/src/rust/runtime/network/socket/state.rs
@@ -10,14 +10,6 @@ use crate::{
     runtime::{fail::Fail, network::socket::operation::SocketOp},
 };
 use ::socket2::Type;
-use ::std::time::Duration;
-
-//======================================================================================================================
-// Structures
-//======================================================================================================================
-
-/// Set the timeout to be large enough that we effectively never time out.
-const TIMEOUT: Duration = Duration::from_secs(1000);
 
 //======================================================================================================================
 // Structures
@@ -77,8 +69,8 @@ impl SocketStateMachine {
         loop {
             match self.may_accept() {
                 Ok(()) => {
-                    // If either a time out or the current state changed, check it again.
-                    _ = self.current.clone().wait_for_change(Some(TIMEOUT)).await;
+                    // Check state again if it changes.
+                    _ = self.current.clone().wait_for_change(None).await;
                     continue;
                 },
                 Err(e) => return e,
@@ -96,8 +88,8 @@ impl SocketStateMachine {
         loop {
             match self.may_connect() {
                 Ok(()) => {
-                    // If either a time out or the current state changed, check it again.
-                    _ = self.current.clone().wait_for_change(Some(TIMEOUT)).await;
+                    // Check state again if it changes.
+                    _ = self.current.clone().wait_for_change(None).await;
                     continue;
                 },
                 Err(e) => return e,
@@ -122,8 +114,8 @@ impl SocketStateMachine {
         loop {
             match self.may_push() {
                 Ok(()) => {
-                    // If either a time out or the current state changed, check it again.
-                    _ = self.current.clone().wait_for_change(Some(TIMEOUT)).await;
+                    // Check state again if it changes.
+                    _ = self.current.clone().wait_for_change(None).await;
                     continue;
                 },
                 Err(e) => return e,
@@ -150,8 +142,8 @@ impl SocketStateMachine {
         loop {
             match self.may_pop() {
                 Ok(()) => {
-                    // If either a time out or the current state changed, check it again.
-                    _ = self.current.clone().wait_for_change(Some(TIMEOUT)).await;
+                    // Check state again if it changes.
+                    _ = self.current.clone().wait_for_change(None).await;
                     continue;
                 },
                 Err(e) => return e,


### PR DESCRIPTION
This PR removes some defaults and adds others:
1. It removes the default timeout values for asynchronous queues and values. This reduces the number of timers that we need to set and then cancel. If None is passed in, now we wait forever instead of for 1000 seconds.
2. It adds a default size for the AsyncQueue and condition variable vecdeque because increasing the size of these for the first few elements is very expensive and hurts tail latency.