### PR TITLE
[demikernel] Enhancement: adjust crate versions to match crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ x86 = "0.52.0"
 yaml-rust = "0.4.5"
 
 # Demikernel crates (published on crates.io).
-demikernel-dpdk-bindings = { version = "1.1.6", optional = true }
+demikernel-dpdk-bindings = { version = "1.1.8", optional = true }
 demikernel-network-simulator = { version = "0.1.0" }
 
 # Windows-specific dependencies.
@@ -53,7 +53,7 @@ windows = { version = "0.57.0", features = [
     "Win32_System_SystemInformation",
     "Win32_System_Threading",
 ] }
-demikernel-xdp-bindings = { version = "1.0.0", optional = true }
+demikernel-xdp-bindings = { version = "1.0.1", optional = true }
 # for interacting with socket2.
 windows-sys = { version = "0.52.0", features = ["Win32_Networking_WinSock"] }
 

--- a/dpdk_bindings/Cargo.toml
+++ b/dpdk_bindings/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "demikernel-dpdk-bindings"
-version = "1.1.7"
+version = "1.1.8"
 authors = ["Microsoft Corporation"]
 edition = "2021"
 description = "Rust Bindings for Libdpdk"


### PR DESCRIPTION
We just updated versions for xdp and dpdk bindings on crates.io, so adjusting the Cargo.toml files to reflect the same for consistency.