### PR TITLE
[runtime] Enhancement: return earliest task first and add some tests

### DIFF
--- a/network_simulator/input/tcp/close/close-blocking.pkt
+++ b/network_simulator/input/tcp/close/close-blocking.pkt
@@ -8,11 +8,12 @@
 +.0 TCP > S seq 0(0) win 65535 <mss 1450, wscale 0>
 // Receive SYN-ACK packet.
 +.1 TCP < S. seq 0(0) ack 1 win 65535 <mss 1450, wscale 0>
-// Send ACK on SYN-ACK packet.
-+.0 TCP > . seq 1(0) ack 1 win 65535 <nop>
 
 // Succeed to establish connection.
 +.0 wait(500, ...) = 0
+
+// Send ACK on SYN-ACK packet.
++.0 TCP > . seq 1(0) ack 1 win 65535 <nop>
 
 // Succeed to disconnect.
 +.1 close(500) = 0

--- a/network_simulator/input/tcp/close/close-local-retransmission.pkt
+++ b/network_simulator/input/tcp/close/close-local-retransmission.pkt
@@ -20,23 +20,23 @@
 // Send data packet.
 +0 TCP > P. seq 1(1000) ack 1 win 65535 <nop>
 
-// Close connection.
-+.2 close(500) = 0
-
-// Send FIN segment.
-+.0 TCP > F. seq 1001(0) ack 1 win 65535 <nop>
-
 // Send data packet.
 +4 TCP > P. seq 1(1000) ack 1 win 65535 <nop>
 
 // Receive ACK on data packet.
 +.1 TCP < . seq 1(0) ack 1001 win 65535 <nop>
 
-// Send FIN again since no ack on it yet.
-+.0 TCP > F. seq 1001(0) ack 1 win 65535 <nop>
-
 // Send completes
 +.0 wait(500, ...) = 9
+
+// Close connection.
++.0 close(500) = 0
+
+// Send FIN segment.
++.0 TCP > F. seq 1001(0) ack 1 win 65535 <nop>
+
+// Send FIN again since no ack on it yet.
++4 TCP > F. seq 1001(0) ack 1 win 65535 <nop>
 
 // Receive FIN segment.
 +.1 TCP < F. seq 1(0) ack 1002 win 65535 <nop>

--- a/network_simulator/input/tcp/close/close-local-retransmission.pkt
+++ b/network_simulator/input/tcp/close/close-local-retransmission.pkt
@@ -8,11 +8,12 @@
 +.0 TCP > S seq 0(0) win 65535 <mss 1450, wscale 0>
 // Receive SYN-ACK segment.
 +.1 TCP < S. seq 0(0) ack 1 win 65535 <mss 1450, wscale 0>
-// Send ACK on SYN-ACK segment.
-+.0 TCP > . seq 1(0) ack 1 win 65535 <nop>
 
 // Succeed to establish connection.
 +.0 wait(500, ...) = 0
+
+// Send ACK on SYN-ACK segment.
++.0 TCP > . seq 1(0) ack 1 win 65535 <nop>
 
 // Send data.
 +.1 write(500, ..., 1000) = 1000

--- a/network_simulator/input/tcp/close/close-local.pkt
+++ b/network_simulator/input/tcp/close/close-local.pkt
@@ -8,11 +8,12 @@
 +.0 TCP > S seq 0(0) win 65535 <mss 1450, wscale 0>
 // Receive SYN-ACK segment.
 +.1 TCP < S. seq 0(0) ack 1 win 65535 <mss 1450, wscale 0>
-// Send ACK on SYN-ACK segment.
-+.0 TCP > . seq 1(0) ack 1 win 65535 <nop>
 
 // Succeed to establish connection.
 +.0 wait(500, ...) = 0
+
+// Send ACK on SYN-ACK segment.
++.0 TCP > . seq 1(0) ack 1 win 65535 <nop>
 
 // Close connection.
 +.2 close(500) = 0

--- a/network_simulator/input/tcp/close/close-out-of-order-fin.pkt
+++ b/network_simulator/input/tcp/close/close-out-of-order-fin.pkt
@@ -8,11 +8,13 @@
 +.0 TCP > S seq 0(0) win 65535 <mss 1450, wscale 0>
 // Receive SYN-ACK segment.
 +.1 TCP < S. seq 0(0) ack 1 win 65535 <mss 1450, wscale 0>
-// Send ACK on SYN-ACK segment.
-+.0 TCP > . seq 1(0) ack 1 win 65535 <nop>
 
 // Succeed to establish connection.
 +.0 wait(500, ...) = 0
+
+// Send ACK on SYN-ACK segment.
++.0 TCP > . seq 1(0) ack 1 win 65535 <nop>
+
 
 // Send data.
 +.1 write(500, ..., 1000) = 1000
@@ -23,14 +25,15 @@
 // Receive out of order FIN segment.
 +.1 TCP < F. seq 1001(0) ack 1001 win 65535 <nop>
 
+// Send finished because out of order FIN acked the data .
++.0 wait(500, ...) = 0
+
 // Send ACK packet for out of order data.
 +.0 TCP > . seq 1001(0) ack 1 win 65535 <nop>
 
 // Receive data packet
 +.1 TCP < P. seq 1(1000) ack 1001 win 65535 <nop>
 
