### PR TITLE
[inetstack] Remove some dead code

### DIFF
--- a/src/rust/inetstack/protocols/layer4/tcp/established/ctrlblk.rs
+++ b/src/rust/inetstack/protocols/layer4/tcp/established/ctrlblk.rs
@@ -28,9 +28,8 @@ use crate::{
         network::{config::TcpConfig, socket::option::TcpSocketOptions},
         yield_with_timeout, SharedDemiRuntime, SharedObject,
     },
-    QDesc,
 };
-use ::futures::{channel::mpsc, never::Never, pin_mut, FutureExt};
+use ::futures::{never::Never, pin_mut, FutureExt};
 use ::std::{
     net::{Ipv4Addr, SocketAddrV4},
     ops::{Deref, DerefMut},
@@ -386,7 +385,7 @@ impl SharedControlBlock {
         Ok(())
     }
 
-    pub async fn background(&self, _dead_socket_tx: mpsc::UnboundedSender<QDesc>) {
+    pub async fn background(&self) {
         let acknowledger = async_timer!(
             "tcp::established::background::acknowledger",
             self.clone().background_acknowledger()

--- a/src/rust/inetstack/protocols/layer4/tcp/established/mod.rs
+++ b/src/rust/inetstack/protocols/layer4/tcp/established/mod.rs
@@ -20,11 +20,11 @@ use crate::{
         fail::Fail,
         memory::DemiBuffer,
         network::{config::TcpConfig, socket::option::TcpSocketOptions},
-        QDesc, SharedDemiRuntime,
+        SharedDemiRuntime,
     },
     QToken,
 };
-use ::futures::{channel::mpsc, FutureExt};
+use ::futures::FutureExt;
 use ::std::{
     net::{Ipv4Addr, SocketAddrV4},
     time::Duration,
@@ -61,7 +61,6 @@ impl EstablishedSocket {
         sender_mss: usize,
         cc_constructor: CongestionControlConstructor,
         congestion_control_options: Option<congestion_control::Options>,
-        dead_socket_tx: mpsc::UnboundedSender<QDesc>,
     ) -> Result<Self, Fail> {
         // TODO: Maybe add the queue descriptor here.
         let cb = SharedControlBlock::new(
@@ -87,7 +86,7 @@ impl EstablishedSocket {
         let cb2: SharedControlBlock = cb.clone();
         let qt: QToken = runtime.insert_background_coroutine(
             "bgc::inetstack::tcp::established::background",
-            Box::pin(async move { cb2.background(dead_socket_tx).await }.fuse()),
+            Box::pin(async move { cb2.background().await }.fuse()),
         )?;
         Ok(Self {
             cb,

--- a/src/rust/inetstack/protocols/layer4/tcp/passive_open.rs
+++ b/src/rust/inetstack/protocols/layer4/tcp/passive_open.rs
@@ -30,10 +30,10 @@ use crate::{
         fail::Fail,
         memory::DemiBuffer,
         network::{config::TcpConfig, consts::MAX_WINDOW_SCALE, socket::option::TcpSocketOptions},
-        QDesc, SharedDemiRuntime, SharedObject,
+        SharedDemiRuntime, SharedObject,
     },
 };
-use ::futures::{channel::mpsc, FutureExt};
+use ::futures::FutureExt;
 use ::libc::{EBADMSG, ETIMEDOUT};
 use ::std::{
     collections::HashMap,
@@ -68,7 +68,6 @@ pub struct PassiveSocket {
     tcp_config: TcpConfig,
     // We do not use these right now, but will in the future.
     socket_options: TcpSocketOptions,
-    dead_socket_tx: mpsc::UnboundedSender<QDesc>,
 }
 
 #[derive(Clone)]
@@ -86,7 +85,6 @@ impl SharedPassiveSocket {
         layer3_endpoint: SharedLayer3Endpoint,
         tcp_config: TcpConfig,
         default_socket_options: TcpSocketOptions,
-        dead_socket_tx: mpsc::UnboundedSender<QDesc>,
         nonce: u32,
     ) -> Result<Self, Fail> {
         Ok(Self(SharedObject::<PassiveSocket>::new(PassiveSocket {
@@ -100,7 +98,6 @@ impl SharedPassiveSocket {
             layer3_endpoint,
             tcp_config,
             socket_options: default_socket_options,
-            dead_socket_tx,
         })))
     }
 
@@ -439,7 +436,6 @@ impl SharedPassiveSocket {
             mss,
             congestion_control::None::new,
             None,
-            self.dead_socket_tx.clone(),
         )?;
 
         Ok(new_socket)

--- a/src/rust/inetstack/protocols/layer4/tcp/peer.rs
+++ b/src/rust/inetstack/protocols/layer4/tcp/peer.rs
@@ -21,10 +21,9 @@ use crate::{
                 SocketId,
             },
         },
-        QDesc, SharedDemiRuntime, SharedObject,
+        SharedDemiRuntime, SharedObject,
     },
 };
-use ::futures::channel::mpsc;
 use ::rand::{prelude::SmallRng, Rng, SeedableRng};
 
 use ::std::{
@@ -45,7 +44,6 @@ pub struct TcpPeer {
     tcp_config: TcpConfig,
     default_socket_options: TcpSocketOptions,
     rng: SmallRng,
-    dead_socket_tx: mpsc::UnboundedSender<QDesc>,
     addresses: HashMap<SocketId, SharedTcpSocket>,
 }
 
@@ -65,7 +63,6 @@ impl SharedTcpPeer {
     ) -> Result<Self, Fail> {
         let mut rng: SmallRng = SmallRng::from_seed(rng_seed);
         let nonce: u32 = rng.gen();
-        let (tx, _) = mpsc::unbounded();
         Ok(Self(SharedObject::<TcpPeer>::new(TcpPeer {
             isn_generator: IsnGenerator::new(nonce),
             runtime,
@@ -74,7 +71,6 @@ impl SharedTcpPeer {
             tcp_config: TcpConfig::new(config)?,
             default_socket_options: TcpSocketOptions::new(config)?,
             rng,
-            dead_socket_tx: tx,
             addresses: HashMap::<SocketId, SharedTcpSocket>::new(),
         })))
     }
@@ -86,7 +82,6 @@ impl SharedTcpPeer {
             self.layer3_endpoint.clone(),
             self.tcp_config.clone(),
             self.default_socket_options.clone(),
-            self.dead_socket_tx.clone(),
         ))
     }
 

--- a/src/rust/inetstack/protocols/layer4/tcp/socket.rs
+++ b/src/rust/inetstack/protocols/layer4/tcp/socket.rs
@@ -24,10 +24,9 @@ use crate::{
                 SocketId,
             },
         },
-        QDesc, SharedDemiRuntime, SharedObject,
+        SharedDemiRuntime, SharedObject,
     },
 };
-use ::futures::channel::mpsc;
 use ::std::{
     fmt::Debug,
     net::{Ipv4Addr, SocketAddrV4},
@@ -58,7 +57,6 @@ pub struct TcpSocket {
     layer3_endpoint: SharedLayer3Endpoint,
     tcp_config: TcpConfig,
     socket_options: TcpSocketOptions,
-    dead_socket_tx: mpsc::UnboundedSender<QDesc>,
 }
 
 pub struct SharedTcpSocket(SharedObject<TcpSocket>);
@@ -74,7 +72,6 @@ impl SharedTcpSocket {
         layer3_endpoint: SharedLayer3Endpoint,
         tcp_config: TcpConfig,
         default_socket_options: TcpSocketOptions,
-        dead_socket_tx: mpsc::UnboundedSender<QDesc>,
     ) -> Self {
         Self(SharedObject::<TcpSocket>::new(TcpSocket {
             state: SocketState::Unbound,
@@ -82,7 +79,6 @@ impl SharedTcpSocket {
             layer3_endpoint,
             tcp_config,
             socket_options: default_socket_options,
-            dead_socket_tx,
         }))
     }
 
@@ -92,7 +88,6 @@ impl SharedTcpSocket {
         layer3_endpoint: SharedLayer3Endpoint,
         tcp_config: TcpConfig,
         default_socket_options: TcpSocketOptions,
-        dead_socket_tx: mpsc::UnboundedSender<QDesc>,
     ) -> Self {
         Self(SharedObject::<TcpSocket>::new(TcpSocket {
             state: SocketState::Established(socket),
@@ -100,7 +95,6 @@ impl SharedTcpSocket {
             layer3_endpoint,
             tcp_config,
             socket_options: default_socket_options,
-            dead_socket_tx,
         }))
     }
 
@@ -157,7 +151,6 @@ impl SharedTcpSocket {
             self.layer3_endpoint.clone(),
             self.tcp_config.clone(),
             self.socket_options.clone(),
-            self.dead_socket_tx.clone(),
             nonce,
         )?;
         self.state = SocketState::Listening(passive_socket);
@@ -178,7 +171,6 @@ impl SharedTcpSocket {
             self.layer3_endpoint.clone(),
             self.tcp_config.clone(),
             self.socket_options.clone(),
-            self.dead_socket_tx.clone(),
         );
         Ok(new_queue)
     }
@@ -198,7 +190,6 @@ impl SharedTcpSocket {
             self.layer3_endpoint.clone(),
             self.tcp_config.clone(),
             self.socket_options.clone(),
-            self.dead_socket_tx.clone(),
         )?;
         self.state = SocketState::Connecting(socket.clone());
         let new_socket = socket.connect().await?;


### PR DESCRIPTION
We do not use the dead_socket transmission channel any more, so this PR removes it.