### PR TITLE
[tests] Enhancement: rename all new_test instances to new

### DIFF
--- a/src/rust/inetstack/mod.rs
+++ b/src/rust/inetstack/mod.rs
@@ -66,14 +66,6 @@ pub struct SharedInetStack(SharedObject<InetStack>);
 impl SharedInetStack {
     pub fn new<P: PhysicalLayer>(
         config: &Config,
-        runtime: SharedDemiRuntime,
-        layer1_endpoint: P,
-    ) -> Result<Self, Fail> {
-        SharedInetStack::new_test(config, runtime, layer1_endpoint)
-    }
-
-    pub fn new_test<P: PhysicalLayer>(
-        config: &Config,
         mut runtime: SharedDemiRuntime,
         layer1_endpoint: P,
     ) -> Result<Self, Fail> {

--- a/src/rust/inetstack/protocols/layer3/arp/tests.rs
+++ b/src/rust/inetstack/protocols/layer3/arp/tests.rs
@@ -214,6 +214,6 @@ fn build_arp_query(local_mac: &MacAddress, local_ipv4: &Ipv4Addr, remote_ipv4: &
 
 /// Creates a new engine.
 fn new_engine(now: Instant, config_path: &str) -> Result<SharedEngine> {
-    let layer1_endpoint: SharedTestPhysicalLayer = SharedTestPhysicalLayer::new_test(now);
+    let layer1_endpoint: SharedTestPhysicalLayer = SharedTestPhysicalLayer::new(now);
     Ok(SharedEngine::new(config_path, layer1_endpoint, now)?)
 }

--- a/src/rust/inetstack/protocols/layer4/tcp/tests/simulator.rs
+++ b/src/rust/inetstack/protocols/layer4/tcp/tests/simulator.rs
@@ -163,7 +163,7 @@ impl Simulation {
     ) -> Result<Simulation> {
         let now: Instant = Instant::now();
 
-        let test_rig: SharedTestPhysicalLayer = SharedTestPhysicalLayer::new_test(now);
+        let test_rig: SharedTestPhysicalLayer = SharedTestPhysicalLayer::new(now);
         let local: SharedEngine = SharedEngine::new(test_helpers::ALICE_CONFIG_PATH, test_rig, now)?;
 
         info!("Local: sockaddr={:?}, macaddr={:?}", local_ipv4, local_mac);

--- a/src/rust/inetstack/test_helpers/engine.rs
+++ b/src/rust/inetstack/test_helpers/engine.rs
@@ -51,7 +51,7 @@ impl SharedEngine {
     pub fn new(config_path: &str, layer1_endpoint: SharedTestPhysicalLayer, now: Instant) -> Result<Self, Fail> {
         let config: Config = Config::new(config_path.to_string())?;
         let runtime: SharedDemiRuntime = SharedDemiRuntime::new(now);
-        let transport: SharedInetStack = SharedInetStack::new_test(&config, runtime.clone(), layer1_endpoint.clone())?;
+        let transport: SharedInetStack = SharedInetStack::new(&config, runtime.clone(), layer1_endpoint.clone())?;
 
         Ok(Self(SharedObject::new(Engine {
             libos: SharedNetworkLibOS::<SharedInetStack>::new(runtime, transport),

--- a/src/rust/inetstack/test_helpers/mod.rs
+++ b/src/rust/inetstack/test_helpers/mod.rs
@@ -28,11 +28,11 @@ pub const CARRIE_CONFIG_PATH: &str = "./src/rust/inetstack/test_helpers/carrie.y
 //======================================================================================================================
 
 pub fn new_bob(now: Instant) -> SharedEngine {
-    let network: SharedTestPhysicalLayer = SharedTestPhysicalLayer::new_test(now);
+    let network: SharedTestPhysicalLayer = SharedTestPhysicalLayer::new(now);
     SharedEngine::new(BOB_CONFIG_PATH, network, now).unwrap()
 }
 
 pub fn new_carrie(now: Instant) -> SharedEngine {
-    let network = SharedTestPhysicalLayer::new_test(now);
+    let network = SharedTestPhysicalLayer::new(now);
     SharedEngine::new(CARRIE_CONFIG_PATH, network, now).unwrap()
 }

--- a/src/rust/inetstack/test_helpers/physical_layer.rs
+++ b/src/rust/inetstack/test_helpers/physical_layer.rs
@@ -43,7 +43,7 @@ pub struct SharedTestPhysicalLayer(SharedObject<TestPhysicalLayer>);
 //======================================================================================================================
 
 impl SharedTestPhysicalLayer {
-    pub fn new_test(now: Instant) -> Self {
+    pub fn new(now: Instant) -> Self {
         logging::initialize();
         Self(SharedObject::<TestPhysicalLayer>::new(TestPhysicalLayer {
             incoming: VecDeque::new(),

--- a/tests/rust/common/libos.rs
+++ b/tests/rust/common/libos.rs
@@ -35,13 +35,13 @@ pub struct DummyLibOS(SharedNetworkLibOS<SharedInetStack>);
 
 impl DummyLibOS {
     /// Initializes the libOS.
-    pub fn new_test(config_path: &str, tx: Sender<DemiBuffer>, rx: Receiver<DemiBuffer>) -> Result<Self, Fail> {
+    pub fn new(config_path: &str, tx: Sender<DemiBuffer>, rx: Receiver<DemiBuffer>) -> Result<Self, Fail> {
         let config: Config = Config::new(config_path.to_string())?;
         let runtime: SharedDemiRuntime = SharedDemiRuntime::default();
         let network: SharedDummyRuntime = SharedDummyRuntime::new(rx, tx);
 
         logging::initialize();
-        let transport = SharedInetStack::new_test(&config, runtime.clone(), network)?;
+        let transport = SharedInetStack::new(&config, runtime.clone(), network)?;
         Ok(Self(SharedNetworkLibOS::<SharedInetStack>::new(runtime, transport)))
     }
 

--- a/tests/rust/tcp.rs
+++ b/tests/rust/tcp.rs
@@ -77,7 +77,7 @@ mod test {
     #[test]
     fn tcp_connection_setup() -> Result<()> {
         let (tx, rx): (Sender<DemiBuffer>, Receiver<DemiBuffer>) = crossbeam_channel::unbounded();
-        let mut libos: DummyLibOS = DummyLibOS::new_test(ALICE_CONFIG_PATH, tx, rx)?;
+        let mut libos: DummyLibOS = DummyLibOS::new(ALICE_CONFIG_PATH, tx, rx)?;
 
         do_passive_connection_setup(&mut libos)?;
         do_passive_connection_setup_ephemeral(&mut libos)?;
@@ -99,7 +99,7 @@ mod test {
         let alice_barrier: Arc<Barrier> = bob_barrier.clone();
 
         let alice: JoinHandle<Result<()>> = thread::Builder::new().name(format!("alice")).spawn(move || {
-            let mut libos: DummyLibOS = match DummyLibOS::new_test(ALICE_CONFIG_PATH, alice_tx, bob_rx) {
+            let mut libos: DummyLibOS = match DummyLibOS::new(ALICE_CONFIG_PATH, alice_tx, bob_rx) {
                 Ok(libos) => libos,
                 Err(e) => anyhow::bail!("Could not create inetstack: {:?}", e),
             };
@@ -131,7 +131,7 @@ mod test {
         })?;
 
         let bob: JoinHandle<Result<()>> = thread::Builder::new().name(format!("bob")).spawn(move || {
-            let mut libos: DummyLibOS = match DummyLibOS::new_test(BOB_CONFIG_PATH, bob_tx, alice_rx) {
+            let mut libos: DummyLibOS = match DummyLibOS::new(BOB_CONFIG_PATH, bob_tx, alice_rx) {
                 Ok(libos) => libos,
                 Err(e) => anyhow::bail!("Could not create inetstack: {:?}", e),
             };
@@ -177,7 +177,7 @@ mod test {
         let alice_barrier: Arc<Barrier> = bob_barrier.clone();
 
         let alice: JoinHandle<Result<()>> = thread::Builder::new().name(format!("alice")).spawn(move || {
-            let mut libos: DummyLibOS = match DummyLibOS::new_test(ALICE_CONFIG_PATH, alice_tx, bob_rx) {
+            let mut libos: DummyLibOS = match DummyLibOS::new(ALICE_CONFIG_PATH, alice_tx, bob_rx) {
                 Ok(libos) => libos,
                 Err(e) => anyhow::bail!("Could not create inetstack: {:?}", e),
             };
@@ -210,7 +210,7 @@ mod test {
         })?;
 
         let bob: JoinHandle<Result<()>> = thread::Builder::new().name(format!("bob")).spawn(move || {
-            let mut libos: DummyLibOS = match DummyLibOS::new_test(BOB_CONFIG_PATH, bob_tx, alice_rx) {
+            let mut libos: DummyLibOS = match DummyLibOS::new(BOB_CONFIG_PATH, bob_tx, alice_rx) {
                 Ok(libos) => libos,
                 Err(e) => anyhow::bail!("Could not create inetstack: {:?}", e),
             };
@@ -261,7 +261,7 @@ mod test {
         let alice_barrier: Arc<Barrier> = bob_barrier.clone();
 
         let alice: JoinHandle<Result<()>> = thread::Builder::new().name(format!("alice")).spawn(move || {
-            let mut libos: DummyLibOS = match DummyLibOS::new_test(ALICE_CONFIG_PATH, alice_tx, bob_rx) {
+            let mut libos: DummyLibOS = match DummyLibOS::new(ALICE_CONFIG_PATH, alice_tx, bob_rx) {
                 Ok(libos) => libos,
                 Err(e) => anyhow::bail!("Could not create inetstack: {:?}", e),
             };
@@ -303,7 +303,7 @@ mod test {
         })?;
 
         let bob: JoinHandle<Result<()>> = thread::Builder::new().name(format!("bob")).spawn(move || {
-            let mut libos: DummyLibOS = match DummyLibOS::new_test(BOB_CONFIG_PATH, bob_tx, alice_rx) {
+            let mut libos: DummyLibOS = match DummyLibOS::new(BOB_CONFIG_PATH, bob_tx, alice_rx) {
                 Ok(libos) => libos,
                 Err(e) => anyhow::bail!("Could not create inetstack: {:?}", e),
             };
@@ -357,7 +357,7 @@ mod test {
     #[test]
     fn tcp_bad_socket() -> Result<()> {
         let (tx, rx): (Sender<DemiBuffer>, Receiver<DemiBuffer>) = crossbeam_channel::unbounded();
-        let mut libos: DummyLibOS = match DummyLibOS::new_test(ALICE_CONFIG_PATH, tx, rx) {
+        let mut libos: DummyLibOS = match DummyLibOS::new(ALICE_CONFIG_PATH, tx, rx) {
             Ok(libos) => libos,
             Err(e) => anyhow::bail!("Could not create inetstack: {:?}", e),
         };
@@ -468,7 +468,7 @@ mod test {
     #[test]
     fn tcp_bad_bind() -> Result<()> {
         let (tx, rx): (Sender<DemiBuffer>, Receiver<DemiBuffer>) = crossbeam_channel::unbounded();
-        let mut libos: DummyLibOS = match DummyLibOS::new_test(ALICE_CONFIG_PATH, tx, rx) {
+        let mut libos: DummyLibOS = match DummyLibOS::new(ALICE_CONFIG_PATH, tx, rx) {
             Ok(libos) => libos,
             Err(e) => anyhow::bail!("Could not create inetstack: {:?}", e),
         };
@@ -509,7 +509,7 @@ mod test {
     #[test]
     fn tcp_bad_listen() -> Result<()> {
         let (tx, rx): (Sender<DemiBuffer>, Receiver<DemiBuffer>) = crossbeam_channel::unbounded();
-        let mut libos: DummyLibOS = match DummyLibOS::new_test(ALICE_CONFIG_PATH, tx, rx) {
+        let mut libos: DummyLibOS = match DummyLibOS::new(ALICE_CONFIG_PATH, tx, rx) {
             Ok(libos) => libos,
             Err(e) => anyhow::bail!("Could not create inetstack: {:?}", e),
         };
@@ -585,7 +585,7 @@ mod test {
     #[test]
     fn tcp_bad_accept() -> Result<()> {
         let (tx, rx): (Sender<DemiBuffer>, Receiver<DemiBuffer>) = crossbeam_channel::unbounded();
-        let mut libos: DummyLibOS = match DummyLibOS::new_test(ALICE_CONFIG_PATH, tx, rx) {
+        let mut libos: DummyLibOS = match DummyLibOS::new(ALICE_CONFIG_PATH, tx, rx) {
             Ok(libos) => libos,
             Err(e) => anyhow::bail!("Could not create inetstack: {:?}", e),
         };
@@ -617,7 +617,7 @@ mod test {
         let alice_barrier: Arc<Barrier> = bob_barrier.clone();
 
         let alice: JoinHandle<Result<()>> = thread::Builder::new().name(format!("alice")).spawn(move || {
-            let mut libos: DummyLibOS = match DummyLibOS::new_test(ALICE_CONFIG_PATH, alice_tx, bob_rx) {
+            let mut libos: DummyLibOS = match DummyLibOS::new(ALICE_CONFIG_PATH, alice_tx, bob_rx) {
                 Ok(libos) => libos,
                 Err(e) => anyhow::bail!("Could not create inetstack: {:?}", e),
             };
@@ -646,7 +646,7 @@ mod test {
         })?;
 
         let bob: JoinHandle<Result<()>> = thread::Builder::new().name(format!("bob")).spawn(move || {
-            let mut libos: DummyLibOS = match DummyLibOS::new_test(BOB_CONFIG_PATH, bob_tx, alice_rx) {
+            let mut libos: DummyLibOS = match DummyLibOS::new(BOB_CONFIG_PATH, bob_tx, alice_rx) {
                 Ok(libos) => libos,
                 Err(e) => anyhow::bail!("Could not create inetstack: {:?}", e),
             };
@@ -719,7 +719,7 @@ mod test {
         let alice_barrier: Arc<Barrier> = bob_barrier.clone();
 
         let alice: JoinHandle<Result<()>> = thread::Builder::new().name(format!("alice")).spawn(move || {
-            let mut libos: DummyLibOS = match DummyLibOS::new_test(ALICE_CONFIG_PATH, alice_tx, bob_rx) {
+            let mut libos: DummyLibOS = match DummyLibOS::new(ALICE_CONFIG_PATH, alice_tx, bob_rx) {
                 Ok(libos) => libos,
                 Err(e) => anyhow::bail!("Could not create inetstack: {:?}", e),
             };
@@ -762,7 +762,7 @@ mod test {
         })?;
 
         let bob: JoinHandle<Result<()>> = thread::Builder::new().name(format!("bob")).spawn(move || {
-            let mut libos: DummyLibOS = match DummyLibOS::new_test(BOB_CONFIG_PATH, bob_tx, alice_rx) {
+            let mut libos: DummyLibOS = match DummyLibOS::new(BOB_CONFIG_PATH, bob_tx, alice_rx) {
                 Ok(libos) => libos,
                 Err(e) => anyhow::bail!("Could not create inetstack: {:?}", e),
             };
@@ -825,7 +825,7 @@ mod test {
         let alice_barrier: Arc<Barrier> = bob_barrier.clone();
 
         let alice: JoinHandle<Result<()>> = thread::Builder::new().name(format!("alice")).spawn(move || {
-            let mut libos: DummyLibOS = match DummyLibOS::new_test(ALICE_CONFIG_PATH, alice_tx, bob_rx) {
+            let mut libos: DummyLibOS = match DummyLibOS::new(ALICE_CONFIG_PATH, alice_tx, bob_rx) {
                 Ok(libos) => libos,
                 Err(e) => anyhow::bail!("Could not create inetstack: {:?}", e),
             };
@@ -868,7 +868,7 @@ mod test {
         })?;
 
         let bob: JoinHandle<Result<()>> = thread::Builder::new().name(format!("bob")).spawn(move || {
-            let mut libos: DummyLibOS = match DummyLibOS::new_test(BOB_CONFIG_PATH, bob_tx, alice_rx) {
+            let mut libos: DummyLibOS = match DummyLibOS::new(BOB_CONFIG_PATH, bob_tx, alice_rx) {
                 Ok(libos) => libos,
                 Err(e) => anyhow::bail!("Could not create inetstack: {:?}", e),
             };
@@ -957,7 +957,7 @@ mod test {
         let alice_barrier: Arc<Barrier> = bob_barrier.clone();
 
         let alice: JoinHandle<Result<()>> = thread::Builder::new().name(format!("alice")).spawn(move || {
-            let mut libos: DummyLibOS = match DummyLibOS::new_test(ALICE_CONFIG_PATH, alice_tx, bob_rx) {
+            let mut libos: DummyLibOS = match DummyLibOS::new(ALICE_CONFIG_PATH, alice_tx, bob_rx) {
                 Ok(libos) => libos,
                 Err(e) => anyhow::bail!("Could not create inetstack: {:?}", e),
             };
@@ -1010,7 +1010,7 @@ mod test {
         })?;
 
         let bob: JoinHandle<Result<()>> = thread::Builder::new().name(format!("bob")).spawn(move || {
-            let mut libos: DummyLibOS = match DummyLibOS::new_test(BOB_CONFIG_PATH, bob_tx, alice_rx) {
+            let mut libos: DummyLibOS = match DummyLibOS::new(BOB_CONFIG_PATH, bob_tx, alice_rx) {
                 Ok(libos) => libos,
                 Err(e) => anyhow::bail!("Could not create inetstack: {:?}", e),
             };

--- a/tests/rust/udp.rs
+++ b/tests/rust/udp.rs
@@ -113,7 +113,7 @@ mod test {
     #[test]
     fn udp_setup() -> Result<()> {
         let (tx, rx): (Sender<DemiBuffer>, Receiver<DemiBuffer>) = crossbeam_channel::unbounded();
-        let mut libos: DummyLibOS = match DummyLibOS::new_test(ALICE_CONFIG_PATH, tx, rx) {
+        let mut libos: DummyLibOS = match DummyLibOS::new(ALICE_CONFIG_PATH, tx, rx) {
             Ok(libos) => libos,
             Err(e) => anyhow::bail!("Could not create inetstack: {:?}", e),
         };
@@ -129,7 +129,7 @@ mod test {
     #[test]
     fn udp_connect_loopback() -> Result<()> {
         let (tx, rx): (Sender<DemiBuffer>, Receiver<DemiBuffer>) = crossbeam_channel::unbounded();
-        let mut libos: DummyLibOS = match DummyLibOS::new_test(ALICE_CONFIG_PATH, tx, rx) {
+        let mut libos: DummyLibOS = match DummyLibOS::new(ALICE_CONFIG_PATH, tx, rx) {
             Ok(libos) => libos,
             Err(e) => anyhow::bail!("Could not create inetstack: {:?}", e),
         };
@@ -177,7 +177,7 @@ mod test {
         let alice_barrier: Arc<Barrier> = bob_barrier.clone();
 
         let alice: JoinHandle<Result<()>> = thread::Builder::new().name(format!("alice")).spawn(move || {
-            let mut libos: DummyLibOS = match DummyLibOS::new_test(ALICE_CONFIG_PATH, alice_tx, bob_rx) {
+            let mut libos: DummyLibOS = match DummyLibOS::new(ALICE_CONFIG_PATH, alice_tx, bob_rx) {
                 Ok(libos) => libos,
                 Err(e) => anyhow::bail!("Could not create inetstack: {:?}", e),
             };
@@ -246,7 +246,7 @@ mod test {
         })?;
 
         let bob: JoinHandle<Result<()>> = thread::Builder::new().name(format!("bob")).spawn(move || {
-            let mut libos: DummyLibOS = match DummyLibOS::new_test(BOB_CONFIG_PATH, bob_tx, alice_rx) {
+            let mut libos: DummyLibOS = match DummyLibOS::new(BOB_CONFIG_PATH, bob_tx, alice_rx) {
                 Ok(libos) => libos,
                 Err(e) => anyhow::bail!("Could not create inetstack: {:?}", e),
             };
@@ -336,7 +336,7 @@ mod test {
         let alice_barrier: Arc<Barrier> = bob_barrier.clone();
 
         let alice: JoinHandle<Result<()>> = thread::Builder::new().name(format!("alice")).spawn(move || {
-            let mut libos: DummyLibOS = match DummyLibOS::new_test(ALICE_CONFIG_PATH, alice_tx, bob_rx) {
+            let mut libos: DummyLibOS = match DummyLibOS::new(ALICE_CONFIG_PATH, alice_tx, bob_rx) {
                 Ok(libos) => libos,
                 Err(e) => anyhow::bail!("Could not create inetstack: {:?}", e),
             };
@@ -405,7 +405,7 @@ mod test {
         })?;
 
         let bob = thread::Builder::new().name(format!("bob")).spawn(move || {
-            let mut libos: DummyLibOS = match DummyLibOS::new_test(ALICE_CONFIG_PATH, bob_tx, alice_rx) {
+            let mut libos: DummyLibOS = match DummyLibOS::new(ALICE_CONFIG_PATH, bob_tx, alice_rx) {
                 Ok(libos) => libos,
                 Err(e) => anyhow::bail!("Could not create inetstack: {:?}", e),
             };


### PR DESCRIPTION
This is done to enhance clarity of code by reducing ambiguity in the naming.