### PR TITLE
[ci] Enhancement: Rename workflows to disambiguate

### DIFF
--- a/.github/workflows/catnap.yml
+++ b/.github/workflows/catnap.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-name: Main Catnap
+name: Catnap (Linux Kernel)
 
 concurrency:
   group: catnap
@@ -26,7 +26,7 @@ env:
 jobs:
 
   debug-pipeline:
-    name: Debug Pipeline
+    name: Catnap Debug Pipeline (Linux Kernel)
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
@@ -69,13 +69,13 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: debug-pipeline-logs
+        name: catnap-debug-pipeline-logs
         path: |
           **/*.stdout.txt
           **/*.stderr.txt
 
   release-pipeline:
-    name: Release Pipeline
+    name: Catnap Release Pipeline (Linux Kernel)
     needs: debug-pipeline
     runs-on: ubuntu-latest
     steps:
@@ -118,13 +118,13 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: release-pipeline-logs
+        name: catnap-release-pipeline-logs
         path: |
           **/*.stdout.txt
           **/*.stderr.txt
 
   report-performance:
-    name: Report Performance
+    name: Catnap Performance Report (Linux Kernel)
     needs: release-pipeline
     runs-on: ubuntu-latest
     permissions:
@@ -142,8 +142,8 @@ jobs:
     - name: Download Release Pipeline Logs
       uses: actions/download-artifact@v4
       with:
-        name: release-pipeline-logs
-        path: ./release_pipeline_logs
+        name: catnap-release-pipeline-logs
+        path: ./catnap_release_pipeline_logs
     - name: Setup FlameGraph Repository
       run: |
         git clone https://github.com/brendangregg/FlameGraph.git /tmp/FlameGraph
@@ -159,7 +159,7 @@ jobs:
         stats=$(python3 tools/perf.py \
           --branch origin/$branch_name \
           --libos $LIBOS \
-          --log-dir ./release_pipeline_logs)
+          --log-dir ./catnap_release_pipeline_logs)
         if [[ "${{ github.event_name }}" == "pull_request" ]]; then
           EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
           echo "MESSAGE<<$EOF" >> $GITHUB_OUTPUT

--- a/.github/workflows/catnapw.yml
+++ b/.github/workflows/catnapw.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-name: Main Catnapw
+name: Catnap + Catpowder (Windows Kernel and XDP)
 
 concurrency:
   group: catnapw
@@ -26,7 +26,7 @@ env:
 jobs:
 
   debug-pipeline:
-    name: Debug Pipeline
+    name: Catnap Debug Pipeline (Windows Kernel)
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
@@ -70,13 +70,13 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: debug-pipeline-logs
+        name: catnapw-debug-pipeline-logs
         path: |
           **/*.stdout.txt
           **/*.stderr.txt
 
   release-pipeline:
-    name: Release Pipeline
+    name: Catnap Release Pipeline (Windows Kernel)
     needs: debug-pipeline
     runs-on: ubuntu-latest
     steps:
@@ -120,13 +120,13 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: release-pipeline-logs
+        name: catnapw-release-pipeline-logs
         path: |
           **/*.stdout.txt
           **/*.stderr.txt
 
   catpowder-debug-pipeline:
-    name: Catpowder Debug Pipeline
+    name: Catpowder Debug Pipeline (Windows XDP)
     needs: release-pipeline
     runs-on: ubuntu-latest
     steps:
