### PR TITLE
[catpowder] Feature: Add cohosting mode to XDP backend

### DIFF
--- a/scripts/config/azure.yaml
+++ b/scripts/config/azure.yaml
@@ -7,6 +7,12 @@ demikernel:
 raw_socket:
   linux_interface_name: "abcde"
   xdp_interface_index: 0
+  xdp_cohost_mode: false
+  # Enable the following for XDP cohosting mode, or override in environment:
+  # xdp_tcp_ports: [80, 443]
+  # xdp_udp_ports: [53]
+  # Enable the following line if you have a VF interface
+  # xdp_vf_interface_index: 0
 dpdk:
   eal_init: ["-c", "0xff", "-n", "4", "-a", "WW:WW.W", "--proc-type=auto", "--vdev=net_vdev_netvsc0,iface=abcde"]
 tcp_socket_options:

--- a/scripts/config/default.yaml
+++ b/scripts/config/default.yaml
@@ -7,6 +7,10 @@ demikernel:
 raw_socket:
   linux_interface_name: "abcde"
   xdp_interface_index: 0
+  xdp_cohost_mode: false
+  # Enable the following for XDP cohosting mode, or override in environment:
+  # xdp_tcp_ports: [80, 443]
+  # xdp_udp_ports: [53]
   # Enable the following line if you have a VF interface
   # xdp_vf_interface_index: 0
 dpdk:

--- a/src/rust/catpowder/win/ring/rule/rule.rs
+++ b/src/rust/catpowder/win/ring/rule/rule.rs
@@ -7,6 +7,7 @@
 
 use crate::{
     catpowder::win::{ring::rule::params::XdpRedirectParams, socket::XdpSocket},
+    inetstack::protocols::Protocol,
     runtime::libxdp,
 };
 use ::std::mem;
@@ -24,7 +25,8 @@ pub struct XdpRule(libxdp::XDP_RULE);
 //======================================================================================================================
 
 impl XdpRule {
-    /// Creates a new XDP rule for the target socket.
+    /// Creates a new XDP rule for the target socket which filters all traffic.
+    #[allow(dead_code)]
     pub fn new(socket: &XdpSocket) -> Self {
         let redirect: XdpRedirectParams = XdpRedirectParams::new(socket);
         let rule: libxdp::XDP_RULE = unsafe {
@@ -34,6 +36,25 @@ impl XdpRule {
             // Perform bitwise copy from redirect to rule, as this is a union field.
             rule.__bindgen_anon_1 =
                 mem::transmute_copy::<libxdp::XDP_REDIRECT_PARAMS, libxdp::_XDP_RULE__bindgen_ty_1>(redirect.as_ref());
+
+            rule
+        };
+        Self(rule)
+    }
+
+    /// Creates a new XDP rule for the target socket which filters for a specific (protocol, port) combination.
+    pub fn new_for_dest(socket: &XdpSocket, protocol: Protocol, port: u16) -> Self {
+        let redirect: XdpRedirectParams = XdpRedirectParams::new(socket);
+        let rule: libxdp::XDP_RULE = unsafe {
+            let mut rule: libxdp::XDP_RULE = std::mem::zeroed();
+            rule.Match = match protocol {
+                Protocol::Udp => libxdp::_XDP_MATCH_TYPE_XDP_MATCH_UDP_DST,
+                Protocol::Tcp => libxdp::_XDP_MATCH_TYPE_XDP_MATCH_TCP_DST,
+            };
+            rule.Action = libxdp::_XDP_RULE_ACTION_XDP_PROGRAM_ACTION_REDIRECT;
+            *rule.Pattern.Port.as_mut() = port;
+            // Perform bitwise copy from redirect to rule, as this is a union field.
+            *rule.__bindgen_anon_1.Redirect.as_mut() = mem::transmute_copy(redirect.as_ref());
 
             rule
         };


### PR DESCRIPTION
Add a cohost setting with redirected ports specified in the config/environment as an initial take on cohosting.

Ideally, the system would do this automatically based on used ports, but there's currently no easy way to hook this up to the inetstack system.