### PR TITLE
[dpdk-bindings] Enhancement: add indirect buffer methods

### DIFF
--- a/dpdk_bindings/Cargo.toml
+++ b/dpdk_bindings/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "demikernel-dpdk-bindings"
-version = "1.1.6"
+version = "1.1.7"
 authors = ["Microsoft Corporation"]
 edition = "2021"
 description = "Rust Bindings for Libdpdk"

--- a/dpdk_bindings/inlined.c
+++ b/dpdk_bindings/inlined.c
@@ -102,3 +102,13 @@ char *rte_pktmbuf_prepend_(struct rte_mbuf *m, uint16_t len)
 {
     return rte_pktmbuf_prepend(m, len);
 }
+
+struct rte_mbuf *rte_mbuf_from_indirect_(struct rte_mbuf *mi)
+{
+    return rte_mbuf_from_indirect(mi);
+} 	
+
+void rte_pktmbuf_detach_(struct rte_mbuf *m)
+{
+    rte_pktmbuf_detach(m);
+}

--- a/dpdk_bindings/src/lib.rs
+++ b/dpdk_bindings/src/lib.rs
@@ -30,6 +30,8 @@ extern "C" {
     fn rte_eth_rx_offload_udp_cksum_() -> c_int;
     fn rte_eth_tx_offload_multi_segs_() -> c_int;
     fn rte_pktmbuf_prepend_(m: *mut rte_mbuf, len: u16) -> *mut c_char;
+    fn rte_mbuf_from_indirect_(m: *mut rte_mbuf) -> *mut rte_mbuf;
+    fn rte_pktmbuf_detach_(m: *mut rte_mbuf);
 }
 
 #[cfg(all(feature = "mlx5", target_os = "windows"))]
@@ -155,4 +157,14 @@ pub unsafe fn rte_eth_tx_offload_multi_segs() -> c_int {
 #[inline]
 pub unsafe fn rte_pktmbuf_prepend(m: *mut rte_mbuf, len: u16) -> *mut c_char {
     rte_pktmbuf_prepend_(m, len)
+}
+
+#[inline]
+pub unsafe fn rte_mbuf_from_indirect(m: *mut rte_mbuf) -> *mut rte_mbuf {
+    rte_mbuf_from_indirect_(m)
+}
+
+#[inline]
+pub unsafe fn rte_pktmbuf_detach(m: *mut rte_mbuf) {
+    rte_pktmbuf_detach_(m)
 }


### PR DESCRIPTION
Add a few methods to DPDK bindings to support indirect buffers for upcoming memory pooling changes.