### PR TITLE
[inetstack] Handle RST packet from peer endpoint

### DIFF
--- a/src/rust/inetstack/mod.rs
+++ b/src/rust/inetstack/mod.rs
@@ -88,7 +88,7 @@ impl SharedInetStack {
             runtime: runtime.clone(),
             layer4_endpoint,
         }));
-        runtime.insert_background_coroutine("bgc::inetstack::poll_recv", Box::pin(me.clone().poll().fuse()))?;
+        runtime.insert_background_coroutine("bgc::inetstack::poll", Box::pin(me.clone().poll().fuse()))?;
         Ok(me)
     }
 
@@ -96,7 +96,6 @@ impl SharedInetStack {
     /// Then ask the runtime to receive new data which we will forward to the engine to parse and
     /// route to the correct protocol.
     pub async fn poll(mut self) {
-        timer!("inetstack::poll");
         loop {
             for _ in 0..MAX_RECV_ITERS {
                 self.layer4_endpoint.poll_once();

--- a/src/rust/inetstack/protocols/layer4/tcp/established/ctrlblk.rs
+++ b/src/rust/inetstack/protocols/layer4/tcp/established/ctrlblk.rs
@@ -337,6 +337,11 @@ impl SharedControlBlock {
     pub fn get_state(&self) -> State {
         self.state
     }
+
+    pub fn set_state(&mut self, state: State) {
+        self.state = state;
+    }
+
     // This coroutine runs the close protocol.
     pub async fn close(&mut self) -> Result<(), Fail> {
         // Assert we are in a valid state and move to new state.


### PR DESCRIPTION
Handle RST packet sent by the peer and close the connection. This is crucial because the profiler information is only emited when the process exits cleanly. If this is not done, we cannot print the profiler information.