### PR TITLE
[inetstack] Enhancement: Remove circular dependencies

### DIFF
--- a/src/rust/inetstack/protocols/layer4/tcp/active_open.rs
+++ b/src/rust/inetstack/protocols/layer4/tcp/active_open.rs
@@ -14,7 +14,7 @@ use crate::{
             constants::{FALLBACK_MSS, MAX_WINDOW_SCALE},
             established::{
                 congestion_control::{self, CongestionControl},
-                EstablishedSocket,
+                SharedEstablishedSocket,
             },
             header::{TcpHeader, TcpOptions2},
             SeqNumber,
@@ -91,7 +91,7 @@ impl SharedActiveOpenSocket {
         })))
     }
 
-    fn process_ack(&mut self, header: TcpHeader) -> Result<EstablishedSocket, Fail> {
+    fn process_ack(&mut self, header: TcpHeader) -> Result<SharedEstablishedSocket, Fail> {
         let expected_seq: SeqNumber = self.local_isn + SeqNumber::from(1);
 
         // Bail if we didn't receive a ACK packet with the right sequence number.
@@ -191,7 +191,7 @@ impl SharedActiveOpenSocket {
             "Window scale: local {}, remote {}",
             local_window_scale, remote_window_scale
         );
-        Ok(EstablishedSocket::new(
+        Ok(SharedEstablishedSocket::new(
             self.local,
             self.remote,
             self.runtime.clone(),
@@ -212,7 +212,7 @@ impl SharedActiveOpenSocket {
         )?)
     }
 
-    pub async fn connect(mut self) -> Result<EstablishedSocket, Fail> {
+    pub async fn connect(mut self) -> Result<SharedEstablishedSocket, Fail> {
         // Start connection handshake.
         let handshake_retries: usize = self.tcp_config.get_handshake_retries();
         let handshake_timeout = self.tcp_config.get_handshake_timeout();

--- a/src/rust/inetstack/protocols/layer4/tcp/established/ctrlblk.rs
+++ b/src/rust/inetstack/protocols/layer4/tcp/established/ctrlblk.rs
@@ -6,35 +6,10 @@
 //======================================================================================================================
 
 use crate::{
-    async_timer,
-    collections::{async_queue::SharedAsyncQueue, async_value::SharedAsyncValue},
-    inetstack::protocols::{
-        layer3::SharedLayer3Endpoint,
-        layer4::tcp::{
-            constants::MSL,
-            established::{
-                congestion_control::{self, CongestionControlConstructor},
-                receiver::Receiver,
-                sender::Sender,
-            },
-            header::TcpHeader,
-            SeqNumber,
-        },
-        MAX_HEADER_SIZE,
-    },
-    runtime::{
-        fail::Fail,
-        memory::DemiBuffer,
-        network::{config::TcpConfig, socket::option::TcpSocketOptions},
-        yield_with_timeout, SharedDemiRuntime, SharedObject,
-    },
+    inetstack::protocols::layer4::tcp::{established::congestion_control, established::Receiver, established::Sender},
+    runtime::network::{config::TcpConfig, socket::option::TcpSocketOptions},
 };
-use ::futures::{never::Never, pin_mut, FutureExt};
-use ::std::{
-    net::{Ipv4Addr, SocketAddrV4},
-    ops::{Deref, DerefMut},
-    time::{Duration, Instant},
-};
+use ::std::net::SocketAddrV4;
 
 //======================================================================================================================
 // Structures
@@ -43,6 +18,8 @@ use ::std::{
 // TCP Connection State.
 // Note: This ControlBlock structure is only used after we've reached the ESTABLISHED state, so states LISTEN,
 // SYN_RCVD, and SYN_SENT aren't included here.
+// This struct has only public members because includes state for both the send and receive path and is accessed by
+// both.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum State {
     Established,
@@ -56,392 +33,53 @@ pub enum State {
 }
 
 //======================================================================================================================
-// Control Block
+// Data Structures
 //======================================================================================================================
 
 /// Transmission control block for representing our TCP connection.
 pub struct ControlBlock {
-    local: SocketAddrV4,
-    remote: SocketAddrV4,
+    pub local: SocketAddrV4,
+    pub remote: SocketAddrV4,
 
-    layer3_endpoint: SharedLayer3Endpoint,
-    runtime: SharedDemiRuntime,
-    tcp_config: TcpConfig,
-    socket_options: TcpSocketOptions,
+    pub tcp_config: TcpConfig,
+    pub socket_options: TcpSocketOptions,
 
     // TCP Connection State.
-    state: State,
+    pub state: State,
 
-    // Send Sequence Variables from RFC 793.
-
-    // SND.UNA - send unacknowledged
-    // SND.NXT - send next
-    // SND.WND - send window
-    // SND.UP  - send urgent pointer - not implemented
-    // SND.WL1 - segment sequence number used for last window update
-    // SND.WL2 - segment acknowledgment number used for last window
-    //           update
-    // ISS     - initial send sequence number
-
-    // Send queues
-    // SND.retrasmission_queue - queue of unacknowledged sent data.
-    // SND.unsent - queue of unsent data that we do not have the windows for.
-    // Previous send variables and queues.
-    // TODO: Consider incorporating this directly into ControlBlock.
-    sender: Sender,
-    // Receive Sequence Variables from RFC 793.
-
-    // RCV.NXT - receive next
-    // RCV.WND - receive window
-    // RCV.UP  - receive urgent pointer - not implemented
-    // IRS     - initial receive sequence number
-    // Receive-side state information.  TODO: Consider incorporating this directly into ControlBlock.
-    receiver: Receiver,
+    // TCP send path state.
+    pub sender: Sender,
+    // TCP receive path state.
+    pub receiver: Receiver,
 
     // Congestion control trait implementation we're currently using.
     // TODO: Consider switching this to a static implementation to avoid V-table call overhead.
-    congestion_control_algorithm: Box<dyn congestion_control::CongestionControl>,
+    pub congestion_control_algorithm: Box<dyn congestion_control::CongestionControl>,
 }
 
-#[derive(Clone)]
-pub struct SharedControlBlock(SharedObject<ControlBlock>);
+//======================================================================================================================
+// Associated Functions
 //======================================================================================================================
 
-impl SharedControlBlock {
+impl ControlBlock {
     pub fn new(
         local: SocketAddrV4,
         remote: SocketAddrV4,
-        layer3_endpoint: SharedLayer3Endpoint,
-        runtime: SharedDemiRuntime,
         tcp_config: TcpConfig,
-        default_socket_options: TcpSocketOptions,
-        // In RFC 793, this is IRS.
-        receive_initial_seq_no: SeqNumber,
-        receive_ack_delay_timeout_secs: Duration,
-        receive_window_size_frames: u32,
-        receive_window_scale_shift_bits: u8,
-        // In RFC 793, this ISS.
-        sender_initial_seq_no: SeqNumber,
-        send_window_size_frames: u32,
-        send_window_scale_shift_bits: u8,
-        sender_mss: usize,
-        congestion_control_algorithm_constructor: CongestionControlConstructor,
-        congestion_control_options: Option<congestion_control::Options>,
-        mut recv_queue: SharedAsyncQueue<(Ipv4Addr, TcpHeader, DemiBuffer)>,
+        socket_options: TcpSocketOptions,
+        sender: Sender,
+        receiver: Receiver,
+        congestion_control_algorithm: Box<dyn congestion_control::CongestionControl>,
     ) -> Self {
-        let sender: Sender = Sender::new(
-            sender_initial_seq_no,
-            send_window_size_frames,
-            send_window_scale_shift_bits,
-            sender_mss,
-        );
-        let receiver: Receiver = Receiver::new(
-            receive_initial_seq_no,
-            receive_initial_seq_no,
-            receive_ack_delay_timeout_secs,
-            receive_window_size_frames,
-            receive_window_scale_shift_bits,
-        );
-        let congestion_control_algorithm =
-            congestion_control_algorithm_constructor(sender_mss, sender_initial_seq_no, congestion_control_options);
-        let mut self_: Self = Self(SharedObject::<ControlBlock>::new(ControlBlock {
+        Self {
             local,
             remote,
-            layer3_endpoint,
-            runtime,
             tcp_config,
-            socket_options: default_socket_options,
-            sender,
+            socket_options,
             state: State::Established,
+            sender,
             receiver,
             congestion_control_algorithm,
-        }));
-        trace!("receive_queue size {:?}", recv_queue.len());
-        // Process all pending received packets while setting up the connection.
-        while let Some((_ipv4_addr, header, data)) = recv_queue.try_pop() {
-            self_.receive(header, data);
         }
-
-        self_
-    }
-
-    pub fn get_local(&self) -> SocketAddrV4 {
-        self.local
-    }
-
-    pub fn get_remote(&self) -> SocketAddrV4 {
-        self.remote
-    }
-
-    pub fn get_now(&self) -> Instant {
-        self.runtime.get_now()
-    }
-
-    pub fn receive(&mut self, tcp_hdr: TcpHeader, buf: DemiBuffer) {
-        debug!(
-            "{:?} Connection Receiving {} bytes + {:?}",
-            self.state,
-            buf.len(),
-            tcp_hdr,
-        );
-
-        let cb: Self = self.clone();
-        let now: Instant = self.runtime.get_now();
-        self.receiver.receive(tcp_hdr, buf, cb, now);
-    }
-
-    pub fn congestion_control_watch_retransmit_now_flag(&self) -> SharedAsyncValue<bool> {
-        self.congestion_control_algorithm.get_retransmit_now_flag()
-    }
-
-    pub fn congestion_control_on_fast_retransmit(&mut self) {
-        self.congestion_control_algorithm.on_fast_retransmit()
-    }
-
-    pub fn congestion_control_on_rto(&mut self, send_unacknowledged: SeqNumber) {
-        self.congestion_control_algorithm.on_rto(send_unacknowledged)
-    }
-
-    pub fn congestion_control_on_send(&mut self, rto: Duration, num_sent_bytes: u32) {
-        self.congestion_control_algorithm.on_send(rto, num_sent_bytes)
-    }
-
-    pub fn congestion_control_on_cwnd_check_before_send(&mut self) {
-        self.congestion_control_algorithm.on_cwnd_check_before_send()
-    }
-
-    pub fn congestion_control_get_cwnd(&self) -> SharedAsyncValue<u32> {
-        self.congestion_control_algorithm.get_cwnd()
-    }
-
-    pub fn congestion_control_get_limited_transmit_cwnd_increase(&self) -> SharedAsyncValue<u32> {
-        self.congestion_control_algorithm.get_limited_transmit_cwnd_increase()
-    }
-
-    pub fn process_ack(&mut self, header: &TcpHeader, now: Instant) -> Result<(), Fail> {
-        let send_unacknowledged: SeqNumber = self.sender.get_unacked_seq_no();
-        let send_next: SeqNumber = self.sender.get_next_seq_no();
-
-        // TODO: Restructure this call into congestion control to either integrate it directly or make it more fine-
-        // grained.  It currently duplicates the new/duplicate ack check itself internally, which is inefficient.
-        // We should either make separate calls for each case or integrate those cases directly.
-        let rto: Duration = self.sender.get_rto();
-
-        self.congestion_control_algorithm
-            .on_ack_received(rto, send_unacknowledged, send_next, header.ack_num);
-
-        // Check whether this is an ack for data that we have sent.
-        if header.ack_num <= send_next {
-            // Does not matter when we get this since the clock will not move between the beginning of packet
-            // processing and now without a call to advance_clock.
-            self.sender.process_ack(header, now);
-        } else {
-            // This segment acknowledges data we have yet to send!?  Send an ACK and drop the segment.
-            // TODO: See RFC 5961, this could be a Blind Data Injection Attack.
-            let cause: String = format!("Received segment acknowledging data we have yet to send!");
-            warn!("process_ack(): {}", cause);
-            self.send_ack();
-            return Err(Fail::new(libc::EBADMSG, &cause));
-        }
-        Ok(())
-    }
-
-    pub fn get_unacked_seq_no(&self) -> SeqNumber {
-        self.sender.get_unacked_seq_no()
-    }
-
-    /// Fetch a TCP header filling out various values based on our current state.
-    /// TODO: Fix the "filling out various values based on our current state" part to actually do that correctly.
-    pub fn tcp_header(&self) -> TcpHeader {
-        let mut header: TcpHeader = TcpHeader::new(self.local.port(), self.remote.port());
-        header.window_size = self.receiver.hdr_window_size();
-
-        // Note that once we reach a synchronized state we always include a valid acknowledgement number.
-        header.ack = true;
-        header.ack_num = self.receiver.receive_next_seq_no();
-
-        // Return this header.
-        header
-    }
-
-    /// Send an ACK to our peer, reflecting our current state.
-    pub fn send_ack(&mut self) {
-        trace!("sending ack");
-        let mut header: TcpHeader = self.tcp_header();
-
-        // TODO: Think about moving this to tcp_header() as well.
-        let seq_num: SeqNumber = self.sender.get_next_seq_no();
-        header.seq_num = seq_num;
-        self.emit(header, None);
-    }
-
-    /// Transmit this message to our connected peer.
-    pub fn emit(&mut self, header: TcpHeader, body: Option<DemiBuffer>) {
-        // Only perform this debug print in debug builds.  debug_assertions is compiler set in non-optimized builds.
-        let mut pkt = match body {
-            Some(body) => {
-                debug!("Sending {} bytes + {:?}", body.len(), header);
-                body
-            },
-            _ => {
-                debug!("Sending 0 bytes + {:?}", header);
-                DemiBuffer::new_with_headroom(0, MAX_HEADER_SIZE as u16)
-            },
-        };
-
-        // This routine should only ever be called to send TCP segments that contain a valid ACK value.
-        debug_assert!(header.ack);
-
-        let remote_ipv4_addr: Ipv4Addr = self.remote.ip().clone();
-        header.serialize_and_attach(
-            &mut pkt,
-            self.local.ip(),
-            self.remote.ip(),
-            self.tcp_config.get_tx_checksum_offload(),
-        );
-
-        // Call lower L3 layer to send the segment.
-        if let Err(e) = self
-            .layer3_endpoint
-            .transmit_tcp_packet_nonblocking(remote_ipv4_addr, pkt)
-        {
-            warn!("could not emit packet: {:?}", e);
-            return;
-        }
-
-        // Post-send operations follow.
-        // Review: We perform these after the send, in order to keep send latency as low as possible.
-
-        // Since we sent an ACK, cancel any outstanding delayed ACK request.
-        self.receiver.set_receive_ack_deadline(None);
-    }
-    pub async fn push(&mut self, buf: DemiBuffer) -> Result<(), Fail> {
-        let cb: Self = self.clone();
-        self.sender.push(buf, cb).await
-    }
-
-    pub async fn pop(&mut self, size: Option<usize>) -> Result<DemiBuffer, Fail> {
-        self.receiver.pop(size).await
-    }
-
-    pub fn process_fin(&mut self) {
-        let state = match self.state {
-            State::Established => State::CloseWait,
-            State::FinWait1 => State::Closing,
-            State::FinWait2 => State::TimeWait,
-            state => unreachable!("Cannot be in any other state at this point: {:?}", state),
-        };
-        self.state = state;
-    }
-
-    pub fn get_state(&self) -> State {
-        self.state
-    }
-
-    pub fn set_state(&mut self, state: State) {
-        self.state = state;
-    }
-
-    // This coroutine runs the close protocol.
-    pub async fn close(&mut self) -> Result<(), Fail> {
-        // Assert we are in a valid state and move to new state.
-        match self.state {
-            State::Established => self.local_close().await,
-            State::CloseWait => self.remote_already_closed().await,
-            _ => {
-                let cause: String = format!("socket is already closing");
-                error!("close(): {}", cause);
-                Err(Fail::new(libc::EBADF, &cause))
-            },
-        }
-    }
-
-    async fn local_close(&mut self) -> Result<(), Fail> {
-        // 1. Start close protocol by setting state and sending FIN.
-        self.state = State::FinWait1;
-        self.sender.push_fin_and_wait_for_ack().await?;
-
-        // 2. Got ACK to our FIN. Check if we also received a FIN from remote in the meantime.
-        let state: State = self.state;
-        match state {
-            State::FinWait1 => {
-                self.state = State::FinWait2;
-                // Haven't received a FIN yet from remote, so wait.
-                self.receiver.wait_for_fin().await?;
-            },
-            State::Closing => self.state = State::TimeWait,
-            state => unreachable!("Cannot be in any other state at this point: {:?}", state),
-        };
-        // 3. TIMED_WAIT
-        debug_assert_eq!(self.state, State::TimeWait);
-        trace!("socket options: {:?}", self.socket_options.get_linger());
-        let timeout: Duration = self.socket_options.get_linger().unwrap_or(MSL * 2);
-        yield_with_timeout(timeout).await;
-        self.state = State::Closed;
-        Ok(())
-    }
-
-    async fn remote_already_closed(&mut self) -> Result<(), Fail> {
-        // 0. Move state forward
-        self.state = State::LastAck;
-        // 1. Send FIN and wait for ack before closing.
-        self.sender.push_fin_and_wait_for_ack().await?;
-        self.state = State::Closed;
-        Ok(())
-    }
-
-    pub async fn background(&self) {
-        let acknowledger = async_timer!(
-            "tcp::established::background::acknowledger",
-            self.clone().background_acknowledger()
-        )
-        .fuse();
-        pin_mut!(acknowledger);
-
-        let retransmitter = async_timer!(
-            "tcp::established::background::retransmitter",
-            self.clone().background_retransmitter()
-        )
-        .fuse();
-        pin_mut!(retransmitter);
-
-        let sender = async_timer!("tcp::established::background::sender", self.clone().background_sender()).fuse();
-        pin_mut!(sender);
-
-        let r = futures::join!(acknowledger, retransmitter, sender);
-        error!("Connection terminated: {:?}", r);
-    }
-
-    pub async fn background_retransmitter(mut self) -> Result<Never, Fail> {
-        let cb: Self = self.clone();
-        self.sender.background_retransmitter(cb).await
-    }
-
-    pub async fn background_sender(mut self) -> Result<Never, Fail> {
-        let cb: Self = self.clone();
-        self.sender.background_sender(cb).await
-    }
-
-    pub async fn background_acknowledger(mut self) -> Result<Never, Fail> {
-        let cb: Self = self.clone();
-        self.receiver.acknowledger(cb).await
-    }
-}
-
-//======================================================================================================================
-// Trait Implementations
-//======================================================================================================================
-
-impl Deref for SharedControlBlock {
-    type Target = ControlBlock;
-
-    fn deref(&self) -> &Self::Target {
-        self.0.deref()
-    }
-}
-
-impl DerefMut for SharedControlBlock {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.0.deref_mut()
     }
 }

--- a/src/rust/inetstack/protocols/layer4/tcp/established/ctrlblk.rs
+++ b/src/rust/inetstack/protocols/layer4/tcp/established/ctrlblk.rs
@@ -15,11 +15,9 @@ use ::std::net::SocketAddrV4;
 // Structures
 //======================================================================================================================
 
-// TCP Connection State.
-// Note: This ControlBlock structure is only used after we've reached the ESTABLISHED state, so states LISTEN,
-// SYN_RCVD, and SYN_SENT aren't included here.
-// This struct has only public members because includes state for both the send and receive path and is accessed by
-// both.
+/// TCP Connection State.
+/// Note: This ControlBlock structure is only used after we've reached the ESTABLISHED state, so states LISTEN,
+/// SYN_RCVD, and SYN_SENT aren't included here.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum State {
     Established,
@@ -32,24 +30,16 @@ pub enum State {
     Closed,
 }
 
-//======================================================================================================================
-// Data Structures
-//======================================================================================================================
-
 /// Transmission control block for representing our TCP connection.
+/// This struct has only public members because includes state for both the send and receive path and is accessed by
+/// both.
 pub struct ControlBlock {
     pub local: SocketAddrV4,
     pub remote: SocketAddrV4,
-
     pub tcp_config: TcpConfig,
     pub socket_options: TcpSocketOptions,
-
-    // TCP Connection State.
     pub state: State,
-
-    // TCP send path state.
     pub sender: Sender,
-    // TCP receive path state.
     pub receiver: Receiver,
 
     // Congestion control trait implementation we're currently using.

--- a/src/rust/inetstack/protocols/layer4/tcp/established/mod.rs
+++ b/src/rust/inetstack/protocols/layer4/tcp/established/mod.rs
@@ -8,110 +8,227 @@ mod rto;
 mod sender;
 
 use crate::{
+    async_timer,
     collections::async_queue::SharedAsyncQueue,
     inetstack::protocols::{
         layer3::SharedLayer3Endpoint,
         layer4::tcp::{
-            congestion_control::CongestionControlConstructor, established::ctrlblk::SharedControlBlock,
-            header::TcpHeader, SeqNumber,
+            congestion_control::CongestionControlConstructor,
+            established::{ctrlblk::ControlBlock, ctrlblk::State, receiver::Receiver, sender::Sender},
+            header::TcpHeader,
+            SeqNumber,
         },
     },
     runtime::{
         fail::Fail,
         memory::DemiBuffer,
-        network::{config::TcpConfig, socket::option::TcpSocketOptions},
-        SharedDemiRuntime,
+        network::{config::TcpConfig, consts::MSL, socket::option::TcpSocketOptions},
+        yield_with_timeout, SharedDemiRuntime, SharedObject,
     },
-    QToken,
 };
+use ::futures::pin_mut;
 use ::futures::FutureExt;
 use ::std::{
     net::{Ipv4Addr, SocketAddrV4},
+    ops::{Deref, DerefMut},
     time::Duration,
+    time::Instant,
 };
 
-#[derive(Clone)]
 pub struct EstablishedSocket {
-    pub cb: SharedControlBlock,
-    // We need this to eventually stop the background task on close.
-    #[allow(unused)]
+    // All shared state for this established TCP connection.
+    cb: ControlBlock,
     runtime: SharedDemiRuntime,
-    /// The background co-routines handles various tasks, such as retransmission and acknowledging.
-    /// We annotate it as unused because the compiler believes that it is never called which is not the case.
-    #[allow(unused)]
-    background_task_qt: QToken,
+    layer3_endpoint: SharedLayer3Endpoint,
 }
 
-impl EstablishedSocket {
+#[derive(Clone)]
+pub struct SharedEstablishedSocket(SharedObject<EstablishedSocket>);
+
+impl SharedEstablishedSocket {
     pub fn new(
         local: SocketAddrV4,
         remote: SocketAddrV4,
         mut runtime: SharedDemiRuntime,
         layer3_endpoint: SharedLayer3Endpoint,
-        recv_queue: SharedAsyncQueue<(Ipv4Addr, TcpHeader, DemiBuffer)>,
+        mut recv_queue: SharedAsyncQueue<(Ipv4Addr, TcpHeader, DemiBuffer)>,
         tcp_config: TcpConfig,
         default_socket_options: TcpSocketOptions,
         receiver_seq_no: SeqNumber,
-        ack_delay_timeout: Duration,
-        receiver_window_size: u32,
-        receiver_window_scale: u8,
+        ack_delay_timeout_secs: Duration,
+        receiver_window_size_frames: u32,
+        receiver_window_scale_bits: u8,
         sender_seq_no: SeqNumber,
-        sender_window_size: u32,
-        sender_window_scale: u8,
+        sender_window_size_frames: u32,
+        sender_window_scale_bits: u8,
         sender_mss: usize,
         cc_constructor: CongestionControlConstructor,
         congestion_control_options: Option<congestion_control::Options>,
     ) -> Result<Self, Fail> {
-        // TODO: Maybe add the queue descriptor here.
-        let cb = SharedControlBlock::new(
-            local,
-            remote,
-            layer3_endpoint,
-            runtime.clone(),
-            tcp_config,
-            default_socket_options,
-            receiver_seq_no,
-            ack_delay_timeout,
-            receiver_window_size,
-            receiver_window_scale,
+        let sender: Sender = Sender::new(
             sender_seq_no,
-            sender_window_size,
-            sender_window_scale,
+            sender_window_size_frames,
+            sender_window_scale_bits,
             sender_mss,
-            cc_constructor,
-            congestion_control_options,
-            recv_queue.clone(),
+        );
+        let receiver: Receiver = Receiver::new(
+            receiver_seq_no,
+            receiver_seq_no,
+            ack_delay_timeout_secs,
+            receiver_window_size_frames,
+            receiver_window_scale_bits,
         );
 
-        let cb2: SharedControlBlock = cb.clone();
-        let qt: QToken = runtime.insert_background_coroutine(
-            "bgc::inetstack::tcp::established::background",
-            Box::pin(async move { cb2.background().await }.fuse()),
-        )?;
-        Ok(Self {
+        let congestion_control_algorithm = cc_constructor(sender_mss, sender_seq_no, congestion_control_options);
+        let cb = ControlBlock::new(
+            local,
+            remote,
+            tcp_config,
+            default_socket_options,
+            sender,
+            receiver,
+            congestion_control_algorithm,
+        );
+        let mut me: Self = Self(SharedObject::new(EstablishedSocket {
             cb,
-            background_task_qt: qt.clone(),
             runtime: runtime.clone(),
-        })
+            layer3_endpoint,
+        }));
+
+        trace!("inital receive_queue size {:?}", recv_queue.len());
+        // Process all pending received packets while setting up the connection.
+        while let Some((_ipv4_addr, header, data)) = recv_queue.try_pop() {
+            me.receive(header, data);
+        }
+        let me2: Self = me.clone();
+        runtime.insert_background_coroutine(
+            "bgc::inetstack::tcp::established::background",
+            Box::pin(async move { me2.background().await }.fuse()),
+        )?;
+        Ok(me)
+    }
+
+    pub fn receive(&mut self, tcp_hdr: TcpHeader, buf: DemiBuffer) {
+        debug!(
+            "{:?} Connection Receiving {} bytes + {:?}",
+            self.cb.state,
+            buf.len(),
+            tcp_hdr,
+        );
+
+        let now: Instant = self.runtime.get_now();
+        let mut layer3_endpoint: SharedLayer3Endpoint = self.layer3_endpoint.clone();
+        Receiver::receive(&mut self.cb, &mut layer3_endpoint, tcp_hdr, buf, now);
+    }
+
+    // This coroutine runs the close protocol.
+    pub async fn close(&mut self) -> Result<(), Fail> {
+        // Assert we are in a valid state and move to new state.
+        match self.cb.state {
+            State::Established => self.local_close().await,
+            State::CloseWait => self.remote_already_closed().await,
+            _ => {
+                let cause: String = format!("socket is already closing");
+                error!("close(): {}", cause);
+                Err(Fail::new(libc::EBADF, &cause))
+            },
+        }
+    }
+
+    async fn local_close(&mut self) -> Result<(), Fail> {
+        // 1. Start close protocol by setting state and sending FIN.
+        self.cb.state = State::FinWait1;
+        Sender::push_fin_and_wait_for_ack(&mut self.cb).await?;
+
+        // 2. Got ACK to our FIN. Check if we also received a FIN from remote in the meantime.
+        let state: State = self.cb.state;
+        match state {
+            State::FinWait1 => {
+                self.cb.state = State::FinWait2;
+                // Haven't received a FIN yet from remote, so wait.
+                self.cb.receiver.wait_for_fin().await?;
+            },
+            State::Closing => self.cb.state = State::TimeWait,
+            state => unreachable!("Cannot be in any other state at this point: {:?}", state),
+        };
+        // 3. TIMED_WAIT
+        debug_assert_eq!(self.cb.state, State::TimeWait);
+        trace!("socket options: {:?}", self.cb.socket_options.get_linger());
+        let timeout: Duration = self.cb.socket_options.get_linger().unwrap_or(MSL * 2);
+        yield_with_timeout(timeout).await;
+        self.cb.state = State::Closed;
+        Ok(())
+    }
+
+    async fn remote_already_closed(&mut self) -> Result<(), Fail> {
+        // 0. Move state forward
+        self.cb.state = State::LastAck;
+        // 1. Send FIN and wait for ack before closing.
+        Sender::push_fin_and_wait_for_ack(&mut self.cb).await?;
+        self.cb.state = State::Closed;
+        Ok(())
     }
 
     pub async fn push(&mut self, buf: DemiBuffer) -> Result<(), Fail> {
-        self.cb.push(buf).await
+        let mut runtime: SharedDemiRuntime = self.runtime.clone();
+        let mut layer3_endpoint: SharedLayer3Endpoint = self.layer3_endpoint.clone();
+        Sender::push(&mut self.cb, &mut layer3_endpoint, &mut runtime, buf).await
     }
 
     pub async fn pop(&mut self, size: Option<usize>) -> Result<DemiBuffer, Fail> {
-        self.cb.pop(size).await
-    }
-
-    pub async fn close(&mut self) -> Result<(), Fail> {
-        self.cb.close().await
+        self.cb.receiver.pop(size).await
     }
 
     pub fn endpoints(&self) -> (SocketAddrV4, SocketAddrV4) {
-        (self.cb.get_local(), self.cb.get_remote())
+        (self.cb.local, self.cb.remote)
     }
 
-    pub fn get_cb(&self) -> SharedControlBlock {
-        self.cb.clone()
+    async fn background(self) {
+        let mut me: Self = self.clone();
+        let acknowledger = async_timer!("tcp::established::background::acknowledger", async {
+            let mut layer3_endpoint: SharedLayer3Endpoint = me.layer3_endpoint.clone();
+            Receiver::acknowledger(&mut me.cb, &mut layer3_endpoint).await
+        })
+        .fuse();
+        pin_mut!(acknowledger);
+
+        let mut me2: Self = self.clone();
+        let retransmitter = async_timer!("tcp::established::background::retransmitter", async {
+            let mut layer3_endpoint: SharedLayer3Endpoint = me2.layer3_endpoint.clone();
+            let mut runtime: SharedDemiRuntime = me2.runtime.clone();
+            Sender::background_retransmitter(&mut me2.cb, &mut layer3_endpoint, &mut runtime).await
+        })
+        .fuse();
+        pin_mut!(retransmitter);
+
+        let mut me3: Self = self.clone();
+        let sender = async_timer!("tcp::established::background::sender", async {
+            let mut layer3_endpoint: SharedLayer3Endpoint = me3.layer3_endpoint.clone();
+            let mut runtime: SharedDemiRuntime = me3.runtime.clone();
+            Sender::background_sender(&mut me3.cb, &mut layer3_endpoint, &mut runtime).await
+        })
+        .fuse();
+        pin_mut!(sender);
+
+        let result = futures::join!(acknowledger, retransmitter, sender);
+        debug!("{:?}", result);
+    }
+}
+
+//======================================================================================================================
+// Trait Implementations
+//======================================================================================================================
+
+impl Deref for SharedEstablishedSocket {
+    type Target = EstablishedSocket;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.deref()
+    }
+}
+
+impl DerefMut for SharedEstablishedSocket {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.0.deref_mut()
     }
 }

--- a/src/rust/inetstack/protocols/layer4/tcp/established/sender.rs
+++ b/src/rust/inetstack/protocols/layer4/tcp/established/sender.rs
@@ -7,21 +7,24 @@
 
 use crate::{
     collections::{async_queue::SharedAsyncQueue, async_value::SharedAsyncValue},
-    inetstack::protocols::layer4::tcp::{
-        established::{rto::RtoCalculator, SharedControlBlock},
-        header::TcpHeader,
-        SeqNumber,
+    inetstack::protocols::{
+        layer3::SharedLayer3Endpoint,
+        layer4::tcp::{
+            established::{rto::RtoCalculator, ControlBlock},
+            header::TcpHeader,
+            SeqNumber,
+        },
+        MAX_HEADER_SIZE,
     },
-    runtime::{conditional_yield_until, fail::Fail, memory::DemiBuffer},
+    runtime::{conditional_yield_until, fail::Fail, memory::DemiBuffer, SharedDemiRuntime},
 };
-use ::futures::{pin_mut, select_biased, FutureExt};
+use ::futures::{never::Never, pin_mut, select_biased, FutureExt};
 use ::libc::{EBUSY, EINVAL};
 use ::std::{
-    fmt,
+    cmp, fmt,
+    net::Ipv4Addr,
     time::{Duration, Instant},
 };
-use futures::never::Never;
-use std::cmp;
 
 //======================================================================================================================
 // Data Structures
@@ -81,7 +84,7 @@ pub struct Sender {
     rto_calculator: RtoCalculator,
 
     // In RFC 793 terms, this is SND.NXT.
-    send_next_seq_no: SharedAsyncValue<SeqNumber>,
+    pub send_next_seq_no: SharedAsyncValue<SeqNumber>,
 
     // Sequence number of next data to be pushed but not sent. When there is an open window, this is equivalent to
     // send_next_seq_no.
@@ -130,397 +133,6 @@ impl Sender {
         }
     }
 
-    // This function sends a packet and waits for it to be acked.
-    pub async fn push(&mut self, mut buf: DemiBuffer, mut cb: SharedControlBlock) -> Result<(), Fail> {
-        // If the user is done sending (i.e. has called close on this connection), then they shouldn't be sending.
-        debug_assert!(self.fin_seq_no.is_none());
-        // Our API supports send buffers up to usize (variable, depends upon architecture) in size.  While we could
-        // allow for larger send buffers, it is simpler and more practical to limit a single send to 1 GiB, which is
-        // also the maximum value a TCP can advertise as its receive window (with maximum window scaling).
-        // TODO: the below check just limits a single send to 4 GiB, not 1 GiB.  Check this doesn't break anything.
-        //
-        // Review: Move this check up the stack (i.e. closer to the user)?
-        //
-        let _: u32 = buf
-            .len()
-            .try_into()
-            .map_err(|_| Fail::new(EINVAL, "buffer too large"))?;
-
-        // TODO: We need to fix this the correct way: limit our send buffer size to the amount we're willing to buffer.
-        if self.unsent_queue.len() > UNSENT_QUEUE_CUTOFF {
-            return Err(Fail::new(EBUSY, "too many packets to send"));
-        }
-
-        // Place the buffer in the unsent queue.
-        self.unsent_next_seq_no = self.unsent_next_seq_no + (buf.len() as u32).into();
-        if self.send_window.get() > 0 {
-            self.send_segment(&mut buf, &mut cb);
-        }
-        if buf.len() > 0 {
-            self.unsent_queue.push(Some(buf));
-        }
-
-        // Wait until the sequnce number of the pushed buffer is acknowledged.
-        let mut send_unacked_watched: SharedAsyncValue<SeqNumber> = self.send_unacked.clone();
-        let ack_seq_no: SeqNumber = self.unsent_next_seq_no;
-        debug_assert!(send_unacked_watched.get() < ack_seq_no);
-        while send_unacked_watched.get() < ack_seq_no {
-            send_unacked_watched.wait_for_change(None).await?;
-        }
-        Ok(())
-    }
-
-    // Places a FIN marker in the outgoing data stream. No data can be pushed after this.
-    pub async fn push_fin_and_wait_for_ack(&mut self) -> Result<(), Fail> {
-        debug_assert!(self.fin_seq_no.is_none());
-        // TODO: We need to fix this the correct way: limit our send buffer size to the amount we're willing to buffer.
-        if self.unsent_queue.len() > UNSENT_QUEUE_CUTOFF {
-            return Err(Fail::new(EBUSY, "too many packets to send"));
-        }
-
-        self.fin_seq_no = Some(self.unsent_next_seq_no);
-        self.unsent_next_seq_no = self.unsent_next_seq_no + 1.into();
-        self.unsent_queue.push(None);
-
-        let mut send_unacked_watched: SharedAsyncValue<SeqNumber> = self.send_unacked.clone();
-        let fin_ack_num: SeqNumber = self.unsent_next_seq_no;
-        while self.send_unacked.get() < fin_ack_num {
-            send_unacked_watched.wait_for_change(None).await?;
-        }
-        Ok(())
-    }
-
-    pub async fn background_sender(&mut self, mut cb: SharedControlBlock) -> Result<Never, Fail> {
-        loop {
-            // Get next bit of unsent data.
-            if let Some(buf) = self.unsent_queue.pop(None).await? {
-                self.send_buffer(buf, &mut cb).await?;
-            } else {
-                let now: Instant = cb.get_now();
-                self.send_fin(&mut cb, now)?;
-                // Exit the loop because we no longer have anything to process
-                return Err(Fail::new(libc::ECONNRESET, "Processed and sent FIN"));
-            }
-        }
-    }
-
-    fn send_fin(&mut self, cb: &mut SharedControlBlock, now: Instant) -> Result<(), Fail> {
-        let mut header: TcpHeader = cb.tcp_header();
-        header.seq_num = self.send_next_seq_no.get();
-        debug_assert!(self.fin_seq_no.is_some_and(|s| { s == header.seq_num }));
-        header.fin = true;
-        cb.emit(header, None);
-        // Update SND.NXT.
-        self.send_next_seq_no.modify(|s| s + 1.into());
-
-        // Add the FIN to our unacknowledged queue.
-        let unacked_segment = UnackedSegment {
-            bytes: None,
-            initial_tx: Some(now),
-        };
-        self.unacked_queue.push(unacked_segment);
-        // Set the retransmit timer.
-        if self.retransmit_deadline_time_secs.get().is_none() {
-            let rto: Duration = self.rto_calculator.rto();
-            trace!("set retransmit: {:?}", rto);
-            self.retransmit_deadline_time_secs.set(Some(now + rto));
-        }
-        Ok(())
-    }
-
-    async fn send_buffer(&mut self, mut buffer: DemiBuffer, cb: &mut SharedControlBlock) -> Result<(), Fail> {
-        let mut send_unacked_watched: SharedAsyncValue<SeqNumber> = self.send_unacked.clone();
-        let mut cwnd_watched: SharedAsyncValue<u32> = cb.congestion_control_get_cwnd();
-
-        // The limited transmit algorithm may increase the effective size of cwnd by up to 2 * mss.
-        let mut ltci_watched: SharedAsyncValue<u32> = cb.congestion_control_get_limited_transmit_cwnd_increase();
-        let mut win_sz_watched: SharedAsyncValue<u32> = self.send_window.clone();
-
-        // Try in a loop until we send this segment.
-        loop {
-            // If we don't have any window size at all, we need to transition to PERSIST mode and
-            // repeatedly send window probes until window opens up.
-            if win_sz_watched.get() == 0 {
-                // Send a window probe (this is a one-byte packet designed to elicit a window update from our peer).
-                self.send_window_probe(buffer.split_front(1)?, cb).await?;
-            } else {
-                // TODO: Nagle's algorithm - We need to coalese small buffers together to send MSS sized packets.
-                // TODO: Silly window syndrome - See RFC 1122's discussion of the SWS avoidance algorithm.
-
-                // We have some window, try to send some or all of the segment.
-                let _: usize = self.send_segment(&mut buffer, cb);
-                // If the buffer is now empty, then we sent all of it.
-                if buffer.len() == 0 {
-                    return Ok(());
-                }
-                // Otherwise, wait until something limiting the window changes and then try again to finish sending
-                // the segment.
-                futures::select_biased! {
-                    _ = send_unacked_watched.wait_for_change(None).fuse() => (),
-                    _ = self.send_next_seq_no.wait_for_change(None).fuse() => (),
-                    _ = win_sz_watched.wait_for_change(None).fuse() => (),
-                    _ = cwnd_watched.wait_for_change(None).fuse() => (),
-                    _ = ltci_watched.wait_for_change(None).fuse() => (),
-                };
-            }
-        }
-    }
-
-    async fn send_window_probe(&mut self, probe: DemiBuffer, cb: &mut SharedControlBlock) -> Result<(), Fail> {
-        // Update SND.NXT.
-        self.send_next_seq_no.modify(|s| s + SeqNumber::from(1));
-
-        // Add the probe byte (as a new separate buffer) to our unacknowledged queue.
-        let unacked_segment = UnackedSegment {
-            bytes: Some(probe.clone()),
-            initial_tx: Some(cb.get_now()),
-        };
-        self.unacked_queue.push(unacked_segment);
-
-        // Note that we loop here *forever*, exponentially backing off.
-        // TODO: Use the correct PERSIST mode timer here.
-        let mut timeout: Duration = Duration::from_secs(1);
-        let mut win_sz_watched: SharedAsyncValue<u32> = self.send_window.clone();
-        loop {
-            // Create packet.
-            let mut header: TcpHeader = cb.tcp_header();
-            header.seq_num = self.send_next_seq_no.get();
-            cb.emit(header, Some(probe.clone()));
-
-            match win_sz_watched.wait_for_change(Some(timeout)).await {
-                Ok(_) => return Ok(()),
-                Err(Fail { errno, cause: _ }) if errno == libc::ETIMEDOUT => timeout *= 2,
-                Err(_) => unreachable!(
-                    "either the ack deadline changed or the deadline passed, no other errors are possible!"
-                ),
-            }
-        }
-    }
-
-    // Takes a segment and attempts to send it. The buffer must be non-zero length and the function returns the number
-    // of bytes sent.
-    fn send_segment(&mut self, segment: &mut DemiBuffer, cb: &mut SharedControlBlock) -> usize {
-        let buf_len: usize = segment.len();
-        debug_assert_ne!(buf_len, 0);
-        // Check window size.
-        let max_frame_size_bytes: usize = match self.get_open_window_size_bytes(cb) {
-            0 => return 0,
-            size => size,
-        };
-
-        // Split the packet if necessary.
-        // TODO: Use a scatter/gather array to coalesce multiple buffers into a single segment.
-        let (frame_size_bytes, do_push): (usize, bool) = {
-            if buf_len > max_frame_size_bytes {
-                // Suppress PSH flag for partial buffers.
-                (max_frame_size_bytes, false)
-            } else {
-                // We can just send the whole packet. Clone it so we can attach headers/retransmit it later.
-                (buf_len, true)
-            }
-        };
-        let segment_data: DemiBuffer = segment
-            .split_front(frame_size_bytes)
-            .expect("Should be able to split within the length of the buffer");
-
-        let segment_data_len: u32 = segment_data.len() as u32;
-
-        let rto: Duration = self.rto_calculator.rto();
-        cb.congestion_control_on_send(rto, (self.send_next_seq_no.get() - self.send_unacked.get()).into());
-
-        // Prepare the segment and send it.
-        let mut header: TcpHeader = cb.tcp_header();
-        header.seq_num = self.send_next_seq_no.get();
-        if do_push {
-            header.psh = true;
-        }
-        cb.emit(header, Some(segment_data.clone()));
-
-        // Update SND.NXT.
-        self.send_next_seq_no.modify(|s| s + SeqNumber::from(segment_data_len));
-
-        // Put this segment on the unacknowledged list.
-        let unacked_segment = UnackedSegment {
-            bytes: Some(segment_data),
-            initial_tx: Some(cb.get_now()),
-        };
-        self.unacked_queue.push(unacked_segment);
-
-        // Set the retransmit timer.
-        if self.retransmit_deadline_time_secs.get().is_none() {
-            let rto: Duration = self.rto_calculator.rto();
-            self.retransmit_deadline_time_secs.set(Some(cb.get_now() + rto));
-        }
-        segment_data_len as usize
-    }
-
-    fn get_open_window_size_bytes(&mut self, cb: &mut SharedControlBlock) -> usize {
-        // Calculate amount of data in flight (SND.NXT - SND.UNA).
-        let send_unacknowledged: SeqNumber = self.send_unacked.get();
-        let send_next: SeqNumber = self.send_next_seq_no.get();
-        let sent_data: u32 = (send_next - send_unacknowledged).into();
-
-        // Before we get cwnd for the check, we prompt it to shrink it if the connection has been idle.
-        cb.congestion_control_on_cwnd_check_before_send();
-        let cwnd: SharedAsyncValue<u32> = cb.congestion_control_get_cwnd();
-
-        // The limited transmit algorithm can increase the effective size of cwnd by up to 2MSS.
-        let effective_cwnd: u32 = cwnd.get() + cb.congestion_control_get_limited_transmit_cwnd_increase().get();
-
-        let win_sz: u32 = self.send_window.get();
-
-        if Self::has_open_window(win_sz, sent_data, effective_cwnd) {
-            Self::calculate_open_window_bytes(win_sz, sent_data, self.mss, effective_cwnd)
-        } else {
-            0
-        }
-    }
-
-    fn has_open_window(win_sz: u32, sent_data: u32, effective_cwnd: u32) -> bool {
-        win_sz > 0 && win_sz >= sent_data && effective_cwnd >= sent_data
-    }
-
-    fn calculate_open_window_bytes(win_sz: u32, sent_data: u32, mss: usize, effective_cwnd: u32) -> usize {
-        cmp::min(
-            cmp::min((win_sz - sent_data) as usize, mss),
-            (effective_cwnd - sent_data) as usize,
-        )
-    }
-
-    pub async fn background_retransmitter(&mut self, mut cb: SharedControlBlock) -> Result<Never, Fail> {
-        // Watch the retransmission deadline.
-        let mut rtx_deadline_watched: SharedAsyncValue<Option<Instant>> = self.retransmit_deadline_time_secs.clone();
-        // Watch the fast retransmit flag.
-        let mut rtx_fast_retransmit_watched: SharedAsyncValue<bool> = cb.congestion_control_watch_retransmit_now_flag();
-        loop {
-            let rtx_deadline: Option<Instant> = rtx_deadline_watched.get();
-            let rtx_fast_retransmit: bool = rtx_fast_retransmit_watched.get();
-            if rtx_fast_retransmit {
-                // Notify congestion control about fast retransmit.
-                cb.congestion_control_on_fast_retransmit();
-
-                // Retransmit earliest unacknowledged segment.
-                self.retransmit(&mut cb);
-                continue;
-            }
-
-            // If either changed, wake up.
-            let something_changed = async {
-                select_biased!(
-                    _ = rtx_deadline_watched.wait_for_change(None).fuse() => (),
-                    _ = rtx_fast_retransmit_watched.wait_for_change(None).fuse() => (),
-                )
-            };
-            pin_mut!(something_changed);
-            match conditional_yield_until(something_changed, rtx_deadline).await {
-                Ok(()) => match self.fin_seq_no {
-                    Some(fin_seq_no) if self.send_unacked.get() > fin_seq_no => {
-                        return Err(Fail::new(libc::ECONNRESET, "connection closed"));
-                    },
-                    _ => continue,
-                },
-                Err(Fail { errno, cause: _ }) if errno == libc::ETIMEDOUT => {
-                    // Retransmit timeout.
-                    trace!("retransmit wake");
-                    // Notify congestion control about RTO.
-                    // TODO: Is this the best place for this?
-                    // TODO: Why call into ControlBlock to get SND.UNA when congestion_control_on_rto() has access to it?
-                    cb.congestion_control_on_rto(self.send_unacked.get());
-
-                    // RFC 6298 Section 5.4: Retransmit earliest unacknowledged segment.
-                    self.retransmit(&mut cb);
-
-                    // RFC 6298 Section 5.5: Back off the retransmission timer.
-                    self.rto_calculator.back_off();
-
-                    // RFC 6298 Section 5.6: Restart the retransmission timer with the new RTO.
-                    let deadline: Instant = cb.get_now() + self.rto_calculator.rto();
-                    self.retransmit_deadline_time_secs.set(Some(deadline));
-                },
-                Err(_) => {
-                    unreachable!(
-                        "either the retransmit deadline changed or the deadline passed, no other errors are possible!"
-                    )
-                },
-            }
-        }
-    }
-
-    /// Retransmits the earliest segment that has not (yet) been acknowledged by our peer.
-    pub fn retransmit(&mut self, cb: &mut SharedControlBlock) {
-        match self.unacked_queue.get_front_mut() {
-            Some(segment) => {
-                // We're retransmitting this, so we can no longer use an ACK for it as an RTT measurement (as we can't
-                // tell if the ACK is for the original or the retransmission).  Remove the transmission timestamp from
-                // the entry.
-                segment.initial_tx.take();
-
-                // Clone the segment data for retransmission.
-                let data: Option<DemiBuffer> = segment.bytes.as_ref().map(|b| b.clone());
-
-                // TODO: Issue #198 Repacketization - we should send a full MSS (and set the FIN flag if applicable).
-
-                // Prepare and send the segment.
-                let mut header: TcpHeader = cb.tcp_header();
-                header.seq_num = self.send_unacked.get();
-                // If data exists, then this is a regular packet, otherwise, its a FIN.
-                if data.is_some() {
-                    header.psh = true;
-                } else {
-                    header.fin = true;
-                }
-                cb.emit(header, data);
-            },
-            None => (),
-        }
-    }
-
-    // Process an ack.
-    pub fn process_ack(&mut self, header: &TcpHeader, now: Instant) {
-        // Start by checking that the ACK acknowledges something new.
-        // TODO: Look into removing Watched types.
-        let send_unacknowledged: SeqNumber = self.send_unacked.get();
-
-        if send_unacknowledged < header.ack_num {
-            // Remove the now acknowledged data from the unacknowledged queue, update the acked sequence number
-            // and update the sender window.
-
-            // Convert the difference in sequence numbers into a u32.
-            let bytes_acknowledged: u32 = (header.ack_num - self.send_unacked.get()).into();
-            // Convert that into a usize for counting bytes to remove from the unacked queue.
-            let mut bytes_remaining: usize = bytes_acknowledged as usize;
-            // Remove bytes from the unacked queue.
-            while bytes_remaining != 0 {
-                bytes_remaining = match self.unacked_queue.try_pop() {
-                    Some(segment) if segment.bytes.is_none() => self.process_acked_fin(bytes_remaining, header.ack_num),
-                    Some(segment) => self.process_acked_segment(bytes_remaining, segment, now),
-                    None => {
-                        unreachable!("There should be enough data in the unacked_queue for the number of bytes acked")
-                    }, // Shouldn't have bytes_remaining with no segments remaining in unacked_queue.
-                };
-            }
-
-            // Update SND.UNA to SEG.ACK.
-            self.send_unacked.set(header.ack_num);
-
-            // Check and update send window if necessary.
-            self.update_send_window(header);
-
-            // Reset the retransmit timer if necessary. If there is more data that hasn't been acked, then set to the
-            // next segment deadline, otherwise, do not set.
-            let retransmit_deadline_time_secs: Option<Instant> = self.update_retransmit_deadline(now);
-            #[cfg(debug_assertions)]
-            if retransmit_deadline_time_secs.is_none() {
-                debug_assert_eq!(self.send_next_seq_no.get(), header.ack_num);
-            }
-            self.retransmit_deadline_time_secs.set(retransmit_deadline_time_secs);
-        } else {
-            // Duplicate ACK (doesn't acknowledge anything new).  We can mostly ignore this, except for fast-retransmit.
-            // TODO: Implement fast-retransmit.  In which case, we'd increment our dup-ack counter here.
-            warn!("process_ack(): received duplicate ack ({:?})", header.ack_num);
-        }
-    }
-
     fn process_acked_fin(&mut self, bytes_remaining: usize, ack_num: SeqNumber) -> usize {
         // This buffer is the end-of-send marker.  So we should only have one byte of acknowledged
         // sequence space remaining (corresponding to our FIN).
@@ -565,7 +177,7 @@ impl Sender {
         }
     }
 
-    fn update_retransmit_deadline(&self, now: Instant) -> Option<Instant> {
+    fn update_retransmit_deadline(&mut self, now: Instant) -> Option<Instant> {
         match self.unacked_queue.get_front() {
             Some(UnackedSegment {
                 bytes: _,
@@ -599,22 +211,494 @@ impl Sender {
         }
     }
 
-    // Get SD.UNA.
-    pub fn get_unacked_seq_no(&self) -> SeqNumber {
-        self.send_unacked.get()
+    // This function sends a packet and waits for it to be acked.
+    pub async fn push(
+        cb: &mut ControlBlock,
+        layer3_endpoint: &mut SharedLayer3Endpoint,
+        runtime: &mut SharedDemiRuntime,
+        mut buf: DemiBuffer,
+    ) -> Result<(), Fail> {
+        // If the user is done sending (i.e. has called close on this connection), then they shouldn't be sending.
+        debug_assert!(cb.sender.fin_seq_no.is_none());
+        // Our API supports send buffers up to usize (variable, depends upon architecture) in size.  While we could
+        // allow for larger send buffers, it is simpler and more practical to limit a single send to 1 GiB, which is
+        // also the maximum value a TCP can advertise as its receive window (with maximum window scaling).
+        // TODO: the below check just limits a single send to 4 GiB, not 1 GiB.  Check this doesn't break anything.
+        //
+        // Review: Move this check up the stack (i.e. closer to the user)?
+        //
+        let _: u32 = buf
+            .len()
+            .try_into()
+            .map_err(|_| Fail::new(EINVAL, "buffer too large"))?;
+
+        // TODO: We need to fix this the correct way: limit our send buffer size to the amount we're willing to buffer.
+        if cb.sender.unsent_queue.len() > UNSENT_QUEUE_CUTOFF {
+            return Err(Fail::new(EBUSY, "too many packets to send"));
+        }
+
+        // Place the buffer in the unsent queue.
+        cb.sender.unsent_next_seq_no = cb.sender.unsent_next_seq_no + (buf.len() as u32).into();
+        if cb.sender.send_window.get() > 0 {
+            Self::send_segment(cb, layer3_endpoint, runtime.get_now(), &mut buf);
+        }
+        if buf.len() > 0 {
+            cb.sender.unsent_queue.push(Some(buf));
+        }
+
+        // Wait until the sequnce number of the pushed buffer is acknowledged.
+        let mut send_unacked_watched: SharedAsyncValue<SeqNumber> = cb.sender.send_unacked.clone();
+        let ack_seq_no: SeqNumber = cb.sender.unsent_next_seq_no;
+        debug_assert!(send_unacked_watched.get() < ack_seq_no);
+        while send_unacked_watched.get() < ack_seq_no {
+            send_unacked_watched.wait_for_change(None).await?;
+        }
+        Ok(())
     }
 
-    // Get SND.NXT.
-    pub fn get_next_seq_no(&self) -> SeqNumber {
-        self.send_next_seq_no.get()
+    // Places a FIN marker in the outgoing data stream. No data can be pushed after this.
+    pub async fn push_fin_and_wait_for_ack(cb: &mut ControlBlock) -> Result<(), Fail> {
+        debug_assert!(cb.sender.fin_seq_no.is_none());
+        // TODO: We need to fix this the correct way: limit our send buffer size to the amount we're willing to buffer.
+        if cb.sender.unsent_queue.len() > UNSENT_QUEUE_CUTOFF {
+            return Err(Fail::new(EBUSY, "too many packets to send"));
+        }
+
+        cb.sender.fin_seq_no = Some(cb.sender.unsent_next_seq_no);
+        cb.sender.unsent_next_seq_no = cb.sender.unsent_next_seq_no + 1.into();
+        cb.sender.unsent_queue.push(None);
+
+        let mut send_unacked_watched: SharedAsyncValue<SeqNumber> = cb.sender.send_unacked.clone();
+        let fin_ack_num: SeqNumber = cb.sender.unsent_next_seq_no;
+        while cb.sender.send_unacked.get() < fin_ack_num {
+            send_unacked_watched.wait_for_change(None).await?;
+        }
+        Ok(())
     }
 
-    // Get the current estimate of RTO.
-    pub fn get_rto(&self) -> Duration {
-        self.rto_calculator.rto()
+    pub async fn background_sender(
+        cb: &mut ControlBlock,
+        layer3_endpoint: &mut SharedLayer3Endpoint,
+        runtime: &mut SharedDemiRuntime,
+    ) -> Result<Never, Fail> {
+        loop {
+            // Get next bit of unsent data.
+            if let Some(buf) = cb.sender.unsent_queue.pop(None).await? {
+                Self::send_buffer(cb, layer3_endpoint, runtime.get_now(), buf).await?;
+            } else {
+                Self::send_fin(cb, layer3_endpoint, runtime.get_now())?;
+                // Exit the loop because we no longer have anything to process
+                return Err(Fail::new(libc::ECONNRESET, "Processed and sent FIN"));
+            }
+        }
+    }
+
+    fn send_fin(cb: &mut ControlBlock, layer3_endpoint: &mut SharedLayer3Endpoint, now: Instant) -> Result<(), Fail> {
+        let mut header: TcpHeader = Self::tcp_header(cb);
+        header.seq_num = cb.sender.send_next_seq_no.get();
+        debug_assert!(cb.sender.fin_seq_no.is_some_and(|s| { s == header.seq_num }));
+        header.fin = true;
+        Self::emit(cb, layer3_endpoint, header, None);
+        // Update SND.NXT.
+        cb.sender.send_next_seq_no.modify(|s| s + 1.into());
+
+        // Add the FIN to our unacknowledged queue.
+        let unacked_segment = UnackedSegment {
+            bytes: None,
+            initial_tx: Some(now),
+        };
+        cb.sender.unacked_queue.push(unacked_segment);
+        // Set the retransmit timer.
+        if cb.sender.retransmit_deadline_time_secs.get().is_none() {
+            let rto: Duration = cb.sender.rto_calculator.rto();
+            cb.sender.retransmit_deadline_time_secs.set(Some(now + rto));
+        }
+        Ok(())
+    }
+
+    async fn send_buffer(
+        cb: &mut ControlBlock,
+        layer3_endpoint: &mut SharedLayer3Endpoint,
+        now: Instant,
+        mut buffer: DemiBuffer,
+    ) -> Result<(), Fail> {
+        let mut send_unacked_watched: SharedAsyncValue<SeqNumber> = cb.sender.send_unacked.clone();
+        let mut cwnd_watched: SharedAsyncValue<u32> = cb.congestion_control_algorithm.get_cwnd();
+
+        // The limited transmit algorithm may increase the effective size of cwnd by up to 2 * mss.
+        let mut ltci_watched: SharedAsyncValue<u32> =
+            cb.congestion_control_algorithm.get_limited_transmit_cwnd_increase();
+        let mut win_sz_watched: SharedAsyncValue<u32> = cb.sender.send_window.clone();
+
+        // Try in a loop until we send this segment.
+        loop {
+            // If we don't have any window size at all, we need to transition to PERSIST mode and
+            // repeatedly send window probes until window opens up.
+            if win_sz_watched.get() == 0 {
+                // Send a window probe (this is a one-byte packet designed to elicit a window update from our peer).
+                Self::send_window_probe(cb, layer3_endpoint, now, buffer.split_front(1)?).await?;
+            } else {
+                // TODO: Nagle's algorithm - We need to coalese small buffers together to send MSS sized packets.
+                // TODO: Silly window syndrome - See RFC 1122's discussion of the SWS avoidance algorithm.
+
+                // We have some window, try to send some or all of the segment.
+                let _: usize = Self::send_segment(cb, layer3_endpoint, now, &mut buffer);
+                // If the buffer is now empty, then we sent all of it.
+                if buffer.len() == 0 {
+                    return Ok(());
+                }
+                // Otherwise, wait until something limiting the window changes and then try again to finish sending
+                // the segment.
+                futures::select_biased! {
+                    _ = send_unacked_watched.wait_for_change(None).fuse() => (),
+                    _ = cb.sender.send_next_seq_no.wait_for_change(None).fuse() => (),
+                    _ = win_sz_watched.wait_for_change(None).fuse() => (),
+                    _ = cwnd_watched.wait_for_change(None).fuse() => (),
+                    _ = ltci_watched.wait_for_change(None).fuse() => (),
+                };
+            }
+        }
+    }
+
+    async fn send_window_probe(
+        cb: &mut ControlBlock,
+        layer3_endpoint: &mut SharedLayer3Endpoint,
+        now: Instant,
+        probe: DemiBuffer,
+    ) -> Result<(), Fail> {
+        // Update SND.NXT.
+        cb.sender.send_next_seq_no.modify(|s| s + SeqNumber::from(1));
+
+        // Add the probe byte (as a new separate buffer) to our unacknowledged queue.
+        let unacked_segment = UnackedSegment {
+            bytes: Some(probe.clone()),
+            initial_tx: Some(now),
+        };
+        cb.sender.unacked_queue.push(unacked_segment);
+
+        // Note that we loop here *forever*, exponentially backing off.
+        // TODO: Use the correct PERSIST mode timer here.
+        let mut timeout: Duration = Duration::from_secs(1);
+        let mut win_sz_watched: SharedAsyncValue<u32> = cb.sender.send_window.clone();
+        loop {
+            // Create packet.
+            let mut header: TcpHeader = Self::tcp_header(cb);
+            header.seq_num = cb.sender.send_next_seq_no.get();
+            Self::emit(cb, layer3_endpoint, header, Some(probe.clone()));
+
+            match win_sz_watched.wait_for_change(Some(timeout)).await {
+                Ok(_) => return Ok(()),
+                Err(Fail { errno, cause: _ }) if errno == libc::ETIMEDOUT => timeout *= 2,
+                Err(_) => {
+                    unreachable!(
+                        "either the ack deadline changed or the deadline passed, no other errors are possible!"
+                    )
+                },
+            }
+        }
+    }
+
+    // Takes a segment and attempts to send it. The buffer must be non-zero length and the function returns the number
+    // of bytes sent.
+    fn send_segment(
+        cb: &mut ControlBlock,
+        layer3_endpoint: &mut SharedLayer3Endpoint,
+        now: Instant,
+        segment: &mut DemiBuffer,
+    ) -> usize {
+        let buf_len: usize = segment.len();
+        debug_assert_ne!(buf_len, 0);
+        // Check window size.
+        let max_frame_size_bytes: usize = match Self::get_open_window_size_bytes(cb) {
+            0 => return 0,
+            size => size,
+        };
+
+        // Split the packet if necessary.
+        // TODO: Use a scatter/gather array to coalesce multiple buffers into a single segment.
+        let (frame_size_bytes, do_push): (usize, bool) = {
+            if buf_len > max_frame_size_bytes {
+                // Suppress PSH flag for partial buffers.
+                (max_frame_size_bytes, false)
+            } else {
+                // We can just send the whole packet. Clone it so we can attach headers/retransmit it later.
+                (buf_len, true)
+            }
+        };
+        let segment_data: DemiBuffer = segment
+            .split_front(frame_size_bytes)
+            .expect("Should be able to split within the length of the buffer");
+
+        let segment_data_len: u32 = segment_data.len() as u32;
+
+        let rto: Duration = cb.sender.rto_calculator.rto();
+        cb.congestion_control_algorithm.on_send(
+            rto,
+            (cb.sender.send_next_seq_no.get() - cb.sender.send_unacked.get()).into(),
+        );
+
+        // Prepare the segment and send it.
+        let mut header: TcpHeader = Self::tcp_header(cb);
+        header.seq_num = cb.sender.send_next_seq_no.get();
+        if do_push {
+            header.psh = true;
+        }
+        Self::emit(cb, layer3_endpoint, header, Some(segment_data.clone()));
+
+        // Update SND.NXT.
+        cb.sender
+            .send_next_seq_no
+            .modify(|s| s + SeqNumber::from(segment_data_len));
+
+        // Put this segment on the unacknowledged list.
+        let unacked_segment = UnackedSegment {
+            bytes: Some(segment_data),
+            initial_tx: Some(now),
+        };
+        cb.sender.unacked_queue.push(unacked_segment);
+
+        // Set the retransmit timer.
+        if cb.sender.retransmit_deadline_time_secs.get().is_none() {
+            let rto: Duration = cb.sender.rto_calculator.rto();
+            cb.sender.retransmit_deadline_time_secs.set(Some(now + rto));
+        }
+        segment_data_len as usize
+    }
+
+    /// Fetch a TCP header filling out various values based on our current state.
+    /// TODO: Fix the "filling out various values based on our current state" part to actually do that correctly.
+    pub fn tcp_header(cb: &mut ControlBlock) -> TcpHeader {
+        let mut header: TcpHeader = TcpHeader::new(cb.local.port(), cb.remote.port());
+        header.window_size = cb.receiver.hdr_window_size();
+
+        // Note that once we reach a synchronized state we always include a valid acknowledgement number.
+        header.ack = true;
+        header.ack_num = cb.receiver.receive_next_seq_no;
+
+        // Return this header.
+        header
+    }
+
+    fn get_open_window_size_bytes(cb: &mut ControlBlock) -> usize {
+        // Calculate amount of data in flight (SND.NXT - SND.UNA).
+        let send_unacknowledged: SeqNumber = cb.sender.send_unacked.get();
+        let send_next: SeqNumber = cb.sender.send_next_seq_no.get();
+        let sent_data: u32 = (send_next - send_unacknowledged).into();
+
+        // Before we get cwnd for the check, we prompt it to shrink it if the connection has been idle.
+        cb.congestion_control_algorithm.on_cwnd_check_before_send();
+        let cwnd: SharedAsyncValue<u32> = cb.congestion_control_algorithm.get_cwnd();
+
+        // The limited transmit algorithm can increase the effective size of cwnd by up to 2MSS.
+        let effective_cwnd: u32 = cwnd.get()
+            + cb.congestion_control_algorithm
+                .get_limited_transmit_cwnd_increase()
+                .get();
+
+        let win_sz: u32 = cb.sender.send_window.get();
+
+        if Self::has_open_window(win_sz, sent_data, effective_cwnd) {
+            Self::calculate_open_window_bytes(win_sz, sent_data, cb.sender.mss, effective_cwnd)
+        } else {
+            0
+        }
+    }
+
+    fn has_open_window(win_sz: u32, sent_data: u32, effective_cwnd: u32) -> bool {
+        win_sz > 0 && win_sz >= sent_data && effective_cwnd >= sent_data
+    }
+
+    fn calculate_open_window_bytes(win_sz: u32, sent_data: u32, mss: usize, effective_cwnd: u32) -> usize {
+        cmp::min(
+            cmp::min((win_sz - sent_data) as usize, mss),
+            (effective_cwnd - sent_data) as usize,
+        )
+    }
+
+    pub async fn background_retransmitter(
+        cb: &mut ControlBlock,
+        layer3_endpoint: &mut SharedLayer3Endpoint,
+        runtime: &mut SharedDemiRuntime,
+    ) -> Result<Never, Fail> {
+        // Watch the retransmission deadline.
+        let mut rtx_deadline_watched: SharedAsyncValue<Option<Instant>> =
+            cb.sender.retransmit_deadline_time_secs.clone();
+        // Watch the fast retransmit flag.
+        let mut rtx_fast_retransmit_watched: SharedAsyncValue<bool> =
+            cb.congestion_control_algorithm.get_retransmit_now_flag();
+        loop {
+            let rtx_deadline: Option<Instant> = rtx_deadline_watched.get();
+            let rtx_fast_retransmit: bool = rtx_fast_retransmit_watched.get();
+            if rtx_fast_retransmit {
+                // Notify congestion control about fast retransmit.
+                cb.congestion_control_algorithm.on_fast_retransmit();
+
+                // Retransmit earliest unacknowledged segment.
+                Self::retransmit(cb, layer3_endpoint);
+                continue;
+            }
+
+            // If either changed, wake up.
+            let something_changed = async {
+                select_biased!(
+                    _ = rtx_deadline_watched.wait_for_change(None).fuse() => (),
+                    _ = rtx_fast_retransmit_watched.wait_for_change(None).fuse() => (),
+                )
+            };
+            pin_mut!(something_changed);
+            match conditional_yield_until(something_changed, rtx_deadline).await {
+                Ok(()) => match cb.sender.fin_seq_no {
+                    Some(fin_seq_no) if cb.sender.send_unacked.get() > fin_seq_no => {
+                        return Err(Fail::new(libc::ECONNRESET, "connection closed"));
+                    },
+                    _ => continue,
+                },
+                Err(Fail { errno, cause: _ }) if errno == libc::ETIMEDOUT => {
+                    // Retransmit timeout.
+                    // Notify congestion control about RTO.
+                    cb.congestion_control_algorithm.on_rto(cb.sender.send_unacked.get());
+
+                    // RFC 6298 Section 5.4: Retransmit earliest unacknowledged segment.
+                    Self::retransmit(cb, layer3_endpoint);
+
+                    // RFC 6298 Section 5.5: Back off the retransmission timer.
+                    cb.sender.rto_calculator.back_off();
+
+                    // RFC 6298 Section 5.6: Restart the retransmission timer with the new RTO.
+                    let deadline: Instant = runtime.get_now() + cb.sender.rto_calculator.rto();
+                    cb.sender.retransmit_deadline_time_secs.set(Some(deadline));
+                },
+                Err(_) => {
+                    unreachable!(
+                        "either the retransmit deadline changed or the deadline passed, no other errors are possible!"
+                    )
+                },
+            }
+        }
+    }
+
+    /// Retransmits the earliest segment that has not (yet) been acknowledged by our peer.
+    pub fn retransmit(cb: &mut ControlBlock, layer3_endpoint: &mut SharedLayer3Endpoint) {
+        match cb.sender.unacked_queue.get_front_mut() {
+            Some(segment) => {
+                // We're retransmitting this, so we can no longer use an ACK for it as an RTT measurement (as we can't
+                // tell if the ACK is for the original or the retransmission).  Remove the transmission timestamp from
+                // the entry.
+                segment.initial_tx.take();
+
+                // Clone the segment data for retransmission.
+                let data: Option<DemiBuffer> = segment.bytes.as_ref().map(|b| b.clone());
+
+                // TODO: Issue #198 Repacketization - we should send a full MSS (and set the FIN flag if applicable).
+
+                // Prepare and send the segment.
+                let mut header: TcpHeader = Self::tcp_header(cb);
+                header.seq_num = cb.sender.send_unacked.get();
+                // If data exists, then this is a regular packet, otherwise, its a FIN.
+                if data.is_some() {
+                    header.psh = true;
+                } else {
+                    header.fin = true;
+                }
+                Self::emit(cb, layer3_endpoint, header, data);
+            },
+            None => (),
+        }
+    }
+
+    // Process an ack.
+    pub fn process_ack(cb: &mut ControlBlock, header: &TcpHeader, now: Instant) {
+        // Start by checking that the ACK acknowledges something new.
+        // TODO: Look into removing Watched types.
+        let send_unacknowledged: SeqNumber = cb.sender.send_unacked.get();
+
+        if send_unacknowledged < header.ack_num {
+            // Remove the now acknowledged data from the unacknowledged queue, update the acked sequence number
+            // and update the sender window.
+
+            // Convert the difference in sequence numbers into a u32.
+            let bytes_acknowledged: u32 = (header.ack_num - cb.sender.send_unacked.get()).into();
+            // Convert that into a usize for counting bytes to remove from the unacked queue.
+            let mut bytes_remaining: usize = bytes_acknowledged as usize;
+            // Remove bytes from the unacked queue.
+            while bytes_remaining != 0 {
+                bytes_remaining = match cb.sender.unacked_queue.try_pop() {
+                    Some(segment) if segment.bytes.is_none() => {
+                        cb.sender.process_acked_fin(bytes_remaining, header.ack_num)
+                    },
+                    Some(segment) => cb.sender.process_acked_segment(bytes_remaining, segment, now),
+                    None => {
+                        unreachable!("There should be enough data in the unacked_queue for the number of bytes acked")
+                    }, // Shouldn't have bytes_remaining with no segments remaining in unacked_queue.
+                };
+            }
+
+            // Update SND.UNA to SEG.ACK.
+            cb.sender.send_unacked.set(header.ack_num);
+
+            // Check and update send window if necessary.
+            cb.sender.update_send_window(header);
+
+            // Reset the retransmit timer if necessary. If there is more data that hasn't been acked, then set to the
+            // next segment deadline, otherwise, do not set.
+            let retransmit_deadline_time_secs: Option<Instant> = cb.sender.update_retransmit_deadline(now);
+            #[cfg(debug_assertions)]
+            if retransmit_deadline_time_secs.is_none() {
+                debug_assert_eq!(cb.sender.send_next_seq_no.get(), header.ack_num);
+            }
+            cb.sender
+                .retransmit_deadline_time_secs
+                .set(retransmit_deadline_time_secs);
+        } else {
+            // Duplicate ACK (doesn't acknowledge anything new).  We can mostly ignore this, except for fast-retransmit.
+            // TODO: Implement fast-retransmit.  In which case, we'd increment our dup-ack counter here.
+            warn!("process_ack(): received duplicate ack ({:?})", header.ack_num);
+        }
+    }
+
+    /// Transmit this message to our connected peer.
+    pub fn emit(
+        cb: &mut ControlBlock,
+        layer3_endpoint: &mut SharedLayer3Endpoint,
+        header: TcpHeader,
+        body: Option<DemiBuffer>,
+    ) {
+        // Only perform this debug print in debug builds.  debug_assertions is compiler set in non-optimized builds.
+        let mut pkt = match body {
+            Some(body) => {
+                debug!("Sending {} bytes + {:?}", body.len(), header);
+                body
+            },
+            _ => {
+                debug!("Sending 0 bytes + {:?}", header);
+                DemiBuffer::new_with_headroom(0, MAX_HEADER_SIZE as u16)
+            },
+        };
+
+        // This routine should only ever be called to send TCP segments that contain a valid ACK value.
+        debug_assert!(header.ack);
+
+        let remote_ipv4_addr: Ipv4Addr = cb.remote.ip().clone();
+        header.serialize_and_attach(
+            &mut pkt,
+            cb.local.ip(),
+            cb.remote.ip(),
+            cb.tcp_config.get_tx_checksum_offload(),
+        );
+
+        // Call lower L3 layer to send the segment.
+        if let Err(e) = layer3_endpoint.transmit_tcp_packet_nonblocking(remote_ipv4_addr, pkt) {
+            warn!("could not emit packet: {:?}", e);
+            return;
+        }
+
+        // Post-send operations follow.
+        // Review: We perform these after the send, in order to keep send latency as low as possible.
+
+        // Since we sent an ACK, cancel any outstanding delayed ACK request.
+        cb.receiver.ack_deadline_time_secs.set(None);
     }
 }
-
 //======================================================================================================================
 // Trait Implementations
 //======================================================================================================================


### PR DESCRIPTION
This PR removes circular dependencies between the sender, receiver and control block in established TCP sockets. We move all state into the control block structure, per the TCP recommendation, and to make it easier to move the state later. However, we pass the control block to static functions in the receiver and sender for receive and send path processing.