-// Send finished.
-+.0 wait(500, ...) = 0
 
 // Send ACK packet for data and FIN.
 +.0 TCP > . seq 1001(0) ack 1002 win 64534 <nop>

--- a/network_simulator/input/tcp/close/close-remote-retransmission.pkt
+++ b/network_simulator/input/tcp/close/close-remote-retransmission.pkt
@@ -8,11 +8,12 @@
 +.0 TCP > S seq 0(0) win 65535 <mss 1450, wscale 0>
 // Receive SYN-ACK segment.
 +.1 TCP < S. seq 0(0) ack 1 win 65535 <mss 1450, wscale 0>
-// Send ACK on SYN-ACK segment.
-+.0 TCP > . seq 1(0) ack 1 win 65535 <nop>
 
 // Succeed to establish connection.
 +.0 wait(500, ...) = 0
+
+// Send ACK on SYN-ACK segment.
++.0 TCP > . seq 1(0) ack 1 win 65535 <nop>
 
 // Receive FIN segment.
 +.1 TCP < F. seq 1(0) ack 1 win 65535 <nop>

--- a/network_simulator/input/tcp/close/close-remote.pkt
+++ b/network_simulator/input/tcp/close/close-remote.pkt
@@ -8,11 +8,12 @@
 +.0 TCP > S seq 0(0) win 65535 <mss 1450, wscale 0>
 // Receive SYN-ACK segment.
 +.1 TCP < S. seq 0(0) ack 1 win 65535 <mss 1450, wscale 0>
-// Send ACK on SYN-ACK segment.
-+.0 TCP > . seq 1(0) ack 1 win 65535 <nop>
 
 // Succeed to establish connection.
 +.0 wait(500, ...) = 0
+
+// Send ACK on SYN-ACK segment.
++.0 TCP > . seq 1(0) ack 1 win 65535 <nop>
 
 // Receive FIN segment.
 +.1 TCP < F. seq 1(0) ack 1 win 65535 <nop>

--- a/network_simulator/input/tcp/close/close-simultaneous.pkt
+++ b/network_simulator/input/tcp/close/close-simultaneous.pkt
@@ -8,11 +8,12 @@
 +.0 TCP > S seq 0(0) win 65535 <mss 1450, wscale 0>
 // Receive SYN-ACK segment.
 +.1 TCP < S. seq 0(0) ack 1 win 65535 <mss 1450, wscale 0>
-// Send ACK on SYN-ACK segment.
-+.0 TCP > . seq 1(0) ack 1 win 65535 <nop>
 
 // Succeed to establish connection.
 +.0 wait(500, ...) = 0
+
+// Send ACK on SYN-ACK segment.
++.0 TCP > . seq 1(0) ack 1 win 65535 <nop>
 
 // Close connection.
 +.2 close(500) = 0

--- a/network_simulator/input/tcp/connect/connect-blocking.pkt
+++ b/network_simulator/input/tcp/connect/connect-blocking.pkt
@@ -8,8 +8,9 @@
 +.0 TCP > S seq 0(0) win 65535 <mss 1450, wscale 0>
 // Receive SYN-ACK packet.
 +.1 TCP < S. seq 0(0) ack 1 win 65535 <mss 1450, wscale 0>
-// Send ACK on SYN-ACK packet.
-+.0 TCP > . seq 1(0) ack 1 win 65535 <nop>
 
 // Succeed to establish connection.
 +.0 wait(500, ...) = 0
+
+// Send ACK on SYN-ACK packet.
++.0 TCP > . seq 1(0) ack 1 win 65535 <nop>

--- a/network_simulator/input/udp/push-blocking.pkt
+++ b/network_simulator/input/udp/push-blocking.pkt
@@ -7,8 +7,8 @@
 // Send data.
 +.1 sendto(500, ..., 1000) = 1000
 
-// Send data packet.
-+.0 UDP > len 1000
-
 // Data sent.
 +.0 wait(500, ...) = 0
+
+// Send data packet.
++.0 UDP > len 1000

--- a/network_simulator/input/udp/push-pop-blocking-1.pkt
+++ b/network_simulator/input/udp/push-pop-blocking-1.pkt
@@ -7,11 +7,11 @@
 // Send data.
 +.1 sendto(500, ..., 1000) = 1000
 
-// Send data packet.
-+.0 UDP > len 1000
-
 // Data sent.
 +.0 wait(500, ...) = 0
+
+// Send data packet.
++.0 UDP > len 1000
 
 // Receive data.
 +.1 read(500, ..., 1000) = 1000

--- a/network_simulator/input/udp/push-pop-blocking-2.pkt
+++ b/network_simulator/input/udp/push-pop-blocking-2.pkt
@@ -7,12 +7,12 @@
 // Send data.
 +.1 sendto(500, ..., 1000) = 1000
 
-// Send data packet.
-+.0 UDP > len 1000
-
 // Data sent.
 +.0 wait(500, ...) = 0
 
+// Send data packet.
++.0 UDP > len 1000
+ 
 // Receive data packet.
 +.0 UDP < len 1000
 

