### PR TITLE
[inetstack] Enhancement: correct timer statements

### DIFF
--- a/src/rust/inetstack/mod.rs
+++ b/src/rust/inetstack/mod.rs
@@ -33,8 +33,6 @@ use ::std::{
     ops::{Deref, DerefMut},
 };
 
-use crate::timer;
-
 //======================================================================================================================
 // Exports
 //======================================================================================================================
@@ -278,8 +276,6 @@ impl NetworkTransport for SharedInetStack {
         buf: &mut DemiBuffer,
         addr: Option<SocketAddr>,
     ) -> Result<(), Fail> {
-        timer!("inetstack::push");
-
         self.layer4_endpoint.push(sd, buf, addr).await
     }
 

--- a/src/rust/inetstack/protocols/layer4/mod.rs
+++ b/src/rust/inetstack/protocols/layer4/mod.rs
@@ -86,19 +86,19 @@ impl Peer {
     }
 
     pub fn poll_once(&mut self) {
-        match {
-            timer!("inetstack::layer4_endpoint::poll_once");
-
-            self.layer3_endpoint.receive()
-        } {
-            Ok(batch) if !batch.is_empty() => self.receive_batch(batch),
-            Ok(_) => (),
+        timer!("inetstack::layer4::poll_once");
+        match self.layer3_endpoint.receive() {
+            Ok(batch) => {
+                if !batch.is_empty() {
+                    self.receive_batch(batch)
+                }
+            },
             Err(_) => warn!("Could not receive from network interface, continuing ..."),
         }
     }
 
     fn receive_batch(&mut self, batch: ArrayVec<(Ipv4Addr, IpProtocol, DemiBuffer), RECEIVE_BATCH_SIZE>) {
-        timer!("inetstack::poll_bg_work::for::for");
+        timer!("inetstack::layer4::receive_batch");
         trace!("found packets: {:?}", batch.len());
         for (src_ipv4_addr, ip_type, payload) in batch {
             match ip_type {


### PR DESCRIPTION
The scope of timer statements governs what they measure. Also, nesting coroutine timers with regular timers causes scope reparenting issues based on the current design of the profiler, so correcting them.