### PR TITLE
[runtime] Enhancement: add a custom logging initializer

### DIFF
--- a/src/rust/runtime/logging.rs
+++ b/src/rust/runtime/logging.rs
@@ -5,15 +5,15 @@
 // Imports
 //======================================================================================================================
 
-use ::flexi_logger::{with_thread, Logger};
-use ::std::sync::Once;
+use ::flexi_logger::{with_thread, Logger, LoggerHandle};
+use ::std::sync::OnceLock;
 
 //======================================================================================================================
 // Static Variables
 //======================================================================================================================
 
 /// Guardian to the logging initialize function.
-static INIT_LOG: Once = Once::new();
+static LOG_HANDLE: OnceLock<LoggerHandle> = OnceLock::new();
 
 //======================================================================================================================
 // Standalone Functions
@@ -21,7 +21,16 @@ static INIT_LOG: Once = Once::new();
 
 /// Initializes logging features.
 pub fn initialize() {
-    INIT_LOG.call_once(|| {
-        Logger::try_with_env().unwrap().format(with_thread).start().unwrap();
+    let _ = LOG_HANDLE.get_or_init(|| Logger::try_with_env().unwrap().format(with_thread).start().unwrap());
+}
+
+/// Initialize logging features. The given callback function will initialize FlexiLogger (using a
+/// `flexi_logger::Logger` constructor) as desired by the consumer, returning the Logger instance
+/// which is then started by Demikernel.
+#[allow(unused)]
+pub fn custom_initialize<F: FnOnce() -> Logger>(f: F) {
+    let _ = LOG_HANDLE.get_or_init(|| {
+        let logger: Logger = f();
+        logger.start().unwrap()
     });
 }


### PR DESCRIPTION
Add a custom logging initializer to `runtime.logging` mod. This allows clients to use non-stdio outputs. This also fixes a potential issue wherein the `LoggingHandle` is currently dropped. This is only a bug when a non-stdio logging output is used.