--- a/src/rust/collections/id_map/direct_map.rs
+++ b/src/rust/collections/id_map/direct_map.rs
@@ -15,6 +15,7 @@ const ID_OFFSET: u32 = 500;
 
 impl<E: Eq + Hash + From<u64> + Into<u64> + Copy, I: From<u64> + Into<u64> + Copy> Id64Map<E, I> {
     #[inline(always)]
+    #[allow(unused)]
     pub fn get(&self, external_id: &E) -> Option<I> {
         Some(Self::mask_id(external_id))
     }

--- a/src/rust/collections/id_map/indirect_map.rs
+++ b/src/rust/collections/id_map/indirect_map.rs
@@ -21,6 +21,7 @@ const DEFAULT_ID: u64 = 500;
 //======================================================================================================================
 
 impl<E: Eq + Hash + From<u64> + Into<u64> + Copy, I: From<u64> + Into<u64> + Copy> Id64Map<E, I> {
+    #[allow(unused)]
     pub fn get(&self, external_id: &E) -> Option<I> {
         self.ids.get(external_id).copied()
     }

--- a/src/rust/inetstack/protocols/layer4/tcp/established/receiver.rs
+++ b/src/rust/inetstack/protocols/layer4/tcp/established/receiver.rs
@@ -307,7 +307,6 @@ impl Receiver {
         // Send an ack on every FIN. We do this separately here because if the FIN is in order, we ack it after the
         // previous line, otherwise we do not ack the FIN.
         if header.fin {
-            trace!("Acking FIN");
             Sender::send_ack(cb, layer3_endpoint)
         }
 
@@ -320,7 +319,7 @@ impl Receiver {
         } else if has_data {
             // We already owe our peer an ACK (the timer was already running), so cancel the timer and ACK now.
             cb.receiver.ack_deadline_time_secs.set(None);
-            trace!("process_packet(): sending ack on second packet");
+            trace!("process_packet(): sending ack before deadline because another packet arrived");
             Sender::send_ack(cb, layer3_endpoint);
         }
 

--- a/src/rust/runtime/mod.rs
+++ b/src/rust/runtime/mod.rs
@@ -207,10 +207,8 @@ impl SharedDemiRuntime {
         timeout: Duration,
     ) -> Result<(usize, QToken, QDesc, OperationResult), Fail> {
         // If any are already complete, grab from the completion table, otherwise, make sure it is valid.
-        for (i, qt) in qts.iter().enumerate() {
-            if let Some((qd, result)) = self.completed_tasks.remove(qt) {
-                return Ok((i, *qt, qd, result));
-            } else if self.qtoken_to_scheduler_id.get(qt).is_none() {
+        for qt in qts.iter() {
+            if self.qtoken_to_scheduler_id.get(qt).is_none() {
                 let cause: String = format!("{:?} is not a valid queue token", qt);
                 warn!("wait_any: {}", cause);
                 return Err(Fail::new(libc::EINVAL, &cause));
@@ -221,20 +219,17 @@ impl SharedDemiRuntime {
         // Wait until one of the qts is ready.
         self.wait_next_n(
             |completed_qt, _, _| {
-                if let Some((i, _)) = qts.iter().enumerate().find(|(_, qt)| completed_qt == **qt) {
-                    offset = i;
-                    false
-                } else {
-                    true
-                }
+                qts.iter()
+                    .enumerate()
+                    .find(|(_, qt)| completed_qt == **qt)
+                    .is_none_or(|(i, _)| {
+                        offset = i;
+                        false
+                    })
             },
             timeout,
         )?;
-
-        let (qd, result) = self
-            .completed_tasks
-            .remove(&qts[offset])
-            .expect("this task should have finished");
+        let (qd, result): (QDesc, OperationResult) = self.remove_completed_task(&qts[offset]);
         Ok((offset, qts[offset], qd, result))
     }
 
@@ -246,22 +241,17 @@ impl SharedDemiRuntime {
         mut acceptor: Acceptor,
         timeout: Duration,
     ) -> Result<(), Fail> {
+        // If any are already complete, grab from the completion table, otherwise, make sure it is valid.
+        for (qt, (qd, result)) in self.completed_tasks.iter() {
+            if !acceptor(*qt, *qd, result) {
+                return Ok(());
+            }
+        }
+
         let mut current_time: Instant = self.get_now();
         let deadline_time: Instant = current_time + timeout;
 
-        while {
-            self.wait_next()
-                .into_iter()
-                .fold(true, |prev: bool, mut task: OperationTask| -> bool {
-                    let qt: QToken = expect_some!(task.get_id(), "should have been set on insert").into();
-                    let (qd, result): (QDesc, OperationResult) =
-                        expect_some!(task.get_result(), "coroutine not finished");
-                    let next: bool = prev && acceptor(qt, qd, &result);
-                    self.qtoken_to_scheduler_id.remove(&qt);
-                    self.completed_tasks.insert(qt, (qd, result));
-                    next
-                })
-        } {
+        while self.wait_next_and_check_whether_to_continue(&mut acceptor) {
             if current_time < deadline_time {
                 // Otherwise, move time forward.
                 self.advance_clock_to_now();
@@ -274,11 +264,30 @@ impl SharedDemiRuntime {
         Ok(())
     }
 
-    /// Runs for one clock iteration and returns. Importantly does not set the current time, so can be used for testing.
-    fn wait_next(&mut self) -> Vec<OperationTask> {
+    /// Runs for one clock iteration and returns [true] if the scheduler should continue running and [false] if the
+    /// scheduler should break and return.
+    fn wait_next_and_check_whether_to_continue<Acceptor: FnMut(QToken, QDesc, &OperationResult) -> bool>(
+        &mut self,
+        acceptor: &mut Acceptor,
+    ) -> bool {
         // Run for one quanta and if one of our queue tokens completed, then return.
         self.poll_background_tasks();
-        self.poll_foreground_tasks()
+        for mut task in self.poll_foreground_tasks().into_iter() {
+            let qt: QToken = expect_some!(task.get_id(), "should have been set on insert").into();
+            let (qd, result): (QDesc, OperationResult) = expect_some!(task.get_result(), "coroutine not finished");
+
+            let should_continue: bool = acceptor(qt, qd, &result);
+            self.completed_tasks.insert(qt, (qd, result));
+            if !should_continue {
+                return false;
+            };
+        }
+        true
+    }
+
+    fn remove_completed_task(&mut self, qt: &QToken) -> (QDesc, OperationResult) {
+        self.qtoken_to_scheduler_id.remove(qt);
+        self.completed_tasks.remove(qt).expect("this task should have finished")
     }
 
     /// Allocates a queue of type `T` and returns the associated queue descriptor.
@@ -394,8 +403,10 @@ impl SharedDemiRuntime {
             .scheduler
             .poll_group_until_unrunnable(foreground_group_id, Some(TIMER_RESOLUTION));
 
+        // Reverse this iterator so that we start from the task first inserted into the scheduler.
         completed_tasks
             .into_iter()
+            .rev()
             .filter_map(|boxed_task| -> Option<OperationTask> {
                 let qt: QToken = expect_some!(boxed_task.get_id(), "should have been set on insert").into();
                 trace!(
@@ -580,18 +591,19 @@ pub trait Runtime: Clone + Unpin + 'static {}
 #[cfg(test)]
 mod tests {
     use crate::{
-        expect_ok,
+        ensure_eq, expect_ok,
         runtime::{poll_yield, OperationResult, QDesc, QToken, SharedDemiRuntime},
     };
+    use ::anyhow::Result;
+    use ::futures::FutureExt;
     use ::std::time::Duration;
-    use futures::FutureExt;
-    use test::Bencher;
+    use ::test::Bencher;
 
-    async fn dummy_coroutine(iterations: usize) -> (QDesc, OperationResult) {
+    async fn dummy_coroutine(iterations: usize, qd: QDesc) -> (QDesc, OperationResult) {
         for _ in 0..iterations {
             poll_yield().await;
         }
-        (QDesc::from(0), OperationResult::Close)
+        (qd, OperationResult::Close)
     }
 
     async fn dummy_background_coroutine() {
@@ -600,11 +612,93 @@ mod tests {
         }
     }
 
+    #[test]
+    fn poll_and_wait_for_first_task() -> Result<()> {
+        let mut runtime: SharedDemiRuntime = SharedDemiRuntime::default();
+
+        let qt: QToken = runtime
+            .insert_nonpolling_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(0)).fuse()))?;
+        let _: QToken = runtime
+            .insert_nonpolling_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(1)).fuse()))?;
+        let _: QToken = runtime
+            .insert_nonpolling_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(2)).fuse()))?;
+
+        let task = runtime.wait(qt, Duration::ZERO)?;
+        ensure_eq!(task.0, QDesc::from(0));
+        Ok(())
+    }
+
+    #[test]
+    fn poll_and_wait_for_middle_task() -> Result<()> {
+        let mut runtime: SharedDemiRuntime = SharedDemiRuntime::default();
+
+        let _: QToken = runtime
+            .insert_nonpolling_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(0)).fuse()))?;
+        let qt2: QToken = runtime
+            .insert_nonpolling_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(1)).fuse()))?;
+        let _: QToken = runtime
+            .insert_nonpolling_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(2)).fuse()))?;
+
+        let task = runtime.wait(qt2, Duration::ZERO)?;
+        ensure_eq!(task.0, QDesc::from(1));
+        Ok(())
+    }
+
+    #[test]
+    fn poll_and_wait_for_last_task() -> Result<()> {
+        let mut runtime: SharedDemiRuntime = SharedDemiRuntime::default();
+
+        let _: QToken = runtime
+            .insert_nonpolling_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(0)).fuse()))?;
+        let _: QToken = runtime
+            .insert_nonpolling_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(1)).fuse()))?;
+        let qt3: QToken = runtime
+            .insert_nonpolling_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(2)).fuse()))?;
+
+        let task = runtime.wait(qt3, Duration::ZERO)?;
+        ensure_eq!(task.0, QDesc::from(2));
+        Ok(())
+    }
+
+    #[test]
+    fn poll_and_wait_any_for_first_tasks() -> Result<()> {
+        let mut runtime: SharedDemiRuntime = SharedDemiRuntime::default();
+
+        let qt: QToken = runtime
+            .insert_nonpolling_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(0)).fuse()))?;
+        let qt2: QToken = runtime
+            .insert_nonpolling_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(1)).fuse()))?;
+        let _: QToken = runtime
+            .insert_nonpolling_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(2)).fuse()))?;
+        let qts: Vec<QToken> = vec![qt, qt2];
+        let task = runtime.wait_any(&qts, Duration::ZERO)?;
+        ensure_eq!(task.2, QDesc::from(0));
+        Ok(())
+    }
+
+    #[test]
+    fn poll_and_wait_any_for_last_tasks() -> Result<()> {
+        let mut runtime: SharedDemiRuntime = SharedDemiRuntime::default();
+
+        let _: QToken = runtime
+            .insert_nonpolling_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(0)).fuse()))?;
+        let qt2: QToken = runtime
+            .insert_nonpolling_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(1)).fuse()))?;
+        let qt3: QToken = runtime
+            .insert_nonpolling_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(2)).fuse()))?;
+        let qts: Vec<QToken> = vec![qt2, qt3];
+        let task = runtime.wait_any(&qts, Duration::ZERO)?;
+        ensure_eq!(task.2, QDesc::from(1));
+        Ok(())
+    }
+
     #[bench]
     fn insert_io_coroutine_bench(b: &mut Bencher) {
         let mut runtime: SharedDemiRuntime = SharedDemiRuntime::default();
 
-        b.iter(|| runtime.insert_nonpolling_coroutine("dummy coroutine", Box::pin(dummy_coroutine(10).fuse())));
+        b.iter(|| {
+            runtime.insert_nonpolling_coroutine("dummy coroutine", Box::pin(dummy_coroutine(10, QDesc::from(0)).fuse()))
+        });
     }
 
     #[bench]