@@ -177,7 +177,7 @@ jobs:
           **/*.stderr.txt
 
   catpowder-release-pipeline:
-    name: Catpowder Release Pipeline
+    name: Catpowder Release Pipeline (Windows XDP)
     needs: catpowder-debug-pipeline
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/catnip.yml
+++ b/.github/workflows/catnip.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-name: Main Catnip
+name: Catnip (Linux DPDK)
 
 concurrency:
   group: catnip
@@ -26,7 +26,7 @@ env:
 jobs:
 
   debug-pipeline:
-    name: Debug Pipeline
+    name: Catnip Debug Pipeline (Linux DPDK)
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
@@ -91,13 +91,13 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: debug-pipeline-logs
+        name: catnip-debug-pipeline-logs
         path: |
           **/*.stdout.txt
           **/*.stderr.txt
 
   release-pipeline:
-    name: Release Pipeline
+    name: Catnip Release Pipeline (Linux DPDK)
     needs: debug-pipeline
     runs-on: ubuntu-latest
     steps:
@@ -162,13 +162,13 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: release-pipeline-logs
+        name: catnip-release-pipeline-logs
         path: |
           **/*.stdout.txt
           **/*.stderr.txt
 
   report-performance:
-    name: Report Performance
+    name: Catnip Performance Report (Linux DPDK)
     needs: release-pipeline
     runs-on: ubuntu-latest
     permissions:
@@ -186,8 +186,8 @@ jobs:
     - name: Download Release Pipeline Logs
       uses: actions/download-artifact@v4
       with:
-        name: release-pipeline-logs
-        path: ./release_pipeline_logs
+        name: catnip-release-pipeline-logs
+        path: ./catnip_release_pipeline_logs
     - name: Setup FlameGraph Repository
       run: |
         git clone https://github.com/brendangregg/FlameGraph.git /tmp/FlameGraph
@@ -203,7 +203,7 @@ jobs:
         stats=$(python3 tools/perf.py \
           --branch origin/$branch_name \
           --libos $LIBOS \
-          --log-dir ./release_pipeline_logs)
+          --log-dir ./catnip_release_pipeline_logs)
         if [[ "${{ github.event_name }}" == "pull_request" ]]; then
           EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
           echo "MESSAGE<<$EOF" >> $GITHUB_OUTPUT

--- a/.github/workflows/catpowder.yml
+++ b/.github/workflows/catpowder.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-name: Main Catpowder
+name: Catpowder (Linux Raw Sockets)
 
 concurrency:
   group: catpowder
@@ -26,7 +26,7 @@ env:
 jobs:
 
   debug-pipeline:
-    name: Debug Pipeline
+    name: Catpowder Debug Pipeline (Linux Raw Sockets)
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
@@ -87,13 +87,13 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: debug-pipeline-logs
+        name: catpowder-debug-pipeline-logs
         path: |
           **/*.stdout.txt
           **/*.stderr.txt
 
   release-pipeline:
-    name: Release Pipeline
+    name: Catpowder Release Pipeline (Linux Raw Sockets)
     needs: debug-pipeline
     runs-on: ubuntu-latest
     steps:
@@ -154,13 +154,13 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: release-pipeline-logs
+        name: catpowder-release-pipeline-logs
         path: |
           **/*.stdout.txt
           **/*.stderr.txt
 
   report-performance:
-    name: Report Performance
+    name: Catpowder Performance Report (Linux Raw Sockets)
     needs: release-pipeline
     runs-on: ubuntu-latest
     permissions:
@@ -178,8 +178,8 @@ jobs:
     - name: Download Release Pipeline Logs
       uses: actions/download-artifact@v4
       with:
-        name: release-pipeline-logs
-        path: ./release_pipeline_logs
+        name: catpowder-release-pipeline-logs
+        path: ./catpowder_release_pipeline_logs
     - name: Setup FlameGraph Repository
       run: |
         git clone https://github.com/brendangregg/FlameGraph.git /tmp/FlameGraph
@@ -195,7 +195,7 @@ jobs:
         stats=$(python3 tools/perf.py \
           --branch origin/$branch_name \
           --libos $LIBOS \
-          --log-dir ./release_pipeline_logs)
+          --log-dir ./catpowder_release_pipeline_logs)
         if [[ "${{ github.event_name }}" == "pull_request" ]]; then
           EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
           echo "MESSAGE<<$EOF" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Renaming all workflows to have distinct and clearer names so that GitHub reporting and status updates are unambiguous and to the point. Without this, several reports were displayed as a single check.