### PR TITLE
[runtime] Enhancement: Add id map to I/O queue table

### DIFF
--- a/network_simulator/input/tcp/accept/accept-blocking-1.pkt
+++ b/network_simulator/input/tcp/accept/accept-blocking-1.pkt
@@ -1,7 +1,7 @@
 // Test for blocking accept.
 
 // Accept a connection.
- +.0 socket(..., SOCK_STREAM, IPPROTO_TCP) = 500
++.0 socket(..., SOCK_STREAM, IPPROTO_TCP) = 500
 +.0 bind(500, ..., ...) = 0
 +.0 listen(500, 1) = 0
 +.2 accept(500, ..., ...) = 0

--- a/src/rust/collections/id_map/direct_map.rs
+++ b/src/rust/collections/id_map/direct_map.rs
@@ -2,10 +2,18 @@
 // Licensed under the MIT license.
 
 //======================================================================================================================
+// Constants
+//======================================================================================================================
+
+// Value that we use to offset direct mapping for 32 bit ids. This number is chosen to avoid collisions with a small
+// default set of POSIX file descriptors.
+const ID_OFFSET: u32 = 500;
+
+//======================================================================================================================
 // Associate Functions
 //======================================================================================================================
 
-impl<E: Eq + Hash + From<u64> + Into<u64> + Copy, I: From<u64> + Into<u64> + Copy> IdMap<E, I> {
+impl<E: Eq + Hash + From<u64> + Into<u64> + Copy, I: From<u64> + Into<u64> + Copy> Id64Map<E, I> {
     #[inline(always)]
     pub fn get(&self, external_id: &E) -> Option<I> {
         Some(Self::mask_id(external_id))
@@ -35,15 +43,45 @@ impl<E: Eq + Hash + From<u64> + Into<u64> + Copy, I: From<u64> + Into<u64> + Cop
     }
 }
 
+impl<E: Eq + Hash + From<u32> + Into<u32> + Copy, I: From<u32> + Into<u32> + Copy> Id32Map<E, I> {
+    #[inline(always)]
+    pub fn get(&self, external_id: &E) -> Option<I> {
+        Some(Into::<I>::into(Into::<u32>::into(*external_id).checked_sub(ID_OFFSET)?))
+    }
+
+    #[inline(always)]
+    pub fn remove(&mut self, external_id: &E) -> Option<I> {
+        Some(Into::<I>::into(Into::<u32>::into(*external_id).checked_sub(ID_OFFSET)?))
+    }
+
+    #[inline(always)]
+    pub fn insert_with_new_id(&mut self, internal_id: I) -> Option<E> {
+        match TryInto::<u32>::try_into(Into::<u32>::into(internal_id)) {
+            Ok(id) => Some(
+                id.checked_add(ID_OFFSET)
+                    .expect("should not run out of 32-bit id space")
+                    .into(),
+            ),
+            Err(_) => None,
+        }
+    }
+}
+
 //======================================================================================================================
 // Trait Implementations
 //======================================================================================================================
 
-impl<E: Eq + Hash + From<u64> + Into<u64> + Copy, I: From<u64> + Into<u64> + Copy> Default for IdMap<E, I> {
+impl<E: Eq + Hash + From<u64> + Into<u64> + Copy, I: From<u64> + Into<u64> + Copy> Default for Id64Map<E, I> {
     fn default() -> Self {
         Self {
             _phantom: PhantomData,
             current_id: 1,
         }
+    }
+}
+
+impl<E: Eq + Hash + From<u32> + Into<u32> + Copy, I: From<u32> + Into<u32> + Copy> Default for Id32Map<E, I> {
+    fn default() -> Self {
+        Self { _phantom: PhantomData }
     }
 }

--- a/src/rust/collections/id_map/indirect_map.rs
+++ b/src/rust/collections/id_map/indirect_map.rs
@@ -13,12 +13,14 @@ const MAX_RETRIES_ID_ALLOC: usize = 500;
 /// Seed for the random number generator.
 #[cfg(debug_assertions)]
 const RNG_SEED: u64 = 42;
+#[cfg(not(debug_assertions))]
+const DEFAULT_ID: u64 = 500;
 
 //======================================================================================================================
 // Associate Functions
 //======================================================================================================================
 
-impl<E: Eq + Hash + From<u64> + Into<u64> + Copy, I: From<u64> + Into<u64> + Copy> IdMap<E, I> {
+impl<E: Eq + Hash + From<u64> + Into<u64> + Copy, I: From<u64> + Into<u64> + Copy> Id64Map<E, I> {
     pub fn get(&self, external_id: &E) -> Option<I> {
         self.ids.get(external_id).copied()
     }
@@ -56,19 +58,67 @@ impl<E: Eq + Hash + From<u64> + Into<u64> + Copy, I: From<u64> + Into<u64> + Cop
     }
 }
 
+impl<E: Eq + Hash + From<u32> + Into<u32> + Copy, I: From<u32> + Into<u32> + Copy> Id32Map<E, I> {
+    pub fn get(&self, external_id: &E) -> Option<I> {
+        self.ids.get(external_id).copied()
+    }
+
+    /// Remove a mapping between a specificed external and internal id. If the mapping exists, then return the internal
+    /// id mapped to the external id.
+    pub fn remove(&mut self, external_id: &E) -> Option<I> {
+        self.ids.remove(external_id)
+    }
+
+    /// Generate a new id and insert the mapping to the internal id. If the id is currently in use, keep generating
+    /// until we find an unused id (up to a maximum number of tries).
+    pub fn insert_with_new_id(&mut self, internal_id: I) -> Option<E> {
+        for _ in 0..MAX_RETRIES_ID_ALLOC {
+            let external_id: E = E::from(self.generate_id());
+            if !self.ids.contains_key(&external_id) {
+                self.ids.insert(external_id, internal_id);
+                return Some(external_id);
+            }
+        }
+        warn!("Could not find a valid task id");
+        None
+    }
+
+    #[cfg(debug_assertions)]
+    fn generate_id(&mut self) -> u32 {
+        self.rng.next_u32()
+    }
+
+    #[cfg(not(debug_assertions))]
+    fn generate_id(&mut self) -> u32 {
+        self.current_id = self.current_id.wrapping_add(1);
+        self.current_id
+    }
+}
+
 //======================================================================================================================
 // Trait Implementations
 //======================================================================================================================
 
-impl<E: Eq + Hash + From<u64> + Into<u64> + Copy, I: From<u64> + Into<u64> + Copy> Default for IdMap<E, I> {
+impl<E: Eq + Hash + From<u64> + Into<u64> + Copy, I: From<u64> + Into<u64> + Copy> Default for Id64Map<E, I> {
     fn default() -> Self {
         Self {
-            // Don't need to pre-allocate, the overhead is a 6ns on the scheduler insert benchmark.
             ids: HashMap::<E, I>::with_capacity(DEFAULT_SIZE),
             #[cfg(debug_assertions)]
             rng: SmallRng::seed_from_u64(RNG_SEED),
             #[cfg(not(debug_assertions))]
-            current_id: 1,
+            current_id: DEFAULT_ID,
+        }
+    }
+}
+
+impl<E: Eq + Hash + From<u32> + Into<u32> + Copy, I: From<u32> + Into<u32> + Copy> Default for Id32Map<E, I> {
+    fn default() -> Self {
+        Self {
+            ids: HashMap::<E, I>::with_capacity(DEFAULT_SIZE),
+            #[cfg(debug_assertions)]
+            rng: SmallRng::seed_from_u64(RNG_SEED),
+            #[cfg(not(debug_assertions))]
+            current_id: DEFAULT_ID as u32,
         }
     }
 }

--- a/src/rust/collections/id_map/mod.rs
+++ b/src/rust/collections/id_map/mod.rs
@@ -13,14 +13,21 @@ use ::std::hash::Hash;
 #[cfg(feature = "direct-mapping")]
 use ::std::marker::PhantomData;
 
+//======================================================================================================================
+// Structures
+//======================================================================================================================
+
+/// A 64-bit mapping table for IDs. This table uses monotonically increasing ids that directly indexes into the slab
+/// offset in "direct-mapping" mode. With "direct-mapping" off, the table uses random ids with a hashmap for
+/// dereferencing.
 #[cfg(feature = "direct-mapping")]
-pub struct IdMap<E: Eq + Hash + From<u64> + Into<u64> + Copy, I: From<u64> + Into<u64> + Copy> {
+pub struct Id64Map<E: Eq + Hash + From<u64> + Into<u64> + Copy, I: From<u64> + Into<u64> + Copy> {
     _phantom: PhantomData<(E, I)>,
     current_id: u64,
 }
 
 #[cfg(not(feature = "direct-mapping"))]
-pub struct IdMap<E: Eq + Hash + From<u64> + Into<u64> + Copy, I: From<u64> + Into<u64> + Copy> {
+pub struct Id64Map<E: Eq + Hash + From<u64> + Into<u64> + Copy, I: From<u64> + Into<u64> + Copy> {
     /// Map between external and internal ids.
     ids: HashMap<E, I>,
     /// Small random number generator for external ids.
@@ -28,6 +35,23 @@ pub struct IdMap<E: Eq + Hash + From<u64> + Into<u64> + Copy, I: From<u64> + Int
     rng: SmallRng,
     #[cfg(not(debug_assertions))]
     current_id: u64,
+}
+
+/// Same as the 64-bit table but a 32-bit to 32-bit id mapping table for ids that will be externalized as uints.
+#[cfg(feature = "direct-mapping")]
+pub struct Id32Map<E: Eq + Hash + From<u32> + Into<u32> + Copy, I: From<u32> + Into<u32> + Copy> {
+    _phantom: PhantomData<(E, I)>,
+}
+
+#[cfg(not(feature = "direct-mapping"))]
+pub struct Id32Map<E: Eq + Hash + From<u32> + Into<u32> + Copy, I: From<u32> + Into<u32> + Copy> {
+    /// Map between external and internal ids.
+    ids: HashMap<E, I>,
+    /// Small random number generator for external ids.
+    #[cfg(debug_assertions)]
+    rng: SmallRng,
+    #[cfg(not(debug_assertions))]
+    current_id: u32,
 }
 
 #[cfg(feature = "direct-mapping")]

--- a/src/rust/inetstack/protocols/layer4/tcp/tests/simulator.rs
+++ b/src/rust/inetstack/protocols/layer4/tcp/tests/simulator.rs
@@ -492,9 +492,23 @@ impl Simulation {
         };
 
         let syscall_qd: QDesc = match args.qd {
-            Some(qd) => qd.into(),
-            None => {
-                anyhow::bail!("remote queue descriptor must have been previously assigned");
+            // 500 in the annotation will represent the local queue descriptor number because they are allocated
+            // starting at 500.
+            Some(qd) if qd == 500 => match self.local_qd {
+                Some((_, qd)) => qd,
+                None => {
+                    let cause: String = format!("unexpected return for push syscall");
+                    info!("run_push_syscall(): ret={:?}", ret);
+                    anyhow::bail!(cause);
+                },
+            },
+            _ => match self.remote_qd {
+                Some((_, Some(qd))) => qd,
+                _ => {
+                    let cause: String = format!("unexpected return for push syscall");
+                    info!("run_push_syscall(): ret={:?}", ret);
+                    anyhow::bail!(cause);
+                },
             },
         };
 
@@ -514,7 +528,24 @@ impl Simulation {
     }
 
     fn run_pop_syscall(&mut self, args: &PopArgs, ret: i32) -> Result<()> {
-        let remote_qd: QDesc = args.qd.into();
+        let remote_qd: QDesc = match args.qd {
+            qd if qd == 500 => match self.local_qd {
+                Some((_, qd)) => qd,
+                None => {
+                    let cause: String = format!("unexpected return for pushto syscall");
+                    info!("run_pop_syscall(): ret={:?}", ret);
+                    anyhow::bail!(cause);
+                },
+            },
+            _ => match self.remote_qd {
+                Some((_, Some(qd))) => qd,
+                _ => {
+                    let cause: String = format!("unexpected return for pop syscall");
+                    info!("run_pop_syscall(): ret={:?}", ret);
+                    anyhow::bail!(cause);
+                },
+            },
+        };
 
         match self.protocol {
             Some(IpProtocol::TCP) => match self.engine.tcp_pop(remote_qd) {
@@ -549,18 +580,9 @@ impl Simulation {
         }
     }
 
-    fn run_wait_syscall(&mut self, args: &WaitArgs, ret: i32) -> Result<()> {
-        let args_qd: QDesc = match args.qd {
-            Some(qd) => QDesc::from(qd),
-            None => {
-                let cause: String = format!("queue descriptor must be informed");
-                info!("run_wait_syscall(): {:?}", cause);
-                anyhow::bail!(cause);
-            },
-        };
-
+    fn run_wait_syscall(&mut self, _: &WaitArgs, ret: i32) -> Result<()> {
         match self.has_operation_completed() {
-            Ok((qd, qr)) if args_qd == qd => match qr {
+            Ok((qd, qr)) => match qr {
                 OperationResult::Accept((remote_qd, remote_addr)) if ret == 0 => {
                     info!("connection accepted (qd={:?}, addr={:?})", qd, remote_addr);
                     self.remote_qd = Some((self.remote_qd.unwrap().0, Some(remote_qd)));
@@ -619,9 +641,21 @@ impl Simulation {
         };
 
         let remote_qd: QDesc = match args.qd {
-            Some(qd) => qd.into(),
-            None => {
-                anyhow::bail!("remote queue descriptor must have been previously assigned");
+            Some(qd) if qd == 500 => match self.local_qd {
+                Some((_, qd)) => qd,
+                None => {
+                    let cause: String = format!("unexpected return for pushto syscall");
+                    info!("run_pushto_syscall(): ret={:?}", ret);
+                    anyhow::bail!(cause);
+                },
+            },
+            _ => match self.remote_qd {
+                Some((_, Some(qd))) => qd,
+                _ => {
+                    let cause: String = format!("unexpected return for pushto syscall");
+                    info!("run_pushto_syscall(): ret={:?}", ret);
+                    anyhow::bail!(cause);
+                },
             },
         };
 
@@ -640,9 +674,26 @@ impl Simulation {
     }
 
     fn run_close_syscall(&mut self, args: &CloseArgs, ret: i32) -> Result<()> {
-        let args_qd: QDesc = args.qd.into();
+        let qd: QDesc = match args.qd {
+            qd if qd == 500 => match self.local_qd {
+                Some((_, qd)) => qd,
+                None => {
+                    let cause: String = format!("unexpected return for close syscall");
+                    info!("run_close_syscall(): ret={:?}", ret);
+                    anyhow::bail!(cause);
+                },
+            },
+            _ => match self.remote_qd {
+                Some((_, Some(qd))) => qd,
+                _ => {
+                    let cause: String = format!("unexpected return for close syscall");
+                    info!("run_close_syscall(): ret={:?}", ret);
+                    anyhow::bail!(cause);
+                },
+            },
+        };
 
-        match self.engine.tcp_async_close(args_qd) {
+        match self.engine.tcp_async_close(qd) {
             Ok(close_qt) => {
                 self.inflight.push_back(close_qt);
                 Ok(())

--- a/src/rust/runtime/mod.rs
+++ b/src/rust/runtime/mod.rs
@@ -34,7 +34,7 @@ pub use demikernel_xdp_bindings as libxdp;
 use crate::coroutine_timer;
 
 use crate::{
-    collections::id_map::IdMap,
+    collections::id_map::Id64Map,
     expect_some,
     runtime::{
         fail::Fail,
@@ -73,7 +73,7 @@ pub struct DemiRuntime {
     qtable: IoQueueTable,
     // Holds the mapping between qtoken and task id. Initialized to invalid id until we insert the task into the
     // scheduler and get the real id.
-    qtoken_to_scheduler_id: IdMap<QToken, SchedulerId>,
+    qtoken_to_scheduler_id: Id64Map<QToken, SchedulerId>,
     scheduler: SharedScheduler,
     foreground_group_id: SchedulerId,
     background_group_id: SchedulerId,
@@ -117,7 +117,7 @@ impl SharedDemiRuntime {
         let background_group_id: SchedulerId = scheduler.create_group();
         Self(SharedObject::<DemiRuntime>::new(DemiRuntime {
             qtable: IoQueueTable::default(),
-            qtoken_to_scheduler_id: IdMap::default(),
+            qtoken_to_scheduler_id: Id64Map::default(),
             scheduler,
             foreground_group_id,
             background_group_id,
@@ -475,7 +475,7 @@ impl Default for SharedDemiRuntime {
         let background_group_id: SchedulerId = scheduler.create_group();
         Self(SharedObject::<DemiRuntime>::new(DemiRuntime {
             qtable: IoQueueTable::default(),
-            qtoken_to_scheduler_id: IdMap::default(),
+            qtoken_to_scheduler_id: Id64Map::default(),
             scheduler,
             foreground_group_id,
             background_group_id,

--- a/src/rust/runtime/queue/mod.rs
+++ b/src/rust/runtime/queue/mod.rs
@@ -10,7 +10,11 @@ mod qtype;
 // Imports
 //======================================================================================================================
 
-use crate::runtime::{fail::Fail, scheduler::TaskWithResult};
+use crate::{
+    collections::id_map::Id32Map,
+    expect_some,
+    runtime::{fail::Fail, scheduler::TaskWithResult},
+};
 use ::slab::{Iter, Slab};
 use ::std::{any::Any, net::SocketAddrV4};
 
@@ -29,6 +33,9 @@ pub type BackgroundTask = TaskWithResult<()>;
 // Structures
 //======================================================================================================================
 
+#[derive(Clone, Copy)]
+struct InternalId(usize);
+
 pub trait IoQueue: Any {
     fn get_qtype(&self) -> QType;
     fn as_any_ref(&self) -> &dyn Any;
@@ -43,6 +50,7 @@ pub trait NetworkQueue: IoQueue {
 
 /// I/O queue descriptors table.
 pub struct IoQueueTable {
+    qd_to_offset: Id32Map<QDesc, InternalId>,
     table: Slab<Box<dyn IoQueue>>,
 }
 
@@ -52,100 +60,43 @@ pub struct IoQueueTable {
 
 /// Associated functions for I/O queue descriptors tables.
 impl IoQueueTable {
-    /// Offset for I/O queue descriptors.
-    ///
-    /// When Demikernel is interposing system calls of the underlying OS
-    /// this offset enables us to distinguish I/O queue descriptors from
-    /// file descriptors.
-    ///
-    /// NOTE: This is intentionally set to be half of FD_SETSIZE (1024) in Linux.
-    const BASE_QD: u32 = 500;
-
     /// Allocates a new entry in the target I/O queue descriptors table.
     pub fn alloc<T: IoQueue>(&mut self, queue: T) -> QDesc {
         let index: usize = self.table.insert(Box::new(queue));
-
-        // Ensure that the allocation would yield to a safe conversion between usize to u32.
-        // Note: This imposes a limit on the number of open queue descriptors in u32::MAX.
-        assert!(
-            (index as u32) + Self::BASE_QD <= u32::MAX,
-            "I/O descriptors table overflow"
+        let qd: QDesc = expect_some!(
+            self.qd_to_offset.insert_with_new_id(InternalId(index)),
+            "should be able to allocate an id"
         );
-
-        QDesc::from((index as u32) + Self::BASE_QD)
+        trace!("inserting queue, index {:?} qd {:?}", index, qd);
+        qd
     }
 
     /// Gets the type of the queue.
     pub fn get_type(&self, qd: &QDesc) -> Result<QType, Fail> {
-        let index: u32 = match self.get_index(qd) {
-            Some(index) => index,
-            None => {
-                let cause: String = format!("invalid queue descriptor (qd={:?})", qd);
-                error!("get_type(): {}", &cause);
-                return Err(Fail::new(libc::EBADF, &cause));
-            },
-        };
-        match self.table.get(index as usize) {
-            Some(boxed_queue_ptr) => Ok(boxed_queue_ptr.get_qtype()),
-            None => {
-                let cause: String = format!("invalid queue descriptor (qd={:?})", qd);
-                error!("get_type(): {}", &cause);
-                Err(Fail::new(libc::EBADF, &cause))
-            },
-        }
+        Ok(self.get_queue_ref(qd)?.get_qtype())
     }
 
     /// Gets/borrows a reference to the queue metadata associated with an I/O queue descriptor.
     pub fn get<'a, T: IoQueue>(&'a self, qd: &QDesc) -> Result<&'a T, Fail> {
-        let index: u32 = match self.get_index(qd) {
-            Some(index) => index,
-            None => {
-                let cause: String = format!("invalid queue descriptor (qd={:?})", qd);
-                error!("get(): {}", &cause);
-                return Err(Fail::new(libc::EBADF, &cause));
-            },
-        };
-        match self.table.get(index as usize) {
-            Some(boxed_queue_ptr) => Ok(downcast_queue_ptr::<T>(boxed_queue_ptr)?),
-            None => {
-                let cause: String = format!("invalid queue descriptor (qd={:?})", qd);
-                error!("get(): {}", &cause);
-                Err(Fail::new(libc::EBADF, &cause))
-            },
-        }
+        Ok(downcast_queue_ptr::<T>(self.get_queue_ref(qd)?)?)
     }
 
     /// Gets/borrows a mutable reference to the queue metadata associated with an I/O queue descriptor
     pub fn get_mut<'a, T: IoQueue>(&'a mut self, qd: &QDesc) -> Result<&'a mut T, Fail> {
-        let index: u32 = match self.get_index(qd) {
-            Some(index) => index,
-            None => {
-                let cause: String = format!("invalid queue descriptor (qd={:?})", qd);
-                error!("get_mut(): {}", &cause);
-                return Err(Fail::new(libc::EBADF, &cause));
-            },
-        };
-        match self.table.get_mut(index as usize) {
-            Some(boxed_queue_ptr) => Ok(downcast_mut_ptr::<T>(boxed_queue_ptr)?),
-            None => {
-                let cause: String = format!("invalid queue descriptor (qd={:?})", qd);
-                error!("get_mut(): {}", &cause);
-                Err(Fail::new(libc::EBADF, &cause))
-            },
-        }
+        Ok(downcast_mut_ptr::<T>(self.get_mut_queue_ref(qd)?)?)
     }
 
     /// Releases the entry associated with an I/O queue descriptor.
     pub fn free<T: IoQueue>(&mut self, qd: &QDesc) -> Result<T, Fail> {
-        let index: u32 = match self.get_index(qd) {
-            Some(index) => index,
+        let internal_id: InternalId = match self.qd_to_offset.remove(qd) {
+            Some(id) => id,
             None => {
                 let cause: String = format!("invalid queue descriptor (qd={:?})", qd);
                 error!("free(): {}", &cause);
                 return Err(Fail::new(libc::EBADF, &cause));
             },
         };
-        Ok(downcast_queue::<T>(self.table.remove(index as usize))?)
+        Ok(downcast_queue::<T>(self.table.remove(internal_id.into()))?)
     }
 
     /// Gets an iterator over all registered queues.
@@ -158,16 +109,28 @@ impl IoQueueTable {
     }
 
     /// Gets the index in the I/O queue descriptors table to which a given I/O queue descriptor refers to.
-    fn get_index(&self, qd: &QDesc) -> Option<u32> {
-        if Into::<u32>::into(*qd) < Self::BASE_QD {
-            None
-        } else {
-            let rawqd: u32 = Into::<u32>::into(*qd) - Self::BASE_QD;
-            if !self.table.contains(rawqd as usize) {
-                return None;
+    fn get_queue_ref(&self, qd: &QDesc) -> Result<&Box<dyn IoQueue>, Fail> {
+        if let Some(internal_id) = self.qd_to_offset.get(qd) {
+            if let Some(queue) = self.table.get(internal_id.into()) {
+                return Ok(queue);
             }
-            Some(rawqd)
         }
+
+        let cause: String = format!("invalid queue descriptor (qd={:?})", qd);
+        error!("get(): {}", &cause);
+        Err(Fail::new(libc::EBADF, &cause))
+    }
+
+    fn get_mut_queue_ref(&mut self, qd: &QDesc) -> Result<&mut Box<dyn IoQueue>, Fail> {
+        if let Some(internal_id) = self.qd_to_offset.get(qd) {
+            if let Some(queue) = self.table.get_mut(internal_id.into()) {
+                return Ok(queue);
+            }
+        }
+
+        let cause: String = format!("invalid queue descriptor (qd={:?})", qd);
+        error!("get(): {}", &cause);
+        Err(Fail::new(libc::EBADF, &cause))
     }
 }
 
@@ -228,8 +191,41 @@ pub fn downcast_queue<T: IoQueue>(boxed_queue: Box<dyn IoQueue>) -> Result<T, Fa
 impl Default for IoQueueTable {
     fn default() -> Self {
         Self {
+            qd_to_offset: Id32Map::<QDesc, InternalId>::default(),
             table: Slab::<Box<dyn IoQueue>>::new(),
         }
+    }
+}
+
+impl From<InternalId> for u64 {
+    fn from(val: InternalId) -> Self {
+        val.0 as u64
+    }
+}
+
+impl From<u32> for InternalId {
+    fn from(val: u32) -> Self {
+        InternalId(val as usize)
+    }
+}
+
+impl From<InternalId> for u32 {
+    fn from(val: InternalId) -> Self {
+        TryInto::<u32>::try_into(val.0).unwrap()
+    }
+}
+
+impl From<InternalId> for usize {
+    /// Converts a [InternalId] to a [usize].
+    fn from(val: InternalId) -> Self {
+        val.0
+    }
+}
+
+impl From<usize> for InternalId {
+    /// Converts a [usize] to a [InternalId].
+    fn from(val: usize) -> Self {
+        InternalId(val)
     }
 }
 

--- a/tests/rust/tcp.rs
+++ b/tests/rust/tcp.rs
@@ -518,7 +518,7 @@ mod test {
         let local2: SocketAddr = SocketAddr::new(ALICE_IP, PORT_NUMBER + 1);
 
         // Invalid queue descriptor.
-        match libos.listen(QDesc::from(0), SOMAXCONN as usize) {
+        match libos.listen(QDesc::from(1000), SOMAXCONN as usize) {
             Err(e) if e.errno == libc::EBADF => (),
             _ => {
                 // Close socket if not error because this test cannot continue.
@@ -591,7 +591,7 @@ mod test {
         };
 
         // Invalid queue descriptor.
-        match libos.accept(QDesc::from(0)) {
+        match libos.accept(QDesc::from(1000)) {
             Err(e) if e.errno == libc::EBADF => (),
             _ => {
                 // Close socket if we somehow got a socket back?
@@ -654,7 +654,7 @@ mod test {
             let remote: SocketAddr = SocketAddr::new(ALICE_IP, PORT_NUMBER);
 
             // Bad queue descriptor.
-            match libos.connect(QDesc::from(0), remote) {
+            match libos.connect(QDesc::from(1000), remote) {
                 Err(e) if e.errno == libc::EBADF => (),
                 _ => {
                     // Close socket if not error because this test cannot continue.
@@ -742,8 +742,8 @@ mod test {
             };
 
             // Close bad queue descriptor.
-            match libos.async_close(QDesc::from(2)) {
-                Ok(_) => anyhow::bail!("close() invalid file descriptir should fail"),
+            match libos.async_close(QDesc::from(2000)) {
+                Ok(_) => anyhow::bail!("close() invalid file descriptor should fail"),
                 Err(_) => (),
             };
 
@@ -783,7 +783,7 @@ mod test {
             }
 
             // Close bad queue descriptor.
-            match libos.async_close(QDesc::from(2)) {
+            match libos.async_close(QDesc::from(2000)) {
                 // Should not be able to close bad queue descriptor.
                 Ok(_) => anyhow::bail!("close() invalid queue descriptor should fail"),
                 Err(_) => (),
@@ -889,7 +889,7 @@ mod test {
             }
 
             let bytes = libos.prepare_dummy_buffer(32)?;
-            match libos.push(QDesc::from(2), &bytes) {
+            match libos.push(QDesc::from(2000), &bytes) {
                 Ok(_) => {
                     // Close socket if not error because this test cannot continue.
                     // FIXME: https://github.com/demikernel/demikernel/issues/633
@@ -980,7 +980,7 @@ mod test {
             };
 
             // Pop from bad socket.
-            match libos.pop(QDesc::from(2), None) {
+            match libos.pop(QDesc::from(2000), None) {
                 Ok(_) => {
                     // Close socket if not error.
                     // FIXME: https://github.com/demikernel/demikernel/issues/633


### PR DESCRIPTION
This PR adds an id map to the I/O queue table, instead of our previous implementation that just started at 500. We retain the behavior for direct mapping by having the id map start allocating at 500. 