@@ -627,7 +721,10 @@ mod tests {
         // Insert a large number of coroutines.
         for i in 0..NUM_TASKS {
             qts[i] = expect_ok!(
-                runtime.insert_nonpolling_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1000000000).fuse())),
+                runtime.insert_nonpolling_coroutine(
+                    "dummy coroutine",
+                    Box::pin(dummy_coroutine(1000000000, QDesc::from(0)).fuse())
+                ),
                 "should be able to insert tasks"
             );
         }

--- a/src/rust/runtime/mod.rs
+++ b/src/rust/runtime/mod.rs
@@ -46,7 +46,6 @@ use crate::{
 };
 use ::futures::{future::FusedFuture, select_biased, Future, FutureExt};
 
-use ::std::pin::Pin;
 use ::std::{
     any::Any,
     collections::HashMap,
@@ -56,6 +55,7 @@ use ::std::{
     rc::Rc,
     time::{Duration, Instant},
 };
+use ::std::{collections::VecDeque, pin::Pin};
 
 //======================================================================================================================
 // Constants
@@ -64,6 +64,8 @@ use ::std::{
 // TODO: Make this more accurate using rdtsc.
 // FIXME: https://github.com/microsoft/demikernel/issues/1226
 const TIMER_RESOLUTION: usize = 64;
+const DEFAULT_TASK_STORAGE_CAPACITY: usize = 1024;
+const DEFAULT_RESULT_STORAGE_CAPACITY: usize = 1024;
 
 //======================================================================================================================
 // Structures
@@ -81,7 +83,8 @@ pub struct DemiRuntime {
     /// Number of iterations that we have polled since advancing the clock.
     ts_iters: usize,
     /// Tasks that have been completed and removed from the scheduler
-    completed_tasks: HashMap<QToken, (QDesc, OperationResult)>,
+    completed_tasks: VecDeque<OperationTask>,
+    completed_results: HashMap<QToken, (QDesc, OperationResult)>,
 }
 
 #[derive(Clone)]
@@ -123,7 +126,8 @@ impl SharedDemiRuntime {
             background_group_id,
             socket_id_to_qdesc_map: SocketIdToQDescMap::default(),
             ts_iters: 0,
-            completed_tasks: HashMap::<QToken, (QDesc, OperationResult)>::new(),
+            completed_tasks: VecDeque::with_capacity(DEFAULT_TASK_STORAGE_CAPACITY),
+            completed_results: HashMap::with_capacity(DEFAULT_RESULT_STORAGE_CAPACITY),
         }))
     }
 
