### PR TITLE
[tests] Enhancement: handle deprecated const

### DIFF
--- a/tests/rust/tcp-tests/socket/mod.rs
+++ b/tests/rust/tcp-tests/socket/mod.rs
@@ -126,7 +126,7 @@ fn create_socket_using_unsupported_type(libos: &mut LibOS) -> Result<()> {
     let socket_types: Vec<libc::c_int> = vec![
         libc::SOCK_DCCP,
         // libc::SOCK_DGRAM,
-        libc::SOCK_PACKET,
+        libc::AF_PACKET,
         libc::SOCK_RAW,
         libc::SOCK_RDM,
         libc::SOCK_SEQPACKET,

--- a/tests/rust/tcp.rs
+++ b/tests/rust/tcp.rs
@@ -427,7 +427,7 @@ mod test {
         let socket_types: Vec<libc::c_int> = vec![
             libc::SOCK_DCCP,
             // libc::SOCK_DGRAM,
-            libc::SOCK_PACKET,
+            libc::AF_PACKET,
             libc::SOCK_RAW,
             libc::SOCK_RDM,
             libc::SOCK_SEQPACKET,


### PR DESCRIPTION
The SOCK_PACKET const is deprecated from the libc crate. Because of the nightly build toolchain update, this issue started showing up, so addressing it by switching to the AF_PACKET const.