### PR TITLE
Demikernel CI script: allow scripts to skip all git operations

### DIFF
--- a/tools/ci/job/factory.py
+++ b/tools/ci/job/factory.py
@@ -13,6 +13,10 @@ class JobFactory:
         self.config = config
 
     def checkout(self) -> BaseJob:
+        if self.config["skip_git"]:
+            print("--skip_git is set to True, skipping git checkout")
+            return True
+
         if self.config["platform"] == "windows":
             return windows.CheckoutJobOnWindows(self.config)
         else:

--- a/tools/ci/job/factory.py
+++ b/tools/ci/job/factory.py
@@ -13,10 +13,6 @@ class JobFactory:
         self.config = config
 
     def checkout(self) -> BaseJob:
-        if self.config["skip_git"]:
-            print("--skip_git is set to True, skipping git checkout")
-            return True
-
         if self.config["platform"] == "windows":
             return windows.CheckoutJobOnWindows(self.config)
         else:

--- a/tools/ci/job/generic.py
+++ b/tools/ci/job/generic.py
@@ -35,6 +35,9 @@ class BaseJob:
     def repository(self) -> str:
         return self.config["repository"]
 
+    def skip_git(self) -> bool:
+        return self.config["skip_git"]
+
     def enable_nfs(self) -> bool:
         return self.config["enable_nfs"]
 

--- a/tools/ci/job/linux.py
+++ b/tools/ci/job/linux.py
@@ -22,6 +22,10 @@ class CheckoutJobOnLinux(BaseLinuxJob):
         super().__init__(config, "checkout")
 
     def execute(self) -> bool:
+        if super().skip_git():
+            print("--skip_git is set to True, skipping git checkout")
+            return True
+
         serverTask: CheckoutOnLinux = CheckoutOnLinux(
             super().server(), super().repository(), super().branch())
 

--- a/tools/ci/job/linux.py
+++ b/tools/ci/job/linux.py
@@ -61,11 +61,11 @@ class CleanupJobOnLinux(BaseLinuxJob):
     def execute(self) -> bool:
         default_branch: str = "dev"
         serverTask: CleanupOnLinux = CleanupOnLinux(
-            super().server(), super().repository(), super().is_sudo(), default_branch)
+            super().server(), super().repository(), super().is_sudo(), default_branch, super().skip_git())
 
         if not super().enable_nfs():
             clientTask: CleanupOnLinux = CleanupOnLinux(
-                super().client(), super().repository(), super().is_sudo(), default_branch)
+                super().client(), super().repository(), super().is_sudo(), default_branch, super().skip_git())
             return super().execute(serverTask, clientTask)
         return super().execute(serverTask)
 

--- a/tools/ci/job/windows.py
+++ b/tools/ci/job/windows.py
@@ -22,6 +22,10 @@ class CheckoutJobOnWindows(BaseWindowsJob):
         super().__init__(config, "checkout")
 
     def execute(self) -> bool:
+        if super().skip_git():
+            print("--skip_git is set to True, skipping git checkout")
+            return True
+
         serverTask: CheckoutOnWindows = CheckoutOnWindows(
             super().server(), super().repository(), super().branch())
 

--- a/tools/ci/job/windows.py
+++ b/tools/ci/job/windows.py
@@ -61,11 +61,11 @@ class CleanupJobOnWindows(BaseWindowsJob):
     def execute(self) -> bool:
         default_branch: str = "dev"
         serverTask: CleanupOnWindows = CleanupOnWindows(
-            super().server(), super().repository(), super().is_sudo(), default_branch)
+            super().server(), super().repository(), super().is_sudo(), default_branch, super().skip_git())
 
         if not super().enable_nfs():
             clientTask: CleanupOnWindows = CleanupOnWindows(
-                super().client(), super().repository(), super().is_sudo(), default_branch)
+                super().client(), super().repository(), super().is_sudo(), default_branch, super().skip_git())
             return super().execute(serverTask, clientTask)
         return super().execute(serverTask)
 

--- a/tools/ci/task/linux.py
+++ b/tools/ci/task/linux.py
@@ -36,9 +36,14 @@ class RunOnLinux(BaseLinuxTask):
 
 
 class CleanupOnLinux(BaseLinuxTask):
-    def __init__(self, host: str, repository: str, is_sudo: bool, branch: str):
+    def __init__(self, host: str, repository: str, is_sudo: bool, branch: str, skip_git: bool):
         sudo_cmd: str = "sudo -E" if is_sudo else ""
-        cmd: str = f"cd {repository} && {sudo_cmd} make clean && git checkout {branch} && git clean -fdx ; sudo -E rm -rf /dev/shm/demikernel* ; sudo pkill -f demikernel*"
+        cmd: str = f"cd {repository} && {sudo_cmd} make clean "
+        if skip_git:
+            print("--skip-git is set to True, skipping git cleanup")
+        else:
+            cmd: str = cmd + "; git checkout ; git clean -fdx"
+        cmd:str = cmd + "; sudo -E rm -rf /dev/shm/demikernel* ; sudo pkill -f demikernel*"
         super().__init__(host, cmd)
 
 

--- a/tools/ci/task/windows.py
+++ b/tools/ci/task/windows.py
@@ -52,7 +52,11 @@ class RunOnWindows(BaseWindowsTask):
 
 
 class CleanupOnWindows(BaseWindowsTask):
-    def __init__(self, host: str, repository: str, is_sudo: bool, branch: str):
+    def __init__(self, host: str, repository: str, is_sudo: bool, branch: str, skip_git: bool):
         env_cmd = BaseWindowsTask._build_env_cmd()
-        cmd: str = f"cd {repository} ; {env_cmd} ; nmake clean ; git checkout ; git clean -fdx"
+        cmd: str = f"cd {repository} ; {env_cmd} ; nmake clean "
+        if skip_git:
+            print("--skip-git is set to True, skipping git cleanup")
+        else:
+            cmd: str = cmd + "; git checkout ; git clean -fdx"
         super().__init__(host, cmd)

--- a/tools/demikernel_ci.py
+++ b/tools/demikernel_ci.py
@@ -247,7 +247,7 @@ def main():
 
     # Initialize glboal variables.
     if skip_git:
-        print("Skipping git operations")
+        print("--skip_git is set to True, skipping git operations")
     else:
         head_commit: str = git.get_head_commit(branch)
         set_commit_hash(head_commit)


### PR DESCRIPTION
In Demikernel CI script, add `--skip_git` parameter to allow CI scripts skip all git operations. Using this parameter is beneficial to leverage existing scripts to run Demikernel Unit Test, Integration Test, or System Test on demikernel repositories set up externally or imported as git submodule.