@@ -207,87 +211,89 @@ impl SharedDemiRuntime {
         timeout: Duration,
     ) -> Result<(usize, QToken, QDesc, OperationResult), Fail> {
         // If any are already complete, grab from the completion table, otherwise, make sure it is valid.
-        for qt in qts.iter() {
-            if self.qtoken_to_scheduler_id.get(qt).is_none() {
-                let cause: String = format!("{:?} is not a valid queue token", qt);
-                warn!("wait_any: {}", cause);
-                return Err(Fail::new(libc::EINVAL, &cause));
+        for (i, qt) in qts.iter().enumerate() {
+            if let Some((qd, result)) = self.completed_results.remove(qt) {
+                return Ok((i, *qt, qd, result));
             }
+            // TODO: Check that the task exists. Unfortunately, we now have three data structures to check for the
+            // qt and I don't think we can do it in an efficient way.
         }
 
-        let mut offset: usize = 0;
+        let mut result: Option<(usize, QToken, QDesc, OperationResult)> = None;
+        let mut unused_results: Vec<(QToken, QDesc, OperationResult)> = vec![];
         // Wait until one of the qts is ready.
-        self.wait_next_n(
-            |completed_qt, _, _| {
-                qts.iter()
-                    .enumerate()
-                    .find(|(_, qt)| completed_qt == **qt)
-                    .is_none_or(|(i, _)| {
-                        offset = i;
-                        false
-                    })
+        let return_value: Result<(), Fail> = self.wait_next_n(
+            |completed_qt, completed_qd, completed_result| match qts
+                .iter()
+                .enumerate()
+                .find(|(_, qt)| completed_qt == **qt)
+            {
+                Some((i, _)) => {
+                    result = Some((i, completed_qt, completed_qd, completed_result));
+                    false
+                },
+                None => {
+                    unused_results.push((completed_qt, completed_qd, completed_result));
+                    true
+                },
             },
             timeout,
-        )?;
-        let (qd, result): (QDesc, OperationResult) = self.remove_completed_task(&qts[offset]);
-        Ok((offset, qts[offset], qd, result))
+        );
+        unused_results
+            .drain(..)
+            .for_each(|(completed_qt, completed_qd, completed_result)| {
+                self.completed_results
+                    .insert(completed_qt, (completed_qd, completed_result));
+            });
+        match return_value {
+            Ok(()) => Ok(result.unwrap()),
+            Err(e) => Err(e),
+        }
     }
 
-    /// Waits until the next task is complete, passing the result to `acceptor`. The acceptor may return true to
+    /// Waits until the next task is complete, passing the result to `acceptor`. The acceptor consumes the result,
+    /// which is not further stored. The qtoken mapping is also removed. The acceptor may return true to
     /// continue waiting or false to exit the wait. The method will return when either the acceptor returns false
     /// (returning Ok) or the timeout has expired (returning a Fail indicating timeout).
-    pub fn wait_next_n<Acceptor: FnMut(QToken, QDesc, &OperationResult) -> bool>(
+    pub fn wait_next_n<Acceptor: FnMut(QToken, QDesc, OperationResult) -> bool>(
         &mut self,
         mut acceptor: Acceptor,
         timeout: Duration,
     ) -> Result<(), Fail> {
-        // If any are already complete, grab from the completion table, otherwise, make sure it is valid.
-        for (qt, (qd, result)) in self.completed_tasks.iter() {
-            if !acceptor(*qt, *qd, result) {
-                return Ok(());
+        let deadline_time: Instant = self.get_now() + timeout;
+        loop {
+            if self.completed_tasks.is_empty() {
+                self.run_scheduler();
             }
-        }
+            while let Some(mut task) = self.completed_tasks.pop_front() {
+                let qt: QToken = expect_some!(task.get_id(), "should have been set on insert").into();
+                let (qd, result): (QDesc, OperationResult) = expect_some!(task.get_result(), "coroutine not finished");
 
-        let mut current_time: Instant = self.get_now();
-        let deadline_time: Instant = current_time + timeout;
-
-        while self.wait_next_and_check_whether_to_continue(&mut acceptor) {
-            if current_time < deadline_time {
-                // Otherwise, move time forward.
-                self.advance_clock_to_now();
-                current_time = self.get_now();
+                if !acceptor(qt, qd, result) {
+                    return Ok(());
+                }
+            }
+            if self.get_now() >= deadline_time {
+                break;
             } else {
-                return Err(Fail::new(libc::ETIMEDOUT, "wait timed out"));
+                self.advance_clock_to_now();
             }
         }
 
-        Ok(())
+        Err(Fail::new(libc::ETIMEDOUT, "wait timed out"))
     }
 
-    /// Runs for one clock iteration and returns [true] if the scheduler should continue running and [false] if the
-    /// scheduler should break and return.
-    fn wait_next_and_check_whether_to_continue<Acceptor: FnMut(QToken, QDesc, &OperationResult) -> bool>(
-        &mut self,
-        acceptor: &mut Acceptor,
-    ) -> bool {
-        // Run for one quanta and if one of our queue tokens completed, then return.
+    /// Either pull the first task from the completed task queue or run the scheduler for one iteration to populate the
+    /// completed task queue and then try again. Returns None if there are still no completed tasks after polling the
+    /// scheduler.
+    pub fn run_scheduler(&mut self) {
+        // 1. Run each of the background tasks once.
         self.poll_background_tasks();
-        for mut task in self.poll_foreground_tasks().into_iter() {
-            let qt: QToken = expect_some!(task.get_id(), "should have been set on insert").into();
-            let (qd, result): (QDesc, OperationResult) = expect_some!(task.get_result(), "coroutine not finished");
+        // 2. Run all foreground tasks until none are ready.
+        let completed_tasks: Vec<OperationTask> = self.poll_foreground_tasks();
 
-            let should_continue: bool = acceptor(qt, qd, &result);
-            self.completed_tasks.insert(qt, (qd, result));
-            if !should_continue {
-                return false;
-            };
-        }
-        true
-    }
-
-    fn remove_completed_task(&mut self, qt: &QToken) -> (QDesc, OperationResult) {
-        self.qtoken_to_scheduler_id.remove(qt);
-        self.completed_tasks.remove(qt).expect("this task should have finished")
+        // 3. Update the list of previously completed tasks.
+        self.completed_tasks = VecDeque::from(completed_tasks);
     }
 
     /// Allocates a queue of type `T` and returns the associated queue descriptor.
@@ -341,10 +347,6 @@ impl SharedDemiRuntime {
     /// Gets the current time according to our internal timer.
     pub fn get_now(&self) -> Instant {
         timer::global_get_time()
-    }
-
-    pub fn get_completed_task(&mut self, qt: QToken) -> Option<(QDesc, OperationResult)> {
-        self.completed_tasks.remove(&qt)
     }
 
     /// Checks if an identifier is in use and returns the queue descriptor if it is.
@@ -403,10 +405,8 @@ impl SharedDemiRuntime {
             .scheduler
             .poll_group_until_unrunnable(foreground_group_id, Some(TIMER_RESOLUTION));
 
-        // Reverse this iterator so that we start from the task first inserted into the scheduler.
         completed_tasks
             .into_iter()
-            .rev()
             .filter_map(|boxed_task| -> Option<OperationTask> {
                 let qt: QToken = expect_some!(boxed_task.get_id(), "should have been set on insert").into();
                 trace!(
@@ -414,9 +414,10 @@ impl SharedDemiRuntime {
                     qt,
                     boxed_task.get_name()
                 );
+                self.qtoken_to_scheduler_id.remove(&qt);
 
-                // OperationTasks return a value to the application, so we must stash these for later. Otherwise, we just
-                // discard the return value of the completed coroutine.
+                // OperationTasks return a value to the application, so we must stash these for later. Otherwise, we
+                // just discard the return value of the completed coroutine.
                 if let Ok(operation_task) = OperationTask::try_from(boxed_task.as_any()) {
                     Some(operation_task)
                 } else {
@@ -492,7 +493,8 @@ impl Default for SharedDemiRuntime {
             background_group_id,
             socket_id_to_qdesc_map: SocketIdToQDescMap::default(),
             ts_iters: 0,
-            completed_tasks: HashMap::<QToken, (QDesc, OperationResult)>::new(),
+            completed_results: HashMap::with_capacity(DEFAULT_RESULT_STORAGE_CAPACITY),
+            completed_tasks: VecDeque::with_capacity(DEFAULT_TASK_STORAGE_CAPACITY),
         }))
     }
 }

--- a/src/rust/runtime/scheduler/group.rs
+++ b/src/rust/runtime/scheduler/group.rs
@@ -23,9 +23,11 @@ use crate::{
 use ::bit_iter::BitIter;
 use ::futures::Future;
 use ::std::{
+    iter::Flatten,
     pin::Pin,
     ptr::NonNull,
     task::{Context, Poll, Waker},
+    vec::IntoIter,
 };
 
 //======================================================================================================================
@@ -41,7 +43,7 @@ pub struct TaskGroup {
     /// Holds the waker bits for controlling task scheduling.
     waker_page_refs: Vec<WakerPageRef>,
     /// List of ready tasks.
-    ready_tasks: Vec<usize>,
+    ready_tasks: Flatten<IntoIter<Vec<usize>>>,
 }
 
 //======================================================================================================================
@@ -125,17 +127,6 @@ impl TaskGroup {
         (waker_page_index << WAKER_BIT_LENGTH_SHIFT) + waker_page_offset
     }
 
-    pub fn check_for_new_ready_tasks(&mut self) {
-        for i in 0..self.get_num_waker_pages() {
-            // Grab notified bits.
-            let notified: u64 = self.waker_page_refs[i].take_notified();
-            let mut runnable_pin_slab_offsets: Vec<usize> = BitIter::from(notified)
-                .map(|x| Self::get_pin_slab_index(i, x))
-                .collect();
-            self.ready_tasks.append(&mut runnable_pin_slab_offsets);
-        }
-    }
-
     fn get_pinned_task_ptr(&mut self, pin_slab_index: usize) -> Pin<&mut Box<dyn Task>> {
         // Get the pinned ref.
         expect_some!(
@@ -152,13 +143,60 @@ impl TaskGroup {
         Some(unsafe { Waker::from_raw(WakerRef::new(raw_waker).into()) })
     }
 
-    /// Get the next runnable
-    pub fn get_next_runnable_task(&mut self) -> Option<usize> {
-        self.ready_tasks.pop()
+    pub fn poll_group(
+        &mut self,
+        max_iterations: Option<usize>,
+        keep_checking_for_new_tasks: bool,
+    ) -> Vec<Box<dyn Task>> {
+        let mut iterations_run: usize = 0;
+        // Return value.
+        let mut completed_tasks: Vec<Box<dyn Task>> = Vec::new();
+        // Definitely check for additional tasks on the first iteration, but then set to [keep_checking_for_new_tasks].
+        let mut check_for_additonal_tasks: bool = true;
+
+        // Loop over the ready tasks.
+        while let Some(next_ready_task_offset) = self.get_next_runnable_task(check_for_additonal_tasks) {
+            if let Some(task) = self.poll_runnable_task(next_ready_task_offset) {
+                completed_tasks.push(task);
+            }
+            check_for_additonal_tasks = keep_checking_for_new_tasks;
+            match max_iterations {
+                Some(max_iterations) if iterations_run >= max_iterations => return completed_tasks,
+                _ => iterations_run += 1,
+            }
+        }
+        completed_tasks
+    }
+
+    /// Get the next runnable task. If no runnable tasks, it will check for new tasks if the [check_for_new_tasks] flag
+    /// is set, then try again.
+    fn get_next_runnable_task(&mut self, check_for_new_tasks: bool) -> Option<usize> {
+        match self.ready_tasks.next() {
+            Some(task) => Some(task),
+            None if check_for_new_tasks => {
+                self.ready_tasks = self.check_for_new_ready_tasks();
+                self.ready_tasks.next()
+            },
+            None => None,
+        }
+    }
+
+    /// Go over the waker pages looking for new runnable tasks.
+    fn check_for_new_ready_tasks(&mut self) -> Flatten<IntoIter<Vec<usize>>> {
+        let mut indices: Vec<Vec<usize>> = vec![];
+        for i in 0..self.get_num_waker_pages() {
+            let notified: u64 = self.waker_page_refs[i].take_notified();
+            indices.push(
+                BitIter::from(notified)
+                    .map(|x| Self::get_pin_slab_index(i, x))
+                    .collect(),
+            )
+        }
+        indices.into_iter().flatten()
     }
 
     // Runs a single ready task. If the task completes after running, returns.
-    pub fn poll_runnable_task(&mut self, pin_slab_index: usize) -> Option<Box<dyn Task>> {
+    fn poll_runnable_task(&mut self, pin_slab_index: usize) -> Option<Box<dyn Task>> {
         // Perform the actual work of running the task.
         let poll_result: Poll<()> = {
             let waker: Waker = self.get_waker(pin_slab_index)?;

--- a/src/rust/runtime/scheduler/scheduler.rs
+++ b/src/rust/runtime/scheduler/scheduler.rs
@@ -70,51 +70,18 @@ impl Scheduler {
         group_id: SchedulerId,
         max_iterations: Option<usize>,
     ) -> Vec<Box<dyn Task>> {
-        let mut completed_tasks: Vec<Box<dyn Task>> = vec![];
-        // Keep running as long as there are runnable tasks.
-        let mut polled_iterations: usize = 0;
         // Expect is safe here because something has really gone wrong if we are polling a group that doesn't exist.
         let group: &mut TaskGroup = self.get_mut_group(group_id).expect("group being polled doesn't exist");
 
         // Keep polling the group and checking for runnable tasks until there are none left.
-        while let Some(next_ready_task_offset) = match group.get_next_runnable_task() {
-            Some(offset) => Some(offset),
-            None => {
-                group.check_for_new_ready_tasks();
-                group.get_next_runnable_task()
-            },
-        } {
-            // Now that we have a runnable task, actually poll it.
-            if let Some(task) = group.poll_runnable_task(next_ready_task_offset) {
-                completed_tasks.push(task);
-            }
-            match max_iterations {
-                Some(max_iterations) if polled_iterations >= max_iterations => return completed_tasks,
-                _ => polled_iterations += 1,
-            }
-        }
-        completed_tasks
+        group.poll_group(max_iterations, true)
     }
 
     /// Polls all of the ready tasks in this group. Only check for new tasks at the beginning.
     pub fn poll_group_once(&mut self, group_id: SchedulerId, max_iterations: Option<usize>) -> Vec<Box<dyn Task>> {
-        let mut completed_tasks: Vec<Box<dyn Task>> = vec![];
-        let mut polled_iterations: usize = 0;
         // Expect is safe here because something has really gone wrong if we are polling a group that doesn't exist.
         let group: &mut TaskGroup = self.get_mut_group(group_id).expect("group being polled doesn't exist");
-        // Only do this once.
-        group.check_for_new_ready_tasks();
-        // Loop over the ready tasks.
-        while let Some(next_ready_task_offset) = group.get_next_runnable_task() {
-            if let Some(task) = group.poll_runnable_task(next_ready_task_offset) {
-                completed_tasks.push(task);
-            }
-            match max_iterations {
-                Some(max_iterations) if polled_iterations >= max_iterations => return completed_tasks,
-                _ => polled_iterations += 1,
-            }
-        }
-        completed_tasks
+        group.poll_group(max_iterations, false)
     }
 }
 


### PR DESCRIPTION
This PR reverses the order in which we iterate over the completed tasks, which ensures that we return the task earliest in the scheduler first. This does not guarantee that the earliest scheduled task is first, but it does ensure some amount of fairness. Since we do not have a specific policy yet for the order in which qtokens are returned, we use this one as a proxy for FIFO. This PR also adds some tests to ensure that the new behavior is correct.

If we want to actually ensure that the first scheduled qt is first, then we likely need to do some more sophisticated queuing. Also if we wanted to return the first qt in the list in wait_any further updates to the scheduler policy would be needed.

The PR looks large but is broken into a few parts (but a single commit because it won't compile):
1. Changes to the scheduler and ensuring the we run earlier tasks in the group pinslab first.
2. Changes to the runtime to match the completed returned tasks in the order in which they are returned.
3. Added tests to the runtime to test that we are respecting the scheduling policy.
4. Changes to the network simulator traces to account for this change to the scheduling policy. 