### PR TITLE
[runtime] Enhancement: Move id_map into runtime

### DIFF
--- a/src/rust/collections/id_map/indirect_map.rs
+++ b/src/rust/collections/id_map/indirect_map.rs
@@ -40,11 +40,6 @@ impl<E: Eq + Hash + From<u64> + Into<u64> + Copy, I: From<u64> + Into<u64> + Cop
         warn!("Could not find a valid task id");
         None
     }
-
-    #[cfg(test)]
-    pub fn len(&self) -> usize {
-        self.ids.len()
-    }
 }
 
 //======================================================================================================================

--- a/src/rust/runtime/mod.rs
+++ b/src/rust/runtime/mod.rs
@@ -18,7 +18,7 @@ pub use condition_variable::SharedConditionVariable;
 mod poll;
 mod timer;
 pub use queue::{BackgroundTask, OperationResult, OperationTask, QDesc, QToken, QType};
-pub use scheduler::{Task, TaskId};
+pub use scheduler::{SchedulerId, Task};
 
 #[cfg(feature = "libdpdk")]
 pub use demikernel_dpdk_bindings as libdpdk;
@@ -34,11 +34,11 @@ pub use demikernel_xdp_bindings as libxdp;
 use crate::coroutine_timer;
 
 use crate::{
+    collections::id_map::IdMap,
     expect_some,
     runtime::{
         fail::Fail,
-        network::socket::SocketId,
-        network::SocketIdToQDescMap,
+        network::{socket::SocketId, SocketIdToQDescMap},
         poll::PollFuture,
         queue::{IoQueue, IoQueueTable},
         scheduler::{SharedScheduler, TaskWithResult},
@@ -71,9 +71,12 @@ const TIMER_RESOLUTION: usize = 64;
 
 pub struct DemiRuntime {
     qtable: IoQueueTable,
+    // Holds the mapping between qtoken and task id. Initialized to invalid id until we insert the task into the
+    // scheduler and get the real id.
+    qtoken_to_scheduler_id: IdMap<QToken, SchedulerId>,
     scheduler: SharedScheduler,
-    foreground_group_id: TaskId,
-    background_group_id: TaskId,
+    foreground_group_id: SchedulerId,
+    background_group_id: SchedulerId,
     socket_id_to_qdesc_map: SocketIdToQDescMap,
     /// Number of iterations that we have polled since advancing the clock.
     ts_iters: usize,
@@ -110,10 +113,11 @@ impl SharedDemiRuntime {
     pub fn new(now: Instant) -> Self {
         timer::global_set_time(now);
         let mut scheduler: SharedScheduler = SharedScheduler::default();
-        let foreground_group_id: TaskId = scheduler.create_group();
-        let background_group_id: TaskId = scheduler.create_group();
+        let foreground_group_id: SchedulerId = scheduler.create_group();
+        let background_group_id: SchedulerId = scheduler.create_group();
         Self(SharedObject::<DemiRuntime>::new(DemiRuntime {
             qtable: IoQueueTable::default(),
+            qtoken_to_scheduler_id: IdMap::default(),
             scheduler,
             foreground_group_id,
             background_group_id,
@@ -150,7 +154,7 @@ impl SharedDemiRuntime {
     fn insert_coroutine<F: FusedFuture + 'static>(
         &mut self,
         task_name: &'static str,
-        group_id: TaskId,
+        group_id: SchedulerId,
         coroutine: Pin<Box<F>>,
     ) -> Result<QToken, Fail>
     where
@@ -161,7 +165,15 @@ impl SharedDemiRuntime {
         let coroutine = coroutine_timer!(task_name, coroutine);
         let task: TaskWithResult<F::Output> = TaskWithResult::<F::Output>::new(task_name, coroutine);
         match self.scheduler.insert_task(group_id, task) {
-            Some(task_id) => Ok(task_id.into()),
+            Some(task_id) => {
+                let qt: QToken = self.qtoken_to_scheduler_id.insert_with_new_id(task_id).unwrap();
+                self.scheduler
+                    .get_mut_task(group_id, task_id)
+                    .unwrap()
+                    .set_id(qt.into());
+                // Stash the newly allocated qtoken in the task.
+                Ok(qt)
+            },
             None => {
                 let cause: String = format!("cannot schedule coroutine (task_name={:?})", &task_name);
                 error!("insert_nonpolling_coroutine(): {}", cause);
@@ -195,11 +207,10 @@ impl SharedDemiRuntime {
         timeout: Duration,
     ) -> Result<(usize, QToken, QDesc, OperationResult), Fail> {
         // If any are already complete, grab from the completion table, otherwise, make sure it is valid.
-        let foreground_group_id: TaskId = self.foreground_group_id;
         for (i, qt) in qts.iter().enumerate() {
             if let Some((qd, result)) = self.completed_tasks.remove(qt) {
                 return Ok((i, *qt, qd, result));
-            } else if !self.scheduler.is_valid_task(&foreground_group_id, &TaskId::from(*qt)) {
+            } else if self.qtoken_to_scheduler_id.get(qt).is_none() {
                 let cause: String = format!("{:?} is not a valid queue token", qt);
                 warn!("wait_any: {}", cause);
                 return Err(Fail::new(libc::EINVAL, &cause));
@@ -242,11 +253,11 @@ impl SharedDemiRuntime {
             self.wait_next()
                 .into_iter()
                 .fold(true, |prev: bool, mut task: OperationTask| -> bool {
-                    let qt: QToken = task.get_id().into();
+                    let qt: QToken = expect_some!(task.get_id(), "should have been set on insert").into();
                     let (qd, result): (QDesc, OperationResult) =
                         expect_some!(task.get_result(), "coroutine not finished");
                     let next: bool = prev && acceptor(qt, qd, &result);
-                    trace!("inserting");
+                    self.qtoken_to_scheduler_id.remove(&qt);
                     self.completed_tasks.insert(qt, (qd, result));
                     next
                 })
@@ -370,14 +381,14 @@ impl SharedDemiRuntime {
     }
 
     pub fn poll_background_tasks(&mut self) {
-        let background_group_id: TaskId = self.background_group_id;
+        let background_group_id: SchedulerId = self.background_group_id;
         // Ignore any results from tasks that completed because background tasks do not return anything.
         self.scheduler
             .poll_group_once(background_group_id, Some(TIMER_RESOLUTION));
     }
 
     pub fn poll_foreground_tasks(&mut self) -> Vec<OperationTask> {
-        let foreground_group_id: TaskId = self.foreground_group_id;
+        let foreground_group_id: SchedulerId = self.foreground_group_id;
 
         let completed_tasks = self
             .scheduler
@@ -386,7 +397,7 @@ impl SharedDemiRuntime {
         completed_tasks
             .into_iter()
             .filter_map(|boxed_task| -> Option<OperationTask> {
-                let qt: QToken = boxed_task.get_id().into();
+                let qt: QToken = expect_some!(boxed_task.get_id(), "should have been set on insert").into();
                 trace!(
                     "Completed while polling coroutine (qt={:?}): {:?}",
                     qt,
@@ -460,10 +471,11 @@ impl Default for SharedDemiRuntime {
     fn default() -> Self {
         timer::global_set_time(Instant::now());
         let mut scheduler: SharedScheduler = SharedScheduler::default();
-        let foreground_group_id: TaskId = scheduler.create_group();
-        let background_group_id: TaskId = scheduler.create_group();
+        let foreground_group_id: SchedulerId = scheduler.create_group();
+        let background_group_id: SchedulerId = scheduler.create_group();
         Self(SharedObject::<DemiRuntime>::new(DemiRuntime {
             qtable: IoQueueTable::default(),
+            qtoken_to_scheduler_id: IdMap::default(),
             scheduler,
             foreground_group_id,
             background_group_id,
@@ -567,7 +579,10 @@ pub trait Runtime: Clone + Unpin + 'static {}
 
 #[cfg(test)]
 mod tests {
-    use crate::runtime::{poll_yield, OperationResult, QDesc, QToken, SharedDemiRuntime};
+    use crate::{
+        expect_ok,
+        runtime::{poll_yield, OperationResult, QDesc, QToken, SharedDemiRuntime},
+    };
     use ::std::time::Duration;
     use futures::FutureExt;
     use test::Bencher;
@@ -611,9 +626,10 @@ mod tests {
         let mut runtime: SharedDemiRuntime = SharedDemiRuntime::default();
         // Insert a large number of coroutines.
         for i in 0..NUM_TASKS {
-            qts[i] = runtime
-                .insert_nonpolling_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1000000000).fuse()))
-                .expect("should be able to insert tasks");
+            qts[i] = expect_ok!(
+                runtime.insert_nonpolling_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1000000000).fuse())),
+                "should be able to insert tasks"
+            );
         }
 
         // Run all of the tasks for one quanta
@@ -627,12 +643,13 @@ mod tests {
         let mut runtime: SharedDemiRuntime = SharedDemiRuntime::default();
         // Insert a large number of coroutines.
         for i in 0..NUM_TASKS {
-            qts[i] = runtime
-                .insert_io_polling_coroutine(
+            qts[i] = expect_ok!(
+                runtime.insert_io_polling_coroutine(
                     "dummy background coroutine",
                     Box::pin(dummy_background_coroutine().fuse()),
-                )
-                .expect("should be able to insert tasks");
+                ),
+                "should be able to insert tasks"
+            );
         }
 
         // Run all of the tasks for one quanta

--- a/src/rust/runtime/queue/qtoken.rs
+++ b/src/rust/runtime/queue/qtoken.rs
@@ -2,12 +2,6 @@
 // Licensed under the MIT license.
 
 //======================================================================================================================
-// Imports
-//======================================================================================================================
-
-use crate::runtime::scheduler::TaskId;
-
-//======================================================================================================================
 // Structures
 //======================================================================================================================
 
@@ -33,18 +27,5 @@ impl From<QToken> for u64 {
     /// Converts a [QToken] to a [u64].
     fn from(value: QToken) -> Self {
         value.0
-    }
-}
-
-/// This converts a QToken to an external identifier specifically for our scheduler.
-impl From<TaskId> for QToken {
-    fn from(value: TaskId) -> Self {
-        QToken(value.into())
-    }
-}
-
-impl From<QToken> for TaskId {
-    fn from(value: QToken) -> Self {
-        TaskId(value.into())
     }
 }

--- a/src/rust/runtime/scheduler/group.rs
+++ b/src/rust/runtime/scheduler/group.rs
@@ -12,13 +12,12 @@
 //======================================================================================================================
 
 use crate::{
-    collections::{id_map::IdMap, pin_slab::PinSlab},
+    collections::pin_slab::PinSlab,
     expect_some,
     runtime::scheduler::{
         page::{WakerPageRef, WakerRef},
-        scheduler::InternalId,
         waker64::{WAKER_BIT_LENGTH, WAKER_BIT_LENGTH_SHIFT},
-        Task, TaskId,
+        SchedulerId, Task,
     },
 };
 use ::bit_iter::BitIter;
@@ -37,7 +36,6 @@ use ::std::{
 /// same task group as the allocating task.
 #[derive(Default)]
 pub struct TaskGroup {
-    ids: IdMap<TaskId, InternalId>,
     /// Stores all the tasks that are held by the scheduler.
     tasks: PinSlab<Box<dyn Task>>,
     /// Holds the waker bits for controlling task scheduling.
@@ -60,14 +58,12 @@ impl TaskGroup {
         };
         waker_page_ref.clear(waker_page_offset);
         if let Some(task) = self.tasks.remove_unpin(pin_slab_index) {
-            let task_id: TaskId = task.get_id();
             trace!(
                 "remove(): name={:?}, id={:?}, pin_slab_index={:?}",
                 task.get_name(),
-                task_id,
+                task.get_id(),
                 pin_slab_index
             );
-            self.ids.remove(&task_id).expect("Should be in the id table");
             Some(task)
         } else {
             warn!("Unable to unpin and remove: pin_slab_index={:?}", pin_slab_index);
@@ -76,11 +72,10 @@ impl TaskGroup {
     }
 
     /// Insert a new task into our scheduler returning a handle corresponding to it.
-    pub fn insert(&mut self, task: Box<dyn Task>) -> Option<TaskId> {
+    pub fn insert(&mut self, task: Box<dyn Task>) -> Option<SchedulerId> {
         let task_name: &'static str = task.get_name();
         // The pin slab index can be reverse-computed in a page index and an offset within the page.
         let pin_slab_index: usize = self.tasks.insert(task)?;
-        let task_id: TaskId = self.ids.insert_with_new_id(pin_slab_index.into())?;
 
         self.add_new_pages_up_to_pin_slab_index(pin_slab_index.into());
 
@@ -91,15 +86,12 @@ impl TaskGroup {
         };
         waker_page_ref.initialize(waker_page_offset);
 
-        trace!(
-            "insert(): name={:?}, id={:?}, pin_slab_index={:?}",
-            task_name,
-            task_id,
-            pin_slab_index
-        );
-        // Set this task's id.
-        expect_some!(self.tasks.get_pin_mut(pin_slab_index), "just allocated!").set_id(task_id);
-        Some(task_id)
+        trace!("insert(): name={:?}, pin_slab_index={:?}", task_name, pin_slab_index);
+        Some(pin_slab_index.into())
+    }
+
+    pub fn get_mut_task(&mut self, pin_slab_index: usize) -> Option<Pin<&mut Box<dyn Task>>> {
+        self.tasks.get_pin_mut(pin_slab_index)
     }
 
     /// Computes the page and page offset of a given task based on its total offset.
@@ -181,19 +173,5 @@ impl TaskGroup {
             return self.remove(pin_slab_index);
         }
         None
-    }
-
-    pub fn is_valid_task(&self, task_id: &TaskId) -> bool {
-        if let Some(internal_id) = self.ids.get(task_id) {
-            self.tasks.contains(internal_id.into())
-        } else {
-            false
-        }
-    }
-
-    #[cfg(not(feature = "direct-mapping"))]
-    #[cfg(test)]
-    pub fn num_tasks(&self) -> usize {
-        self.ids.len()
     }
 }

--- a/src/rust/runtime/scheduler/mod.rs
+++ b/src/rust/runtime/scheduler/mod.rs
@@ -41,6 +41,6 @@ mod waker64;
 //======================================================================================================================
 
 pub use self::{
-    scheduler::SharedScheduler,
-    task::{Task, TaskId, TaskWithResult},
+    scheduler::{SchedulerId, SharedScheduler},
+    task::{Task, TaskWithResult},
 };

--- a/src/rust/runtime/scheduler/scheduler.rs
+++ b/src/rust/runtime/scheduler/scheduler.rs
@@ -12,25 +12,29 @@
 //======================================================================================================================
 
 use crate::runtime::{
-    scheduler::{group::TaskGroup, Task, TaskId},
+    scheduler::{group::TaskGroup, Task},
     SharedObject,
 };
 use ::slab::Slab;
-use ::std::ops::{Deref, DerefMut};
+use ::std::{
+    ops::{Deref, DerefMut},
+    pin::Pin,
+};
 
 //======================================================================================================================
 // Structures
 //======================================================================================================================
-
-/// Internal offset into the slab that holds the task state.
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
-pub struct InternalId(usize);
 
 #[derive(Default)]
 pub struct Scheduler {
     // A list of groups. We just use direct mapping for identifying these because they are never externalized.
     groups: Slab<TaskGroup>,
 }
+
+/// Internal ids used by the scheduler. These should NEVER be exposed to the application without first going through
+/// the runtime.
+#[derive(Clone, Copy, Hash, PartialEq, Eq, Debug)]
+pub struct SchedulerId(pub usize);
 
 #[derive(Clone, Default)]
 pub struct SharedScheduler(SharedObject<Scheduler>);
@@ -40,34 +44,30 @@ pub struct SharedScheduler(SharedObject<Scheduler>);
 //======================================================================================================================
 
 impl Scheduler {
-    pub fn create_group(&mut self) -> TaskId {
-        let internal_id: InternalId = self.groups.insert(TaskGroup::default()).into();
-        // Returns an identifier for the group directly derived from the offset.
-        Into::<u64>::into(internal_id).into()
+    pub fn create_group(&mut self) -> SchedulerId {
+        self.groups.insert(TaskGroup::default()).into()
     }
 
-    fn get_group(&self, id: TaskId) -> Option<&TaskGroup> {
-        // Get the internal id of the parent task or group.
-        let group_id: InternalId = Into::<u64>::into(id).into();
-        self.groups.get(group_id.into())
-    }
-
-    fn get_mut_group(&mut self, id: TaskId) -> Option<&mut TaskGroup> {
-        let group_id: InternalId = Into::<u64>::into(id).into();
-        self.groups.get_mut(group_id.into())
+    fn get_mut_group(&mut self, id: SchedulerId) -> Option<&mut TaskGroup> {
+        self.groups.get_mut(id.into())
     }
 
     /// The parent id can either be the id of the group or another task in the same group.
-    pub fn insert_task<T: Task>(&mut self, group_id: TaskId, task: T) -> Option<TaskId> {
+    pub fn insert_task<T: Task>(&mut self, group_id: SchedulerId, task: T) -> Option<SchedulerId> {
         let group: &mut TaskGroup = self.get_mut_group(group_id)?;
         group.insert(Box::new(task))
+    }
+
+    pub fn get_mut_task(&mut self, group_id: SchedulerId, task_id: SchedulerId) -> Option<Pin<&mut Box<dyn Task>>> {
+        let group: &mut TaskGroup = self.get_mut_group(group_id)?;
+        group.get_mut_task(task_id.into())
     }
 
     /// Polls all ready tasks in this group until there are no runnable ones. Do not use this function on coroutines
     /// that use poll_yield, unless max_iterations is set.
     pub fn poll_group_until_unrunnable(
         &mut self,
-        group_id: TaskId,
+        group_id: SchedulerId,
         max_iterations: Option<usize>,
     ) -> Vec<Box<dyn Task>> {
         let mut completed_tasks: Vec<Box<dyn Task>> = vec![];
@@ -97,7 +97,7 @@ impl Scheduler {
     }
 
     /// Polls all of the ready tasks in this group. Only check for new tasks at the beginning.
-    pub fn poll_group_once(&mut self, group_id: TaskId, max_iterations: Option<usize>) -> Vec<Box<dyn Task>> {
+    pub fn poll_group_once(&mut self, group_id: SchedulerId, max_iterations: Option<usize>) -> Vec<Box<dyn Task>> {
         let mut completed_tasks: Vec<Box<dyn Task>> = vec![];
         let mut polled_iterations: usize = 0;
         // Expect is safe here because something has really gone wrong if we are polling a group that doesn't exist.
@@ -115,24 +115,6 @@ impl Scheduler {
             }
         }
         completed_tasks
-    }
-
-    pub fn is_valid_task(&self, group_id: &TaskId, task_id: &TaskId) -> bool {
-        if let Some(group) = self.get_group(*group_id) {
-            group.is_valid_task(&task_id)
-        } else {
-            false
-        }
-    }
-
-    #[cfg(not(feature = "direct-mapping"))]
-    #[cfg(test)]
-    pub fn num_tasks(&self) -> usize {
-        let mut num_tasks: usize = 0;
-        for (_, group) in self.groups.iter() {
-            num_tasks += group.num_tasks();
-        }
-        num_tasks
     }
 }
 
@@ -154,26 +136,26 @@ impl DerefMut for SharedScheduler {
     }
 }
 
-impl From<usize> for InternalId {
+impl From<usize> for SchedulerId {
     fn from(value: usize) -> Self {
         Self(value)
     }
 }
 
-impl From<InternalId> for usize {
-    fn from(value: InternalId) -> Self {
+impl From<SchedulerId> for usize {
+    fn from(value: SchedulerId) -> Self {
         value.0
     }
 }
 
-impl From<u64> for InternalId {
+impl From<u64> for SchedulerId {
     fn from(value: u64) -> Self {
         Self(value as usize)
     }
 }
 
-impl From<InternalId> for u64 {
-    fn from(value: InternalId) -> Self {
+impl From<SchedulerId> for u64 {
+    fn from(value: SchedulerId) -> Self {
         value.0 as u64
     }
 }
@@ -187,7 +169,7 @@ mod tests {
     use crate::{
         expect_some,
         runtime::scheduler::{
-            scheduler::{Scheduler, TaskId},
+            scheduler::{Scheduler, SchedulerId},
             task::TaskWithResult,
         },
     };
@@ -233,7 +215,7 @@ mod tests {
     #[test]
     fn insert_creates_unique_tasks_ids() -> Result<()> {
         let mut scheduler: Scheduler = Scheduler::default();
-        let group_id: TaskId = scheduler.create_group();
+        let group_id: SchedulerId = scheduler.create_group();
 
         // Insert a task and make sure the task id is not a simple counter.
         let task: DummyTask = DummyTask::new("testing", Box::pin(DummyCoroutine::new(0).fuse()));
@@ -253,41 +235,19 @@ mod tests {
     }
 
     #[test]
-    fn poll_once_with_one_small_task_completes_it() -> Result<()> {
+    fn poll_group_with_one_small_task_completes_it() -> Result<()> {
         let mut scheduler: Scheduler = Scheduler::default();
-        let group_id: TaskId = scheduler.create_group();
+        let group_id: SchedulerId = scheduler.create_group();
 
         // Insert a single future in the scheduler. This future shall complete with a single poll operation.
         let task: DummyTask = DummyTask::new("testing", Box::pin(DummyCoroutine::new(0).fuse()));
-        let Some(task_id) = scheduler.insert_task(group_id, task) else {
+        let Some(_) = scheduler.insert_task(group_id, task) else {
             anyhow::bail!("insert() failed")
         };
 
         // All futures are inserted in the scheduler with notification flag set.
         // By polling once, our future should complete.
-        if let Some(task) = scheduler.poll_group_once(group_id, None).pop() {
-            crate::ensure_eq!(task.get_id(), task_id);
-        } else {
-            anyhow::bail!("task should have completed");
-        }
-        Ok(())
-    }
-
-    #[test]
-    fn poll_next_with_one_small_task_completes_it() -> Result<()> {
-        let mut scheduler: Scheduler = Scheduler::default();
-        let group_id: TaskId = scheduler.create_group();
-
-        // Insert a single future in the scheduler. This future shall complete with a single poll operation.
-        let task: DummyTask = DummyTask::new("testing", Box::pin(DummyCoroutine::new(0).fuse()));
-        let Some(task_id) = scheduler.insert_task(group_id, task) else {
-            anyhow::bail!("insert() failed")
-        };
-
-        // All futures are inserted in the scheduler with notification flag set.
-        // By polling once, our future should complete.
-        if let Some(task) = scheduler.poll_group_once(group_id, None).pop() {
-            crate::ensure_eq!(task_id, task.get_id());
+        if let Some(_) = scheduler.poll_group_once(group_id, None).pop() {
             Ok(())
         } else {
             anyhow::bail!("task should have completed")
@@ -295,48 +255,44 @@ mod tests {
     }
 
     #[test]
-    fn poll_twice_with_one_long_task_completes_it() -> Result<()> {
+    fn poll_group_twice_with_one_long_task_completes_it() -> Result<()> {
         let mut scheduler: Scheduler = Scheduler::default();
-        let group_id: TaskId = scheduler.create_group();
+        let group_id: SchedulerId = scheduler.create_group();
 
         // Insert a single future in the scheduler. This future shall complete
         // with two poll operations.
         let task: DummyTask = DummyTask::new("testing", Box::pin(DummyCoroutine::new(1).fuse()));
-        let Some(task_id) = scheduler.insert_task(group_id, task) else {
+        let Some(_) = scheduler.insert_task(group_id, task) else {
             anyhow::bail!("insert() failed")
         };
 
         // All futures are inserted in the scheduler with notification flag set.
         // By polling once, this future should make a transition.
-        // All futures are inserted in the scheduler with notification flag set.
-        // By polling once, our future should complete.
         let result = scheduler.poll_group_once(group_id, None).pop();
         crate::ensure_eq!(result.is_some(), false);
 
         // This shall make the future ready.
-        if let Some(task) = scheduler.poll_group_once(group_id, None).pop() {
-            crate::ensure_eq!(task.get_id(), task_id);
+        if let Some(_) = scheduler.poll_group_once(group_id, None).pop() {
+            Ok(())
         } else {
             anyhow::bail!("task should have completed");
         }
-        Ok(())
     }
 
     #[test]
-    fn poll_next_with_one_long_task_completes_it() -> Result<()> {
+    fn poll_until_unrunnable_with_one_long_task_completes_it() -> Result<()> {
         let mut scheduler: Scheduler = Scheduler::default();
-        let group_id: TaskId = scheduler.create_group();
+        let group_id: SchedulerId = scheduler.create_group();
 
         // Insert a single future in the scheduler. This future shall complete with a single poll operation.
         let task: DummyTask = DummyTask::new("testing", Box::pin(DummyCoroutine::new(0).fuse()));
-        let Some(task_id) = scheduler.insert_task(group_id, task) else {
+        let Some(_) = scheduler.insert_task(group_id, task) else {
             anyhow::bail!("insert() failed")
         };
 
         // All futures are inserted in the scheduler with notification flag set.
         // By polling until the task completes, our future should complete.
-        if let Some(task) = scheduler.poll_group_until_unrunnable(group_id, None).pop() {
-            crate::ensure_eq!(task_id, task.get_id());
+        if let Some(_) = scheduler.poll_group_until_unrunnable(group_id, None).pop() {
             Ok(())
         } else {
             anyhow::bail!("task should have completed")
@@ -347,7 +303,7 @@ mod tests {
     #[test]
     fn insert_consecutive_creates_unique_task_ids() -> Result<()> {
         let mut scheduler: Scheduler = Scheduler::default();
-        let group_id: TaskId = scheduler.create_group();
+        let group_id: SchedulerId = scheduler.create_group();
 
         // Create and run a task.
         let task: DummyTask = DummyTask::new("testing", Box::pin(DummyCoroutine::new(0).fuse()));
@@ -369,11 +325,11 @@ mod tests {
     #[bench]
     fn insert_bench(b: &mut Bencher) {
         let mut scheduler: Scheduler = Scheduler::default();
-        let group_id: TaskId = scheduler.create_group();
+        let group_id: SchedulerId = scheduler.create_group();
 
         b.iter(|| {
             let task: DummyTask = DummyTask::new("testing", Box::pin(black_box(DummyCoroutine::default().fuse())));
-            let task_id: TaskId = expect_some!(
+            let task_id: SchedulerId = expect_some!(
                 scheduler.insert_task(group_id, task),
                 "couldn't insert future in scheduler"
             );
@@ -382,12 +338,12 @@ mod tests {
     }
 
     #[bench]
-    fn poll_one_task_bench(b: &mut Bencher) {
+    fn benchmark_poll_one_task_at_a_time(b: &mut Bencher) {
         let mut scheduler: Scheduler = Scheduler::default();
-        let group_id: TaskId = scheduler.create_group();
+        let group_id: SchedulerId = scheduler.create_group();
 
         const NUM_TASKS: usize = 1024;
-        let mut task_ids: Vec<TaskId> = Vec::<TaskId>::with_capacity(NUM_TASKS);
+        let mut task_ids: Vec<SchedulerId> = Vec::<SchedulerId>::with_capacity(NUM_TASKS);
 
         for val in 0..NUM_TASKS {
             let task: DummyTask = DummyTask::new("testing", Box::pin(DummyCoroutine::new(val).fuse()));
@@ -398,17 +354,17 @@ mod tests {
         }
 
         b.iter(|| {
-            black_box(scheduler.poll_group_once(group_id, Some(1)));
+            black_box(scheduler.poll_group_once(group_id, None));
         });
     }
 
     #[bench]
     fn poll_many_tasks_until_done_bench(b: &mut Bencher) {
         let mut scheduler: Scheduler = Scheduler::default();
-        let group_id: TaskId = scheduler.create_group();
+        let group_id: SchedulerId = scheduler.create_group();
 
         const NUM_TASKS: usize = 8;
-        let mut task_ids: Vec<TaskId> = Vec::<TaskId>::with_capacity(NUM_TASKS);
+        let mut task_ids: Vec<SchedulerId> = Vec::<SchedulerId>::with_capacity(NUM_TASKS);
 
         for val in 0..NUM_TASKS {
             let task: DummyTask = DummyTask::new("testing", Box::pin(DummyCoroutine::new(val).fuse()));

--- a/src/rust/runtime/scheduler/task.rs
+++ b/src/rust/runtime/scheduler/task.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-use crate::expect_some;
 /// A Task is the abstraction that represents processes in Demikernel. Each Task runs a single async function, which
 /// represents a coroutine, until it completes. The Task then stores the result until get_result is called.
 ///
@@ -40,17 +39,13 @@ use ::std::{
 // Structures
 //======================================================================================================================
 
-/// Externally visible task identifier.
-#[derive(Clone, Copy, Hash, PartialEq, Eq, Debug)]
-pub struct TaskId(pub u64);
-
 /// Task runs a single coroutine to completion and stores the result for later. Thus, it implements Future but
 /// never directly returns anything.
 pub trait Task: FusedFuture<Output = ()> + Unpin + Any {
     fn get_name(&self) -> &'static str;
     fn as_any(self: Box<Self>) -> Box<dyn Any>;
-    fn get_id(&self) -> TaskId;
-    fn set_id(&mut self, id: TaskId);
+    fn get_id(&self) -> Option<u64>;
+    fn set_id(&mut self, id: u64);
 }
 
 /// This trait is just for convenience of having defined associated types because we cannot define them on the struct
@@ -64,7 +59,7 @@ pub trait TaskWith: TryFrom<Box<dyn Any>> {
 pub struct TaskWithResult<R: Unpin + Clone + Any> {
     /// The libOS should use this to identify the type of task.
     name: &'static str,
-    task_id: Option<TaskId>,
+    task_id: Option<u64>,
     coroutine: Pin<<Self as TaskWith>::Coroutine>,
     result: Option<<Self as TaskWith>::ResultType>,
 }
@@ -93,18 +88,6 @@ impl<R: Unpin + Clone + Any> TaskWithResult<R> {
 // Trait Implementations
 //======================================================================================================================
 
-impl From<u64> for TaskId {
-    fn from(value: u64) -> Self {
-        Self(value)
-    }
-}
-
-impl From<TaskId> for u64 {
-    fn from(value: TaskId) -> Self {
-        value.0
-    }
-}
-
 /// Define the Coroutine type and returned ResultType.
 impl<R: Unpin + Clone + Any> TaskWith for TaskWithResult<R> {
     type Coroutine = Box<dyn FusedFuture<Output = R>>;
@@ -132,11 +115,11 @@ impl<R: Unpin + Clone + Any> Task for TaskWithResult<R> {
         self
     }
 
-    fn get_id(&self) -> TaskId {
-        expect_some!(self.task_id, "should have this set immediately")
+    fn get_id(&self) -> Option<u64> {
+        self.task_id
     }
 
-    fn set_id(&mut self, id: TaskId) {
+    fn set_id(&mut self, id: u64) {
         self.task_id = Some(id);
     }
 }


### PR DESCRIPTION
This PR begins to move id_maps into a single unified place and use the data structure in a organized way to allocate ids.