### PR TITLE
[include] Bug fix: add missing prgma pack pop

### DIFF
--- a/include/demi/types.h
+++ b/include/demi/types.h
@@ -149,6 +149,9 @@ extern "C"
         char *const *argv;        /**< Command-line Arguments.           */
         demi_callback_t callback; /**< Callback Function.                */
     };
+#ifdef _WIN32
+#pragma pack(pop)
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This PR adds a missing pragma to the demikernel C includes.