### PR TITLE
[demikernel] Enhancement: prepare for publishing to crates.io

### DIFF
--- a/dpdk_bindings/Cargo.toml
+++ b/dpdk_bindings/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 description = "Rust Bindings for Libdpdk"
 homepage = "https://aka.ms/demikernel"
 repository = "https://github.com/demikernel/demikernel"
-license = "MIT"
+license-file = "LICENSE.txt"
 
 [dependencies]
 cfg-if = "1.0.0"

--- a/dpdk_bindings/README.md
+++ b/dpdk_bindings/README.md
@@ -10,6 +10,8 @@ We have tested this crate on Windows and Linux.
 - Install DPDK.
 - Set the env. var CFLAGS to add include path to DPDK installation for header files. (-I<path_to_dpdk_headers>)
 - Set the env. var LIBDPDK_PATH to point to the root of the DPDK installation.
+- Install Clang.
+- Set the env. var CC to point to the clang compiler. Add the clang compiler path to PATH variable.
 
 ## Related crates:
 

--- a/dpdk_bindings/build.rs
+++ b/dpdk_bindings/build.rs
@@ -306,7 +306,6 @@ fn os_build() -> Result<()> {
         .allowlist_var("RTE_MAX_ETHPORTS")
         .allowlist_var("RTE_MBUF_DEFAULT_BUF_SIZE")
         .allowlist_var("RTE_PKTMBUF_HEADROOM")
-        .clang_arg("-std=c11")
         .clang_arg("-mavx")
         .header("wrapper.h")
         .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
@@ -321,7 +320,6 @@ fn os_build() -> Result<()> {
     let mut builder: Build = cc::Build::new();
     builder.opt_level(3);
     builder.pic(true);
-    builder.flag("-std=c11");
     builder.flag("-march=native");
     builder.file("inlined.c");
     for header_location in &header_locations {

--- a/xdp_bindings/Cargo.toml
+++ b/xdp_bindings/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 description = "Rust Bindings for XDP"
 homepage = "https://aka.ms/demikernel"
 repository = "https://github.com/demikernel/demikernel"
+license-file = "LICENSE.txt"
 
 [dependencies]
 windows = { version = "0.57.0", features = [


### PR DESCRIPTION
Preparing crates for publishing to crates.io. Refer to commit tab for detailed changes.

After this PR is merged into the `dev` branch, we will:

1. Bring the `unstable` branch up to date with `dev` using rebase.
2. Add tags to the `unstable` branch with crates.io version tags, so as to be able to reproduce the code corresponding to those versions.