### PR TITLE
[build] Enhancement: remove unnecessary echoes

### DIFF
--- a/examples/rust/linux.mk
+++ b/examples/rust/linux.mk
@@ -21,7 +21,6 @@ all: all-examples
 	cp -f $(BUILD_DIR)/examples/tcp-wait $(BINDIR)/examples/rust/tcp-wait.$(EXEC_SUFFIX)
 
 all-examples:
-	@echo "$(CARGO) build --examples $(CARGO_FEATURES) $(CARGO_FLAGS)"
 	$(CARGO) build --examples $(CARGO_FEATURES) $(CARGO_FLAGS)
 
 clean:

--- a/examples/rust/windows.mk
+++ b/examples/rust/windows.mk
@@ -16,7 +16,6 @@ all: all-examples
 	copy /Y $(BUILD_DIR)\examples\tcp-ping-pong.exe $(BINDIR)\examples\rust\tcp-ping-pong.exe
 
 all-examples:
-	@echo "$(CARGO) build --examples $(CARGO_FEATURES) $(CARGO_FLAGS)"
 	$(CARGO) build --examples $(CARGO_FEATURES) $(CARGO_FLAGS)
 
 clean:

--- a/linux.mk
+++ b/linux.mk
@@ -107,7 +107,6 @@ all-libs: all-libs-demikernel
 all-libs-demikernel:
 	@echo "LD_LIBRARY_PATH: $(LD_LIBRARY_PATH)"
 	@echo "PKG_CONFIG_PATH: $(PKG_CONFIG_PATH)"
-	@echo "$(CARGO) build --libs $(CARGO_FEATURES) $(CARGO_FLAGS)"
 	$(CARGO) build --lib $(CARGO_FEATURES) $(CARGO_FLAGS)
 	cp -f $(BUILD_DIR)/$(DEMIKERNEL_LIB) $(LIBDIR)/$(DEMIKERNEL_LIB)
 
@@ -126,7 +125,6 @@ clean-libs-demikernel:
 all-tests: all-tests-rust all-tests-c
 
 all-tests-rust:
-	@echo "$(CARGO) build --tests $(CARGO_FEATURES) $(CARGO_FLAGS)"
 	$(CARGO) build --tests $(CARGO_FEATURES) $(CARGO_FLAGS)
 
 all-tests-c: all-libs

--- a/windows.mk
+++ b/windows.mk
@@ -132,7 +132,6 @@ install:
 all-libs:
 	@echo "LD_LIBRARY_PATH: $(LD_LIBRARY_PATH)"
 	@echo "XDP_PATH: $(XDP_PATH)"
-	@echo "$(CARGO) build --libs $(CARGO_FEATURES) $(CARGO_FLAGS)"
 	set XDP_PATH=$(XDP_PATH)
 	set RUSTFLAGS=$(RUSTFLAGS)
 	$(CARGO) build --lib $(CARGO_FEATURES) $(CARGO_FLAGS)
@@ -147,7 +146,6 @@ all-libs:
 all-tests: all-tests-rust all-tests-c
 
 all-tests-rust: all-libs
-	@echo "$(CARGO) build --tests $(CARGO_FEATURES) $(CARGO_FLAGS)"
 	set RUSTFLAGS=$(RUSTFLAGS)
 	$(CARGO) build --tests $(CARGO_FEATURES) $(CARGO_FLAGS)
 


### PR DESCRIPTION
These unnecessary echo statements are causing duplicate output, which may cause confusion around how many times builds commands may be executed.