### PR TITLE
[inetstack] Bug Fix: Correctly initialize window size seq no

### DIFF
--- a/network_simulator/input/tcp/close/close-duplicate-fin.pkt
+++ b/network_simulator/input/tcp/close/close-duplicate-fin.pkt
@@ -1,0 +1,46 @@
+// Test for duplicate FIN.
+
+// Establish a connection.
+ +.0 socket(..., SOCK_STREAM, IPPROTO_TCP) = 500
++.2 connect(500, ..., ...) = 0
+
+// Send SYN segment.
++.0 TCP > S seq 65535(0) win 65535 <mss 1450, wscale 0>
+// Receive SYN-ACK segment.
++.1 TCP < S. seq 50000(0) ack 65536 win 65535 <mss 1450, wscale 0>
+
+// Succeed to establish connection.
++.0 wait(500, ...) = 0
+
+// Send ACK on SYN-ACK segment.
++.0 TCP > . seq 65536(0) ack 50001 win 65535 <nop>
+
+// Receive FIN segment.
++.1 TCP < F. seq 50001(0) ack 65536 win 65535 <nop>
+
+// Send ACK on FIN segment.
++.0 TCP > . seq 65536(0) ack 50002 win 65534 <nop>
+
+// Receive another FIN segment.
++.1 TCP < F. seq 50001(0) ack 65536 win 65535 <nop>
+
+// Send ACK on FIN segment.
++.0 TCP > . seq 65536(0) ack 50002 win 65534 <nop>
+
+// Close connection.
++.2 close(500) = 0
+
+// Send FIN segment.
++.0 TCP > F. seq 65536(0) ack 50002 win 65534 <nop>
+
+// Receive another FIN segment.
++.1 TCP < F. seq 50001(0) ack 65536 win 65535 <nop>
+
+// Send ACK on FIN segment.
++.0 TCP > . seq 65537(0) ack 50002 win 65534 <nop>
+
+// Receive ACK on FIN segment.
++.1 TCP < . seq 50002(0) ack 65537 win 65535 <nop>
+
+// Succeed to close connection immediately.
++.0 wait(500, ...) = 0

--- a/network_simulator/input/tcp/close/close-rst.pkt
+++ b/network_simulator/input/tcp/close/close-rst.pkt
@@ -1,0 +1,31 @@
+// Test for a remote RST.
+
+// Establish a connection.
+ +.0 socket(..., SOCK_STREAM, IPPROTO_TCP) = 500
++.2 connect(500, ..., ...) = 0
+
+// Send SYN segment.
++.0 TCP > S seq 65535(0) win 65535 <mss 1450, wscale 0>
+// Receive SYN-ACK segment.
++.1 TCP < S. seq 50000(0) ack 65536 win 65535 <mss 1450, wscale 0>
+
+// Succeed to establish connection.
++.0 wait(500, ...) = 0
+
+// Send ACK on SYN-ACK segment.
++.0 TCP > . seq 65536(0) ack 50001 win 65535 <nop>
+
+// Receive FIN segment.
++.1 TCP < F. seq 50001(0) ack 65536 win 65535 <nop>
+
+// Send ACK on FIN segment.
++.0 TCP > . seq 65536(0) ack 50002 win 65534 <nop>
+
+// Receive RST.
++.1 TCP < R. seq 50002(0) ack 65536 win 65535 <nop>
+
+// Close connection.
++.2 close(500) = 0
+
+// Succeed to close connection immediately with an ECONNRESET.
++.0 wait(500, ...) = 9

--- a/network_simulator/input/tcp/pop/pop-blocking-early-ack.pkt
+++ b/network_simulator/input/tcp/pop/pop-blocking-early-ack.pkt
@@ -1,0 +1,38 @@
+// Test for blocking pop where more data arrives and we send a bare ack before the timeout.
+
+// Accept a connection.
+ +.0 socket(..., SOCK_STREAM, IPPROTO_TCP) = 500
++.0 bind(500, ..., ...) = 0
++.0 listen(500, 1) = 0
++.2 accept(500, ..., ...) = 0
+
+// Receive SYN packet.
++.2 TCP < S seq 10000(0) win 65535 <mss 1450,wscale 0>
+// Send SYN-ACK packet.
++.0 TCP > S. seq 12345(0) ack 10001 win 65535 <mss 1450,wscale 0>
+// Receive ACK on SYN-ACK packet.
++.2 TCP < . seq 10001(0) ack 12346 win 65535 <nop>
+
+// Succeed to accept connection.
++.0 wait(500, ...) = 0
+
+// Read data.
++.1 read(501, ..., 1000) = 1000
+
+// Receive data packet.
++.1 TCP < P. seq 10001(1000) ack 12346 win 65535 <nop>
+
+// Data read.
++.0 wait(501, ...) = 0
+
+// Read data.
++.1 read(501, ..., 1000) = 1000
+
+// Receive data packet.
++.1 TCP < P. seq 11001(1000) ack 12346 win 65535 <nop>
+
+// Send ACK early because another packet arrived.
++.0 TCP > . seq 12346(0) ack 12001 win 64535 <nop>
+
+// Data read.
++.0 wait(501, ...) = 0

--- a/network_simulator/input/tcp/pop/pop-on-accept.pkt
+++ b/network_simulator/input/tcp/pop/pop-on-accept.pkt
@@ -1,0 +1,26 @@
+// Test for pop of data on accept.
+
+// Accept a connection.
+ +.0 socket(..., SOCK_STREAM, IPPROTO_TCP) = 500
++.0 bind(500, ..., ...) = 0
++.0 listen(500, 1) = 0
++.2 accept(500, ..., ...) = 0
+
+// Receive SYN packet.
++.2 TCP < S seq 400(0) win 65535 <mss 1450,wscale 0>
+// Send SYN-ACK packet.
++.0 TCP > S. seq 12345(0) ack 401 win 65535 <mss 1450,wscale 0>
+// Receive ACK on SYN-ACK packet with data.
++.0 TCP < P. seq 401(1000) ack 12346 win 65535 <nop>
+
+// Succeed to accept connection.
++.0 wait(500, ...) = 0
+
+// Read data.
++.0 read(501, ..., 1000) = 1000
+
+// Data read.
++.0 wait(501, ...) = 0
+
+// Send ACK packet.
++.6 TCP > . seq 12346(0) ack 1401 win 65535 <nop>

--- a/network_simulator/input/tcp/push/push-change-window-2.pkt
+++ b/network_simulator/input/tcp/push/push-change-window-2.pkt
@@ -1,0 +1,35 @@
+// Test for blocking push with a change to window size after the inital set up.
+
+// Accept a connection.
+ +.0 socket(..., SOCK_STREAM, IPPROTO_TCP) = 500
++.0 bind(500, ..., ...) = 0
++.0 listen(500, 1) = 0
++.2 accept(500, ..., ...) = 0
+
+// Receive SYN packet.
++.2 TCP < S seq 100(0) win 65535 <mss 1450,wscale 0>
+// Send SYN-ACK packet.
++.0 TCP > S. seq 12345(0) ack 101 win 65535 <mss 1450,wscale 0>
+// Receive ACK on SYN-ACK packet.
++.2 TCP < . seq 101(0) ack 12346 win 500 <nop>
+
+// Succeed to accept connection.
++.0 wait(500, ...) = 0
+
+// Send data.
++.1 write(501, ..., 1000) = 1000
+
+// Send data packet.
++.0 TCP > . seq 12346(500) ack 101 win 65535 <nop>
+
+// Receive ACK on data packet.
++.1 TCP < . seq 101(0) ack 12846 win 500 <nop>
+
+// Send data packet.
++.0 TCP > P. seq 12846(500) ack 101 win 65535 <nop>
+
+// Receive ACK on data packet.
++.1 TCP < . seq 101(0) ack 13346 win 500 <nop>
+
+// Data sent.
++.0 wait(501, ...) = 0

--- a/network_simulator/input/tcp/push/push-change-window.pkt
+++ b/network_simulator/input/tcp/push/push-change-window.pkt
@@ -1,0 +1,47 @@
+// Test for blocking push with a change to window size after the inital set up.
+
+// Accept a connection.
+ +.0 socket(..., SOCK_STREAM, IPPROTO_TCP) = 500
++.0 bind(500, ..., ...) = 0
++.0 listen(500, 1) = 0
++.2 accept(500, ..., ...) = 0
+
+// Receive SYN packet.
++.2 TCP < S seq 100(0) win 65535 <mss 1450,wscale 0>
+// Send SYN-ACK packet.
++.0 TCP > S. seq 12345(0) ack 101 win 65535 <mss 1450,wscale 0>
+// Receive ACK on SYN-ACK packet.
++.2 TCP < . seq 101(0) ack 12346 win 65535 <nop>
+
+// Succeed to accept connection.
++.0 wait(500, ...) = 0
+
+// Send data.
++.1 write(501, ..., 1000) = 1000
+
+// Send data packet.
++.0 TCP > P. seq 12346(1000) ack 101 win 65535 <nop>
+
+// Receive ACK on data packet.
++.1 TCP < . seq 101(0) ack 13346 win 500 <nop>
+
+// Data sent.
++.0 wait(501, ...) = 0
+
+// Send data.
++.1 write(501, ..., 1000) = 1000
+
+// Send some of the data.
++.0 TCP > . seq 13346(500) ack 101 win 65535 <nop>
+
+// Receive ACK on data packet.
++.1 TCP < . seq 101(0) ack 13846 win 65535 <nop>
+
+// Send rest of the data.
++.0 TCP > P. seq 13846(500) ack 101 win 65535 <nop>
+
+// Receive ACK on data packet.
++.1 TCP < . seq 101(0) ack 14346 win 65535 <nop>
+
+// Data sent.
++.0 wait(501, ...) = 0

--- a/src/rust/inetstack/protocols/layer4/tcp/established/mod.rs
+++ b/src/rust/inetstack/protocols/layer4/tcp/established/mod.rs
@@ -135,6 +135,7 @@ impl SharedEstablishedSocket {
 
         let sender: Sender = Sender::new(
             sender_seq_no,
+            receiver_seq_no,
             sender_window_size_bytes,
             sender_window_scale_bits,
             sender_mss,

--- a/src/rust/inetstack/protocols/layer4/tcp/established/receiver.rs
+++ b/src/rust/inetstack/protocols/layer4/tcp/established/receiver.rs
@@ -460,8 +460,10 @@ impl Receiver {
             return Ok(());
         }
         info!("Received RST: remote reset connection");
+        if cb.receiver.fin_seq_no.get().is_none() {
+            cb.receiver.push_fin();
+        }
         cb.state = State::Closed;
-        cb.receiver.push_fin();
         return Err(Fail::new(libc::ECONNRESET, "remote reset connection"));
     }
 

--- a/src/rust/inetstack/protocols/layer4/tcp/established/sender.rs
+++ b/src/rust/inetstack/protocols/layer4/tcp/established/sender.rs
@@ -114,19 +114,25 @@ pub struct Sender {
 //======================================================================================================================
 
 impl Sender {
-    pub fn new(seq_no: SeqNumber, send_window: u32, send_window_scale_shift_bits: u8, mss: usize) -> Self {
+    pub fn new(
+        local_seq_no: SeqNumber,
+        remote_seq_no: SeqNumber,
+        send_window: u32,
+        send_window_scale_shift_bits: u8,
+        mss: usize,
+    ) -> Self {
         Self {
-            send_unacked: SharedAsyncValue::new(seq_no),
+            send_unacked: SharedAsyncValue::new(local_seq_no),
             unacked_queue: SharedAsyncQueue::with_capacity(MIN_UNACKED_QUEUE_SIZE_FRAMES),
             retransmit_deadline_time_secs: SharedAsyncValue::new(None),
             rto_calculator: RtoCalculator::new(),
-            send_next_seq_no: SharedAsyncValue::new(seq_no),
-            unsent_next_seq_no: seq_no,
+            send_next_seq_no: SharedAsyncValue::new(local_seq_no),
+            unsent_next_seq_no: local_seq_no,
             fin_seq_no: None,
             unsent_queue: SharedAsyncQueue::with_capacity(MIN_UNSENT_QUEUE_SIZE_FRAMES),
             send_window: SharedAsyncValue::new(send_window),
-            send_window_last_update_seq: seq_no,
-            send_window_last_update_ack: seq_no,
+            send_window_last_update_seq: remote_seq_no,
+            send_window_last_update_ack: local_seq_no,
             send_window_scale_shift_bits,
             mss,
         }
@@ -616,6 +622,8 @@ impl Sender {
     pub fn process_ack(cb: &mut ControlBlock, header: &TcpHeader, now: Instant) {
         // Start by checking that the ACK acknowledges something new.
         let send_unacknowledged: SeqNumber = cb.sender.send_unacked.get();
+        // Check and update send window if necessary.
+        cb.sender.update_send_window(header);
 
         if send_unacknowledged < header.ack_num {
             // Remove the now acknowledged data from the unacknowledged queue, update the acked sequence number
@@ -640,9 +648,6 @@ impl Sender {
 
             // Update SND.UNA to SEG.ACK.
             cb.sender.send_unacked.set(header.ack_num);
-
-            // Check and update send window if necessary.
-            cb.sender.update_send_window(header);
 
             // Reset the retransmit timer if necessary. If there is more data that hasn't been acked, then set to the
             // next segment deadline, otherwise, do not set.

--- a/src/rust/inetstack/protocols/layer4/tcp/passive_open.rs
+++ b/src/rust/inetstack/protocols/layer4/tcp/passive_open.rs
@@ -292,7 +292,6 @@ impl SharedPassiveSocket {
                 remote,
                 local_isn,
                 remote_isn,
-                tcp_hdr.window_size,
                 remote_window_scale,
                 mss,
             );
@@ -362,7 +361,6 @@ impl SharedPassiveSocket {
         remote: SocketAddrV4,
         local_isn: SeqNumber,
         remote_isn: SeqNumber,
-        remote_window_size_bytes: u16,
         remote_window_scale_bits: Option<u8>,
         mss: usize,
     ) -> Result<SharedEstablishedSocket, Fail> {
@@ -407,7 +405,7 @@ impl SharedPassiveSocket {
         // Expect is safe here because the window size is a 16-bit unsigned integer and MAX_WINDOW_SCALE is 14, so it is impossible to overflow the 32-bit
         debug_assert!((remote_window_scale_bits as usize) <= MAX_WINDOW_SCALE);
         let remote_window_size_bytes: u32 = expect_some!(
-            (remote_window_size_bytes as u32).checked_shl(remote_window_scale_bits as u32),
+            (tcp_hdr.window_size as u32).checked_shl(remote_window_scale_bits as u32),
             "Window size overflow"
         );
         // Expect is safe here because the receive window size is a 16-bit unsigned integer and MAX_WINDOW_SCALE is 14,

--- a/tests/rust/tcp.rs
+++ b/tests/rust/tcp.rs
@@ -123,6 +123,7 @@ mod test {
                         anyhow::bail!("accept() has failed")
                     },
                 };
+                alice_barrier.wait();
 
                 // Close connection.
                 safe_close_active(&mut libos, qd)?;
@@ -155,6 +156,7 @@ mod test {
                     },
                 }
 
+                bob_barrier.wait();
                 // Close connection.
                 safe_close_active(&mut libos, sockqd)?;
                 // Sleep for a while to give Alice time to finish.
@@ -205,6 +207,7 @@ mod test {
                         anyhow::bail!("accept() has failed")
                     },
                 };
+                alice_barrier.wait();
 
                 // Close connection.
                 safe_close_active(&mut libos, qd)?;
@@ -240,6 +243,7 @@ mod test {
                     },
                 }
 
+                bob_barrier.wait();
                 // Close connection.
                 safe_close_active(&mut libos, sockqd)?;
                 // Sleep for a while to give Alice time to finish.
@@ -293,6 +297,7 @@ mod test {
                             anyhow::bail!("accept() has failed")
                         },
                     };
+                    alice_barrier.wait();
 
                     // Pop data.
                     let qt: QToken = safe_pop(&mut libos, qd)?;
@@ -336,6 +341,7 @@ mod test {
                             anyhow::bail!("connect() has failed")
                         },
                     }
+                    bob_barrier.wait();
 
                     let buf = libos.prepare_dummy_buffer(32)?;
                     let qt: QToken = safe_push(&mut libos, sockqd, buf)?;
@@ -654,6 +660,7 @@ mod test {
                             anyhow::bail!("accept() has failed")
                         },
                     };
+                    alice_barrier.wait();
 
                     // Close connection.
                     safe_close_active(&mut libos, qd)?;
@@ -697,7 +704,7 @@ mod test {
                         _ => anyhow::bail!("connect() should have timed out"),
                     }
 
-                    // Close connection.
+                    // Create connection.
                     let remote: SocketAddr = SocketAddr::new(ALICE_IP, PORT_NUMBER);
                     let sockqd: QDesc = safe_socket(&mut libos)?;
                     let qt: QToken = safe_connect(&mut libos, sockqd, remote)?;
@@ -710,6 +717,7 @@ mod test {
                             anyhow::bail!("connect() has failed")
                         },
                     }
+                    bob_barrier.wait();
 
                     // Close connection.
                     safe_close_active(&mut libos, sockqd)?;
@@ -763,6 +771,7 @@ mod test {
                             anyhow::bail!("accept() has failed")
                         },
                     };
+                    alice_barrier.wait();
 
                     // Close bad queue descriptor.
                     match libos.async_close(QDesc::from(2000)) {
@@ -807,6 +816,7 @@ mod test {
                             anyhow::bail!("connect() has failed")
                         },
                     }
+                    bob_barrier.wait();
 
                     // Close bad queue descriptor.
                     match libos.async_close(QDesc::from(2000)) {
@@ -875,6 +885,7 @@ mod test {
                             anyhow::bail!("accept() has failed")
                         },
                     };
+                    alice_barrier.wait();
 
                     // Pop data.
                     let qt: QToken = safe_pop(&mut libos, qd)?;
@@ -891,6 +902,7 @@ mod test {
                     // Close connection.
                     safe_close_active(&mut libos, qd)?;
                     safe_close_passive(&mut libos, sockqd)?;
+
                     alice_barrier.wait();
 
                     Ok(())
@@ -919,6 +931,7 @@ mod test {
                             anyhow::bail!("connect() has failed")
                         },
                     }
+                    bob_barrier.wait();
 
                     let bytes = libos.prepare_dummy_buffer(32)?;
                     match libos.push(QDesc::from(2000), &bytes) {
@@ -960,6 +973,7 @@ mod test {
                             anyhow::bail!("push() has failed")
                         },
                     }
+
                     // Close connection.
                     safe_close_active(&mut libos, sockqd)?;
 
@@ -1013,6 +1027,7 @@ mod test {
                             anyhow::bail!("accept() has failed")
                         },
                     };
+                    alice_barrier.wait();
 
                     // Pop from bad socket.
                     match libos.pop(QDesc::from(2000), None) {
@@ -1068,6 +1083,7 @@ mod test {
                         },
                     }
 
+                    bob_barrier.wait();
                     let bytes = libos.prepare_dummy_buffer(32)?;
                     let qt: QToken = safe_push(&mut libos, sockqd, bytes)?;
                     let (_, qr): (QDesc, OperationResult) = safe_wait(&mut libos, qt)?;

--- a/tests/rust/tcp.rs
+++ b/tests/rust/tcp.rs
@@ -98,66 +98,70 @@ mod test {
         let bob_barrier: Arc<Barrier> = Arc::new(Barrier::new(2));
         let alice_barrier: Arc<Barrier> = bob_barrier.clone();
 
-        let alice: JoinHandle<Result<()>> = thread::Builder::new().name(format!("alice")).spawn(move || {
-            let mut libos: DummyLibOS = match DummyLibOS::new(ALICE_CONFIG_PATH, alice_tx, bob_rx) {
-                Ok(libos) => libos,
-                Err(e) => anyhow::bail!("Could not create inetstack: {:?}", e),
-            };
+        let alice: JoinHandle<Result<()>> = thread::Builder::new()
+            .name(format!("tcp_establish_connection_unbound::alice"))
+            .spawn(move || {
+                let mut libos: DummyLibOS = match DummyLibOS::new(ALICE_CONFIG_PATH, alice_tx, bob_rx) {
+                    Ok(libos) => libos,
+                    Err(e) => anyhow::bail!("Could not create inetstack: {:?}", e),
+                };
 
-            let local: SocketAddr = SocketAddr::new(ALICE_IP, PORT_NUMBER);
+                let local: SocketAddr = SocketAddr::new(ALICE_IP, PORT_NUMBER);
 
-            // Open connection.
-            let sockqd: QDesc = safe_socket(&mut libos)?;
-            safe_bind(&mut libos, sockqd, local)?;
-            safe_listen(&mut libos, sockqd)?;
-            let qt: QToken = safe_accept(&mut libos, sockqd)?;
-            let (_, qr): (QDesc, OperationResult) = safe_wait(&mut libos, qt)?;
+                // Open connection.
+                let sockqd: QDesc = safe_socket(&mut libos)?;
+                safe_bind(&mut libos, sockqd, local)?;
+                safe_listen(&mut libos, sockqd)?;
+                let qt: QToken = safe_accept(&mut libos, sockqd)?;
+                let (_, qr): (QDesc, OperationResult) = safe_wait(&mut libos, qt)?;
 
-            let qd: QDesc = match qr {
-                OperationResult::Accept((qd, addr)) if addr.ip() == &BOB_IP => qd,
-                _ => {
-                    // Close socket on error.
-                    // FIXME: https://github.com/demikernel/demikernel/issues/633
-                    anyhow::bail!("accept() has failed")
-                },
-            };
+                let qd: QDesc = match qr {
+                    OperationResult::Accept((qd, addr)) if addr.ip() == &BOB_IP => qd,
+                    _ => {
+                        // Close socket on error.
+                        // FIXME: https://github.com/demikernel/demikernel/issues/633
+                        anyhow::bail!("accept() has failed")
+                    },
+                };
 
-            // Close connection.
-            safe_close_active(&mut libos, qd)?;
-            safe_close_passive(&mut libos, sockqd)?;
-            alice_barrier.wait();
+                // Close connection.
+                safe_close_active(&mut libos, qd)?;
+                safe_close_passive(&mut libos, sockqd)?;
+                alice_barrier.wait();
 
-            Ok(())
-        })?;
+                Ok(())
+            })?;
 
-        let bob: JoinHandle<Result<()>> = thread::Builder::new().name(format!("bob")).spawn(move || {
-            let mut libos: DummyLibOS = match DummyLibOS::new(BOB_CONFIG_PATH, bob_tx, alice_rx) {
-                Ok(libos) => libos,
-                Err(e) => anyhow::bail!("Could not create inetstack: {:?}", e),
-            };
+        let bob: JoinHandle<Result<()>> = thread::Builder::new()
+            .name(format!("tcp_establish_connection_unbound::bob"))
+            .spawn(move || {
+                let mut libos: DummyLibOS = match DummyLibOS::new(BOB_CONFIG_PATH, bob_tx, alice_rx) {
+                    Ok(libos) => libos,
+                    Err(e) => anyhow::bail!("Could not create inetstack: {:?}", e),
+                };
 
-            let remote: SocketAddr = SocketAddr::new(ALICE_IP, PORT_NUMBER);
+                let remote: SocketAddr = SocketAddr::new(ALICE_IP, PORT_NUMBER);
 
-            // Open connection.
-            let sockqd: QDesc = safe_socket(&mut libos)?;
-            let qt: QToken = safe_connect(&mut libos, sockqd, remote)?;
-            let (_, qr): (QDesc, OperationResult) = safe_wait(&mut libos, qt)?;
-            match qr {
-                OperationResult::Connect => (),
-                _ => {
-                    // Close socket on error.
-                    // FIXME: https://github.com/demikernel/demikernel/issues/633
-                    anyhow::bail!("connect() has failed")
-                },
-            }
+                // Open connection.
+                let sockqd: QDesc = safe_socket(&mut libos)?;
+                let qt: QToken = safe_connect(&mut libos, sockqd, remote)?;
+                let (_, qr): (QDesc, OperationResult) = safe_wait(&mut libos, qt)?;
+                match qr {
+                    OperationResult::Connect => (),
+                    _ => {
+                        // Close socket on error.
+                        // FIXME: https://github.com/demikernel/demikernel/issues/633
+                        anyhow::bail!("connect() has failed")
+                    },
+                }
 
-            // Close connection.
-            safe_close_active(&mut libos, sockqd)?;
-            // Sleep for a while to give Alice time to finish.
-            bob_barrier.wait();
+                // Close connection.
+                safe_close_active(&mut libos, sockqd)?;
+                // Sleep for a while to give Alice time to finish.
+                bob_barrier.wait();
 
-            Ok(())
-        })?;
+                Ok(())
+            })?;
 
         // It is safe to use unwrap here because there should not be any reason that we can't join the thread and if there
         // is, there is nothing to clean up here on the main thread.
@@ -176,68 +180,72 @@ mod test {
         let bob_barrier: Arc<Barrier> = Arc::new(Barrier::new(2));
         let alice_barrier: Arc<Barrier> = bob_barrier.clone();
 
-        let alice: JoinHandle<Result<()>> = thread::Builder::new().name(format!("alice")).spawn(move || {
-            let mut libos: DummyLibOS = match DummyLibOS::new(ALICE_CONFIG_PATH, alice_tx, bob_rx) {
-                Ok(libos) => libos,
-                Err(e) => anyhow::bail!("Could not create inetstack: {:?}", e),
-            };
+        let alice: JoinHandle<Result<()>> = thread::Builder::new()
+            .name(format!("tcp_establish_connection_bound::alice"))
+            .spawn(move || {
+                let mut libos: DummyLibOS = match DummyLibOS::new(ALICE_CONFIG_PATH, alice_tx, bob_rx) {
+                    Ok(libos) => libos,
+                    Err(e) => anyhow::bail!("Could not create inetstack: {:?}", e),
+                };
 
-            let local: SocketAddr = SocketAddr::new(ALICE_IP, PORT_NUMBER);
+                let local: SocketAddr = SocketAddr::new(ALICE_IP, PORT_NUMBER);
 
-            // Open connection.
-            let sockqd: QDesc = safe_socket(&mut libos)?;
-            safe_bind(&mut libos, sockqd, local)?;
-            safe_listen(&mut libos, sockqd)?;
-            let qt: QToken = safe_accept(&mut libos, sockqd)?;
-            let (_, qr): (QDesc, OperationResult) = safe_wait(&mut libos, qt)?;
+                // Open connection.
+                let sockqd: QDesc = safe_socket(&mut libos)?;
+                safe_bind(&mut libos, sockqd, local)?;
+                safe_listen(&mut libos, sockqd)?;
+                let qt: QToken = safe_accept(&mut libos, sockqd)?;
+                let (_, qr): (QDesc, OperationResult) = safe_wait(&mut libos, qt)?;
 
-            let qd: QDesc = match qr {
-                OperationResult::Accept((qd, addr)) if addr.ip() == &BOB_IP => qd,
-                _ => {
-                    // Close socket on error.
-                    // FIXME: https://github.com/demikernel/demikernel/issues/633
-                    anyhow::bail!("accept() has failed")
-                },
-            };
+                let qd: QDesc = match qr {
+                    OperationResult::Accept((qd, addr)) if addr.ip() == &BOB_IP => qd,
+                    _ => {
+                        // Close socket on error.
+                        // FIXME: https://github.com/demikernel/demikernel/issues/633
+                        anyhow::bail!("accept() has failed")
+                    },
+                };
 
-            // Close connection.
-            safe_close_active(&mut libos, qd)?;
-            safe_close_passive(&mut libos, sockqd)?;
-            // Sleep for a while to give Bob time to finish.
-            alice_barrier.wait();
+                // Close connection.
+                safe_close_active(&mut libos, qd)?;
+                safe_close_passive(&mut libos, sockqd)?;
+                // Sleep for a while to give Bob time to finish.
+                alice_barrier.wait();
 
-            Ok(())
-        })?;
+                Ok(())
+            })?;
 
-        let bob: JoinHandle<Result<()>> = thread::Builder::new().name(format!("bob")).spawn(move || {
-            let mut libos: DummyLibOS = match DummyLibOS::new(BOB_CONFIG_PATH, bob_tx, alice_rx) {
-                Ok(libos) => libos,
-                Err(e) => anyhow::bail!("Could not create inetstack: {:?}", e),
-            };
+        let bob: JoinHandle<Result<()>> = thread::Builder::new()
+            .name(format!("tcp_establish_connection_bound::bob"))
+            .spawn(move || {
+                let mut libos: DummyLibOS = match DummyLibOS::new(BOB_CONFIG_PATH, bob_tx, alice_rx) {
+                    Ok(libos) => libos,
+                    Err(e) => anyhow::bail!("Could not create inetstack: {:?}", e),
+                };
 
-            let local: SocketAddr = SocketAddr::new(BOB_IP, PORT_NUMBER);
-            let remote: SocketAddr = SocketAddr::new(ALICE_IP, PORT_NUMBER);
+                let local: SocketAddr = SocketAddr::new(BOB_IP, PORT_NUMBER);
+                let remote: SocketAddr = SocketAddr::new(ALICE_IP, PORT_NUMBER);
 
-            // Open connection.
-            let sockqd: QDesc = safe_socket(&mut libos)?;
-            safe_bind(&mut libos, sockqd, local)?;
-            let qt: QToken = safe_connect(&mut libos, sockqd, remote)?;
-            let (_, qr): (QDesc, OperationResult) = safe_wait(&mut libos, qt)?;
-            match qr {
-                OperationResult::Connect => (),
-                _ => {
-                    // Close socket on error.
-                    // FIXME: https://github.com/demikernel/demikernel/issues/633
-                    anyhow::bail!("connect() has failed")
-                },
-            }
+                // Open connection.
+                let sockqd: QDesc = safe_socket(&mut libos)?;
+                safe_bind(&mut libos, sockqd, local)?;
+                let qt: QToken = safe_connect(&mut libos, sockqd, remote)?;
+                let (_, qr): (QDesc, OperationResult) = safe_wait(&mut libos, qt)?;
+                match qr {
+                    OperationResult::Connect => (),
+                    _ => {
+                        // Close socket on error.
+                        // FIXME: https://github.com/demikernel/demikernel/issues/633
+                        anyhow::bail!("connect() has failed")
+                    },
+                }
 
-            // Close connection.
-            safe_close_active(&mut libos, sockqd)?;
-            // Sleep for a while to give Alice time to finish.
-            bob_barrier.wait();
-            Ok(())
-        })?;
+                // Close connection.
+                safe_close_active(&mut libos, sockqd)?;
+                // Sleep for a while to give Alice time to finish.
+                bob_barrier.wait();
+                Ok(())
+            })?;
 
         // It is safe to use unwrap here because there should not be any reason that we can't join the thread and if there
         // is, there is nothing to clean up here on the main thread.
@@ -260,87 +268,93 @@ mod test {
         let bob_barrier: Arc<Barrier> = Arc::new(Barrier::new(2));
         let alice_barrier: Arc<Barrier> = bob_barrier.clone();
 
-        let alice: JoinHandle<Result<()>> = thread::Builder::new().name(format!("alice")).spawn(move || {
-            let mut libos: DummyLibOS = match DummyLibOS::new(ALICE_CONFIG_PATH, alice_tx, bob_rx) {
-                Ok(libos) => libos,
-                Err(e) => anyhow::bail!("Could not create inetstack: {:?}", e),
-            };
+        let alice: JoinHandle<Result<()>> =
+            thread::Builder::new()
+                .name(format!("tcp_push_remote::alice"))
+                .spawn(move || {
+                    let mut libos: DummyLibOS = match DummyLibOS::new(ALICE_CONFIG_PATH, alice_tx, bob_rx) {
+                        Ok(libos) => libos,
+                        Err(e) => anyhow::bail!("Could not create inetstack: {:?}", e),
+                    };
 
-            let local: SocketAddr = SocketAddr::new(ALICE_IP, PORT_NUMBER);
+                    let local: SocketAddr = SocketAddr::new(ALICE_IP, PORT_NUMBER);
 
-            // Open connection.
-            let sockqd: QDesc = safe_socket(&mut libos)?;
-            safe_bind(&mut libos, sockqd, local)?;
-            safe_listen(&mut libos, sockqd)?;
-            let qt: QToken = safe_accept(&mut libos, sockqd)?;
-            let (_, qr): (QDesc, OperationResult) = safe_wait(&mut libos, qt)?;
-            let qd: QDesc = match qr {
-                OperationResult::Accept((qd, addr)) if addr.ip() == &BOB_IP => qd,
-                _ => {
-                    // Close socket on error.
-                    // FIXME: https://github.com/demikernel/demikernel/issues/633
-                    anyhow::bail!("accept() has failed")
-                },
-            };
+                    // Open connection.
+                    let sockqd: QDesc = safe_socket(&mut libos)?;
+                    safe_bind(&mut libos, sockqd, local)?;
+                    safe_listen(&mut libos, sockqd)?;
+                    let qt: QToken = safe_accept(&mut libos, sockqd)?;
+                    let (_, qr): (QDesc, OperationResult) = safe_wait(&mut libos, qt)?;
+                    let qd: QDesc = match qr {
+                        OperationResult::Accept((qd, addr)) if addr.ip() == &BOB_IP => qd,
+                        _ => {
+                            // Close socket on error.
+                            // FIXME: https://github.com/demikernel/demikernel/issues/633
+                            anyhow::bail!("accept() has failed")
+                        },
+                    };
 
-            // Pop data.
-            let qt: QToken = safe_pop(&mut libos, qd)?;
-            let (qd, qr): (QDesc, OperationResult) = safe_wait(&mut libos, qt)?;
-            match qr {
-                OperationResult::Pop(_, _) => (),
-                _ => {
-                    // Close socket on error.
-                    // FIXME: https://github.com/demikernel/demikernel/issues/633
-                    anyhow::bail!("pop() has has failed {:?}", qr)
-                },
-            }
+                    // Pop data.
+                    let qt: QToken = safe_pop(&mut libos, qd)?;
+                    let (qd, qr): (QDesc, OperationResult) = safe_wait(&mut libos, qt)?;
+                    match qr {
+                        OperationResult::Pop(_, _) => (),
+                        _ => {
+                            // Close socket on error.
+                            // FIXME: https://github.com/demikernel/demikernel/issues/633
+                            anyhow::bail!("pop() has has failed {:?}", qr)
+                        },
+                    }
 
-            // Close connection.
-            safe_close_active(&mut libos, qd)?;
-            safe_close_passive(&mut libos, sockqd)?;
-            alice_barrier.wait();
-            Ok(())
-        })?;
+                    // Close connection.
+                    safe_close_active(&mut libos, qd)?;
+                    safe_close_passive(&mut libos, sockqd)?;
+                    alice_barrier.wait();
+                    Ok(())
+                })?;
 
-        let bob: JoinHandle<Result<()>> = thread::Builder::new().name(format!("bob")).spawn(move || {
-            let mut libos: DummyLibOS = match DummyLibOS::new(BOB_CONFIG_PATH, bob_tx, alice_rx) {
-                Ok(libos) => libos,
-                Err(e) => anyhow::bail!("Could not create inetstack: {:?}", e),
-            };
+        let bob: JoinHandle<Result<()>> =
+            thread::Builder::new()
+                .name(format!("tcp_push_remote::bob"))
+                .spawn(move || {
+                    let mut libos: DummyLibOS = match DummyLibOS::new(BOB_CONFIG_PATH, bob_tx, alice_rx) {
+                        Ok(libos) => libos,
+                        Err(e) => anyhow::bail!("Could not create inetstack: {:?}", e),
+                    };
 
-            let remote: SocketAddr = SocketAddr::new(ALICE_IP, PORT_NUMBER);
+                    let remote: SocketAddr = SocketAddr::new(ALICE_IP, PORT_NUMBER);
 
-            // Open connection.
-            let sockqd: QDesc = safe_socket(&mut libos)?;
-            let qt: QToken = safe_connect(&mut libos, sockqd, remote)?;
-            let (_, qr): (QDesc, OperationResult) = safe_wait(&mut libos, qt)?;
-            match qr {
-                OperationResult::Connect => (),
-                _ => {
-                    // Close socket on error.
-                    // FIXME: https://github.com/demikernel/demikernel/issues/633
-                    anyhow::bail!("connect() has failed")
-                },
-            }
+                    // Open connection.
+                    let sockqd: QDesc = safe_socket(&mut libos)?;
+                    let qt: QToken = safe_connect(&mut libos, sockqd, remote)?;
+                    let (_, qr): (QDesc, OperationResult) = safe_wait(&mut libos, qt)?;
+                    match qr {
+                        OperationResult::Connect => (),
+                        _ => {
+                            // Close socket on error.
+                            // FIXME: https://github.com/demikernel/demikernel/issues/633
+                            anyhow::bail!("connect() has failed")
+                        },
+                    }
 
-            let buf = libos.prepare_dummy_buffer(32)?;
-            let qt: QToken = safe_push(&mut libos, sockqd, buf)?;
-            let (_, qr): (QDesc, OperationResult) = safe_wait(&mut libos, qt)?;
-            match qr {
-                OperationResult::Push => (),
-                _ => {
-                    // Close socket on error.
-                    // FIXME: https://github.com/demikernel/demikernel/issues/633
-                    anyhow::bail!("push() has failed")
-                },
-            }
+                    let buf = libos.prepare_dummy_buffer(32)?;
+                    let qt: QToken = safe_push(&mut libos, sockqd, buf)?;
+                    let (_, qr): (QDesc, OperationResult) = safe_wait(&mut libos, qt)?;
+                    match qr {
+                        OperationResult::Push => (),
+                        _ => {
+                            // Close socket on error.
+                            // FIXME: https://github.com/demikernel/demikernel/issues/633
+                            anyhow::bail!("push() has failed")
+                        },
+                    }
 
-            // Close connection.
-            safe_close_active(&mut libos, sockqd)?;
-            bob_barrier.wait();
+                    // Close connection.
+                    safe_close_active(&mut libos, sockqd)?;
+                    bob_barrier.wait();
 
-            Ok(())
-        })?;
+                    Ok(())
+                })?;
         // It is safe to use unwrap here because there should not be any reason that we can't join the thread and if there
         // is, there is nothing to clean up here on the main thread.
         alice.join().unwrap()?;
@@ -616,86 +630,92 @@ mod test {
         let bob_barrier: Arc<Barrier> = Arc::new(Barrier::new(2));
         let alice_barrier: Arc<Barrier> = bob_barrier.clone();
 
-        let alice: JoinHandle<Result<()>> = thread::Builder::new().name(format!("alice")).spawn(move || {
-            let mut libos: DummyLibOS = match DummyLibOS::new(ALICE_CONFIG_PATH, alice_tx, bob_rx) {
-                Ok(libos) => libos,
-                Err(e) => anyhow::bail!("Could not create inetstack: {:?}", e),
-            };
-            let local: SocketAddr = SocketAddr::new(ALICE_IP, PORT_NUMBER);
+        let alice: JoinHandle<Result<()>> =
+            thread::Builder::new()
+                .name(format!("tcp_bad_connect::alice"))
+                .spawn(move || {
+                    let mut libos: DummyLibOS = match DummyLibOS::new(ALICE_CONFIG_PATH, alice_tx, bob_rx) {
+                        Ok(libos) => libos,
+                        Err(e) => anyhow::bail!("Could not create inetstack: {:?}", e),
+                    };
+                    let local: SocketAddr = SocketAddr::new(ALICE_IP, PORT_NUMBER);
 
-            // Open connection.
-            let sockqd: QDesc = safe_socket(&mut libos)?;
-            safe_bind(&mut libos, sockqd, local)?;
-            safe_listen(&mut libos, sockqd)?;
-            let qt: QToken = safe_accept(&mut libos, sockqd)?;
-            let (_, qr): (QDesc, OperationResult) = safe_wait(&mut libos, qt)?;
-            let qd: QDesc = match qr {
-                OperationResult::Accept((qd, addr)) if addr.ip() == &BOB_IP => qd,
-                _ => {
-                    // Close socket on error.
-                    // FIXME: https://github.com/demikernel/demikernel/issues/633
-                    anyhow::bail!("accept() has failed")
-                },
-            };
+                    // Open connection.
+                    let sockqd: QDesc = safe_socket(&mut libos)?;
+                    safe_bind(&mut libos, sockqd, local)?;
+                    safe_listen(&mut libos, sockqd)?;
+                    let qt: QToken = safe_accept(&mut libos, sockqd)?;
+                    let (_, qr): (QDesc, OperationResult) = safe_wait(&mut libos, qt)?;
+                    let qd: QDesc = match qr {
+                        OperationResult::Accept((qd, addr)) if addr.ip() == &BOB_IP => qd,
+                        _ => {
+                            // Close socket on error.
+                            // FIXME: https://github.com/demikernel/demikernel/issues/633
+                            anyhow::bail!("accept() has failed")
+                        },
+                    };
 
-            // Close connection.
-            safe_close_active(&mut libos, qd)?;
-            safe_close_passive(&mut libos, sockqd)?;
-            alice_barrier.wait();
-            Ok(())
-        })?;
+                    // Close connection.
+                    safe_close_active(&mut libos, qd)?;
+                    safe_close_passive(&mut libos, sockqd)?;
+                    alice_barrier.wait();
+                    Ok(())
+                })?;
 
-        let bob: JoinHandle<Result<()>> = thread::Builder::new().name(format!("bob")).spawn(move || {
-            let mut libos: DummyLibOS = match DummyLibOS::new(BOB_CONFIG_PATH, bob_tx, alice_rx) {
-                Ok(libos) => libos,
-                Err(e) => anyhow::bail!("Could not create inetstack: {:?}", e),
-            };
+        let bob: JoinHandle<Result<()>> =
+            thread::Builder::new()
+                .name(format!("tcp_bad_connect::bob"))
+                .spawn(move || {
+                    let mut libos: DummyLibOS = match DummyLibOS::new(BOB_CONFIG_PATH, bob_tx, alice_rx) {
+                        Ok(libos) => libos,
+                        Err(e) => anyhow::bail!("Could not create inetstack: {:?}", e),
+                    };
 
-            let remote: SocketAddr = SocketAddr::new(ALICE_IP, PORT_NUMBER);
+                    let remote: SocketAddr = SocketAddr::new(ALICE_IP, PORT_NUMBER);
 
-            // Bad queue descriptor.
-            match libos.connect(QDesc::from(1000), remote) {
-                Err(e) if e.errno == libc::EBADF => (),
-                _ => {
-                    // Close socket if not error because this test cannot continue.
-                    // FIXME: https://github.com/demikernel/demikernel/issues/633
-                    anyhow::bail!("invalid call to connect() should fail with EBADF")
-                },
-            };
+                    // Bad queue descriptor.
+                    match libos.connect(QDesc::from(1000), remote) {
+                        Err(e) if e.errno == libc::EBADF => (),
+                        _ => {
+                            // Close socket if not error because this test cannot continue.
+                            // FIXME: https://github.com/demikernel/demikernel/issues/633
+                            anyhow::bail!("invalid call to connect() should fail with EBADF")
+                        },
+                    };
 
-            // Bad endpoint.
-            let bad_remote: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), PORT_NUMBER);
-            let sockqd: QDesc = safe_socket(&mut libos)?;
-            let qt: QToken = safe_connect(&mut libos, sockqd, bad_remote)?;
-            match libos.wait(qt, BAD_WAIT_TIMEOUT_MILLISECONDS) {
-                Err(e) if e.errno == libc::ETIMEDOUT => (),
-                Ok((_, OperationResult::Connect)) => {
-                    // Close socket if not error because this test cannot continue.
-                    // FIXME: https://github.com/demikernel/demikernel/issues/633
-                    anyhow::bail!("connect() should have timed out")
-                },
-                _ => anyhow::bail!("connect() should have timed out"),
-            }
+                    // Bad endpoint.
+                    let bad_remote: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), PORT_NUMBER);
+                    let sockqd: QDesc = safe_socket(&mut libos)?;
+                    let qt: QToken = safe_connect(&mut libos, sockqd, bad_remote)?;
+                    match libos.wait(qt, BAD_WAIT_TIMEOUT_MILLISECONDS) {
+                        Err(e) if e.errno == libc::ETIMEDOUT => (),
+                        Ok((_, OperationResult::Connect)) => {
+                            // Close socket if not error because this test cannot continue.
+                            // FIXME: https://github.com/demikernel/demikernel/issues/633
+                            anyhow::bail!("connect() should have timed out")
+                        },
+                        _ => anyhow::bail!("connect() should have timed out"),
+                    }
 
-            // Close connection.
-            let remote: SocketAddr = SocketAddr::new(ALICE_IP, PORT_NUMBER);
-            let sockqd: QDesc = safe_socket(&mut libos)?;
-            let qt: QToken = safe_connect(&mut libos, sockqd, remote)?;
-            let (_, qr): (QDesc, OperationResult) = safe_wait(&mut libos, qt)?;
-            match qr {
-                OperationResult::Connect => (),
-                _ => {
-                    // Close socket if not error because this test cannot continue.
-                    // FIXME: https://github.com/demikernel/demikernel/issues/633
-                    anyhow::bail!("connect() has failed")
-                },
-            }
+                    // Close connection.
+                    let remote: SocketAddr = SocketAddr::new(ALICE_IP, PORT_NUMBER);
+                    let sockqd: QDesc = safe_socket(&mut libos)?;
+                    let qt: QToken = safe_connect(&mut libos, sockqd, remote)?;
+                    let (_, qr): (QDesc, OperationResult) = safe_wait(&mut libos, qt)?;
+                    match qr {
+                        OperationResult::Connect => (),
+                        _ => {
+                            // Close socket if not error because this test cannot continue.
+                            // FIXME: https://github.com/demikernel/demikernel/issues/633
+                            anyhow::bail!("connect() has failed")
+                        },
+                    }
 
-            // Close connection.
-            safe_close_active(&mut libos, sockqd)?;
-            bob_barrier.wait();
-            Ok(())
-        })?;
+                    // Close connection.
+                    safe_close_active(&mut libos, sockqd)?;
+                    bob_barrier.wait();
+                    Ok(())
+                })?;
 
         // It is safe to use unwrap here because there should not be any reason that we can't join the thread and if there
         // is, there is nothing to clean up here on the main thread.
@@ -718,90 +738,96 @@ mod test {
         let bob_barrier: Arc<Barrier> = Arc::new(Barrier::new(2));
         let alice_barrier: Arc<Barrier> = bob_barrier.clone();
 
-        let alice: JoinHandle<Result<()>> = thread::Builder::new().name(format!("alice")).spawn(move || {
-            let mut libos: DummyLibOS = match DummyLibOS::new(ALICE_CONFIG_PATH, alice_tx, bob_rx) {
-                Ok(libos) => libos,
-                Err(e) => anyhow::bail!("Could not create inetstack: {:?}", e),
-            };
+        let alice: JoinHandle<Result<()>> =
+            thread::Builder::new()
+                .name(format!("tcp_bad_close::alice"))
+                .spawn(move || {
+                    let mut libos: DummyLibOS = match DummyLibOS::new(ALICE_CONFIG_PATH, alice_tx, bob_rx) {
+                        Ok(libos) => libos,
+                        Err(e) => anyhow::bail!("Could not create inetstack: {:?}", e),
+                    };
 
-            let local: SocketAddr = SocketAddr::new(ALICE_IP, PORT_NUMBER);
+                    let local: SocketAddr = SocketAddr::new(ALICE_IP, PORT_NUMBER);
 
-            // Open connection.
-            let sockqd: QDesc = safe_socket(&mut libos)?;
-            safe_bind(&mut libos, sockqd, local)?;
-            safe_listen(&mut libos, sockqd)?;
-            let qt: QToken = safe_accept(&mut libos, sockqd)?;
-            let (_, qr): (QDesc, OperationResult) = safe_wait(&mut libos, qt)?;
-            let qd: QDesc = match qr {
-                OperationResult::Accept((qd, addr)) if addr.ip() == &BOB_IP => qd,
-                _ => {
-                    // Close socket if error.
-                    // FIXME: https://github.com/demikernel/demikernel/issues/633
-                    anyhow::bail!("accept() has failed")
-                },
-            };
+                    // Open connection.
+                    let sockqd: QDesc = safe_socket(&mut libos)?;
+                    safe_bind(&mut libos, sockqd, local)?;
+                    safe_listen(&mut libos, sockqd)?;
+                    let qt: QToken = safe_accept(&mut libos, sockqd)?;
+                    let (_, qr): (QDesc, OperationResult) = safe_wait(&mut libos, qt)?;
+                    let qd: QDesc = match qr {
+                        OperationResult::Accept((qd, addr)) if addr.ip() == &BOB_IP => qd,
+                        _ => {
+                            // Close socket if error.
+                            // FIXME: https://github.com/demikernel/demikernel/issues/633
+                            anyhow::bail!("accept() has failed")
+                        },
+                    };
 
-            // Close bad queue descriptor.
-            match libos.async_close(QDesc::from(2000)) {
-                Ok(_) => anyhow::bail!("close() invalid file descriptor should fail"),
-                Err(_) => (),
-            };
+                    // Close bad queue descriptor.
+                    match libos.async_close(QDesc::from(2000)) {
+                        Ok(_) => anyhow::bail!("close() invalid file descriptor should fail"),
+                        Err(_) => (),
+                    };
 
-            // Close connection.
-            safe_close_active(&mut libos, qd)?;
-            safe_close_passive(&mut libos, sockqd)?;
+                    // Close connection.
+                    safe_close_active(&mut libos, qd)?;
+                    safe_close_passive(&mut libos, sockqd)?;
 
-            // Double close queue descriptor.
-            match libos.async_close(qd) {
-                Ok(_) => anyhow::bail!("double close() should fail"),
-                Err(_) => (),
-            };
+                    // Double close queue descriptor.
+                    match libos.async_close(qd) {
+                        Ok(_) => anyhow::bail!("double close() should fail"),
+                        Err(_) => (),
+                    };
 
-            alice_barrier.wait();
-            Ok(())
-        })?;
+                    alice_barrier.wait();
+                    Ok(())
+                })?;
 
-        let bob: JoinHandle<Result<()>> = thread::Builder::new().name(format!("bob")).spawn(move || {
-            let mut libos: DummyLibOS = match DummyLibOS::new(BOB_CONFIG_PATH, bob_tx, alice_rx) {
-                Ok(libos) => libos,
-                Err(e) => anyhow::bail!("Could not create inetstack: {:?}", e),
-            };
+        let bob: JoinHandle<Result<()>> =
+            thread::Builder::new()
+                .name(format!("tcp_bad_close::bob"))
+                .spawn(move || {
+                    let mut libos: DummyLibOS = match DummyLibOS::new(BOB_CONFIG_PATH, bob_tx, alice_rx) {
+                        Ok(libos) => libos,
+                        Err(e) => anyhow::bail!("Could not create inetstack: {:?}", e),
+                    };
 
-            let remote: SocketAddr = SocketAddr::new(ALICE_IP, PORT_NUMBER);
+                    let remote: SocketAddr = SocketAddr::new(ALICE_IP, PORT_NUMBER);
 
-            // Open connection.
-            let sockqd: QDesc = safe_socket(&mut libos)?;
-            let qt: QToken = safe_connect(&mut libos, sockqd, remote)?;
-            let (_, qr): (QDesc, OperationResult) = safe_wait(&mut libos, qt)?;
-            match qr {
-                OperationResult::Connect => (),
-                _ => {
-                    // Close socket if error.
-                    // FIXME: https://github.com/demikernel/demikernel/issues/633
-                    anyhow::bail!("connect() has failed")
-                },
-            }
+                    // Open connection.
+                    let sockqd: QDesc = safe_socket(&mut libos)?;
+                    let qt: QToken = safe_connect(&mut libos, sockqd, remote)?;
+                    let (_, qr): (QDesc, OperationResult) = safe_wait(&mut libos, qt)?;
+                    match qr {
+                        OperationResult::Connect => (),
+                        _ => {
+                            // Close socket if error.
+                            // FIXME: https://github.com/demikernel/demikernel/issues/633
+                            anyhow::bail!("connect() has failed")
+                        },
+                    }
 
-            // Close bad queue descriptor.
-            match libos.async_close(QDesc::from(2000)) {
-                // Should not be able to close bad queue descriptor.
-                Ok(_) => anyhow::bail!("close() invalid queue descriptor should fail"),
-                Err(_) => (),
-            };
+                    // Close bad queue descriptor.
+                    match libos.async_close(QDesc::from(2000)) {
+                        // Should not be able to close bad queue descriptor.
+                        Ok(_) => anyhow::bail!("close() invalid queue descriptor should fail"),
+                        Err(_) => (),
+                    };
 
-            // Close connection.
-            safe_close_active(&mut libos, sockqd)?;
+                    // Close connection.
+                    safe_close_active(&mut libos, sockqd)?;
 
-            // Double close queue descriptor.
-            match libos.async_close(sockqd) {
-                // Should not be able to double close.
-                Ok(_) => anyhow::bail!("double close() should fail"),
-                Err(_) => (),
-            };
+                    // Double close queue descriptor.
+                    match libos.async_close(sockqd) {
+                        // Should not be able to double close.
+                        Ok(_) => anyhow::bail!("double close() should fail"),
+                        Err(_) => (),
+                    };
 
-            bob_barrier.wait();
-            Ok(())
-        })?;
+                    bob_barrier.wait();
+                    Ok(())
+                })?;
 
         // It is safe to use unwrap here because there should not be any reason that we can't join the thread and if there
         // is, there is nothing to clean up here on the main thread.
@@ -824,116 +850,122 @@ mod test {
         let bob_barrier: Arc<Barrier> = Arc::new(Barrier::new(2));
         let alice_barrier: Arc<Barrier> = bob_barrier.clone();
 
-        let alice: JoinHandle<Result<()>> = thread::Builder::new().name(format!("alice")).spawn(move || {
-            let mut libos: DummyLibOS = match DummyLibOS::new(ALICE_CONFIG_PATH, alice_tx, bob_rx) {
-                Ok(libos) => libos,
-                Err(e) => anyhow::bail!("Could not create inetstack: {:?}", e),
-            };
+        let alice: JoinHandle<Result<()>> =
+            thread::Builder::new()
+                .name(format!("tcp_bad_push::alice"))
+                .spawn(move || {
+                    let mut libos: DummyLibOS = match DummyLibOS::new(ALICE_CONFIG_PATH, alice_tx, bob_rx) {
+                        Ok(libos) => libos,
+                        Err(e) => anyhow::bail!("Could not create inetstack: {:?}", e),
+                    };
 
-            let local: SocketAddr = SocketAddr::new(ALICE_IP, PORT_NUMBER);
+                    let local: SocketAddr = SocketAddr::new(ALICE_IP, PORT_NUMBER);
 
-            // Open connection.
-            let sockqd: QDesc = safe_socket(&mut libos)?;
-            safe_bind(&mut libos, sockqd, local)?;
-            safe_listen(&mut libos, sockqd)?;
-            let qt: QToken = safe_accept(&mut libos, sockqd)?;
-            let (_, qr): (QDesc, OperationResult) = safe_wait(&mut libos, qt)?;
-            let qd: QDesc = match qr {
-                OperationResult::Accept((qd, addr)) if addr.ip() == &BOB_IP => qd,
-                _ => {
-                    // Close socket if error.
-                    // FIXME: https://github.com/demikernel/demikernel/issues/633
-                    anyhow::bail!("accept() has failed")
-                },
-            };
+                    // Open connection.
+                    let sockqd: QDesc = safe_socket(&mut libos)?;
+                    safe_bind(&mut libos, sockqd, local)?;
+                    safe_listen(&mut libos, sockqd)?;
+                    let qt: QToken = safe_accept(&mut libos, sockqd)?;
+                    let (_, qr): (QDesc, OperationResult) = safe_wait(&mut libos, qt)?;
+                    let qd: QDesc = match qr {
+                        OperationResult::Accept((qd, addr)) if addr.ip() == &BOB_IP => qd,
+                        _ => {
+                            // Close socket if error.
+                            // FIXME: https://github.com/demikernel/demikernel/issues/633
+                            anyhow::bail!("accept() has failed")
+                        },
+                    };
 
-            // Pop data.
-            let qt: QToken = safe_pop(&mut libos, qd)?;
-            let (qd, qr): (QDesc, OperationResult) = safe_wait(&mut libos, qt)?;
-            match qr {
-                OperationResult::Pop(_, _) => (),
-                _ => {
-                    // Close socket if error.
-                    // FIXME: https://github.com/demikernel/demikernel/issues/633
-                    anyhow::bail!("pop() has has failed {:?}", qr)
-                },
-            }
+                    // Pop data.
+                    let qt: QToken = safe_pop(&mut libos, qd)?;
+                    let (qd, qr): (QDesc, OperationResult) = safe_wait(&mut libos, qt)?;
+                    match qr {
+                        OperationResult::Pop(_, _) => (),
+                        _ => {
+                            // Close socket if error.
+                            // FIXME: https://github.com/demikernel/demikernel/issues/633
+                            anyhow::bail!("pop() has has failed {:?}", qr)
+                        },
+                    }
 
-            // Close connection.
-            safe_close_active(&mut libos, qd)?;
-            safe_close_passive(&mut libos, sockqd)?;
-            alice_barrier.wait();
+                    // Close connection.
+                    safe_close_active(&mut libos, qd)?;
+                    safe_close_passive(&mut libos, sockqd)?;
+                    alice_barrier.wait();
 
-            Ok(())
-        })?;
+                    Ok(())
+                })?;
 
-        let bob: JoinHandle<Result<()>> = thread::Builder::new().name(format!("bob")).spawn(move || {
-            let mut libos: DummyLibOS = match DummyLibOS::new(BOB_CONFIG_PATH, bob_tx, alice_rx) {
-                Ok(libos) => libos,
-                Err(e) => anyhow::bail!("Could not create inetstack: {:?}", e),
-            };
+        let bob: JoinHandle<Result<()>> =
+            thread::Builder::new()
+                .name(format!("tcp_bad_push::bob"))
+                .spawn(move || {
+                    let mut libos: DummyLibOS = match DummyLibOS::new(BOB_CONFIG_PATH, bob_tx, alice_rx) {
+                        Ok(libos) => libos,
+                        Err(e) => anyhow::bail!("Could not create inetstack: {:?}", e),
+                    };
 
-            let remote: SocketAddr = SocketAddr::new(ALICE_IP, PORT_NUMBER);
+                    let remote: SocketAddr = SocketAddr::new(ALICE_IP, PORT_NUMBER);
 
-            // Open connection.
-            let sockqd: QDesc = safe_socket(&mut libos)?;
-            let qt: QToken = safe_connect(&mut libos, sockqd, remote)?;
-            let (_, qr): (QDesc, OperationResult) = safe_wait(&mut libos, qt)?;
-            match qr {
-                OperationResult::Connect => (),
-                _ => {
-                    // Close socket if error.
-                    // FIXME: https://github.com/demikernel/demikernel/issues/633
-                    anyhow::bail!("connect() has failed")
-                },
-            }
+                    // Open connection.
+                    let sockqd: QDesc = safe_socket(&mut libos)?;
+                    let qt: QToken = safe_connect(&mut libos, sockqd, remote)?;
+                    let (_, qr): (QDesc, OperationResult) = safe_wait(&mut libos, qt)?;
+                    match qr {
+                        OperationResult::Connect => (),
+                        _ => {
+                            // Close socket if error.
+                            // FIXME: https://github.com/demikernel/demikernel/issues/633
+                            anyhow::bail!("connect() has failed")
+                        },
+                    }
 
-            let bytes = libos.prepare_dummy_buffer(32)?;
-            match libos.push(QDesc::from(2000), &bytes) {
-                Ok(_) => {
-                    // Close socket if not error because this test cannot continue.
-                    // FIXME: https://github.com/demikernel/demikernel/issues/633
-                    anyhow::bail!("push() to bad socket should fail.")
-                },
-                Err(_) => (),
-            };
+                    let bytes = libos.prepare_dummy_buffer(32)?;
+                    match libos.push(QDesc::from(2000), &bytes) {
+                        Ok(_) => {
+                            // Close socket if not error because this test cannot continue.
+                            // FIXME: https://github.com/demikernel/demikernel/issues/633
+                            anyhow::bail!("push() to bad socket should fail.")
+                        },
+                        Err(_) => (),
+                    };
 
-            // Push bad data to socket.
-            let zero_bytes: [u8; 0] = [];
-            let buf: DemiBuffer = match DemiBuffer::from_slice(&zero_bytes) {
-                Ok(buf) => buf,
-                Err(e) => anyhow::bail!("(zero-byte) slice should fit in a DemiBuffer: {:?}", e),
-            };
-            let data: demi_sgarray_t = libos.get_transport().into_sgarray(buf)?;
+                    // Push bad data to socket.
+                    let zero_bytes: [u8; 0] = [];
+                    let buf: DemiBuffer = match DemiBuffer::from_slice(&zero_bytes) {
+                        Ok(buf) => buf,
+                        Err(e) => anyhow::bail!("(zero-byte) slice should fit in a DemiBuffer: {:?}", e),
+                    };
+                    let data: demi_sgarray_t = libos.get_transport().into_sgarray(buf)?;
 
-            match libos.push(sockqd, &data) {
-                Ok(_) =>
-                // Close socket if not error because this test cannot continue.
-                // FIXME: https://github.com/demikernel/demikernel/issues/633
-                {
-                    anyhow::bail!("push() zero-length slice should fail.")
-                },
-                Err(_) => (),
-            };
+                    match libos.push(sockqd, &data) {
+                        Ok(_) =>
+                        // Close socket if not error because this test cannot continue.
+                        // FIXME: https://github.com/demikernel/demikernel/issues/633
+                        {
+                            anyhow::bail!("push() zero-length slice should fail.")
+                        },
+                        Err(_) => (),
+                    };
 
-            // Push data.
-            let bytes = libos.prepare_dummy_buffer(32)?;
-            let qt: QToken = safe_push(&mut libos, sockqd, bytes)?;
-            let (_, qr): (QDesc, OperationResult) = safe_wait(&mut libos, qt)?;
-            match qr {
-                OperationResult::Push => (),
-                _ => {
-                    // Close socket if error.
-                    // FIXME: https://github.com/demikernel/demikernel/issues/633
-                    anyhow::bail!("push() has failed")
-                },
-            }
-            // Close connection.
-            safe_close_active(&mut libos, sockqd)?;
+                    // Push data.
+                    let bytes = libos.prepare_dummy_buffer(32)?;
+                    let qt: QToken = safe_push(&mut libos, sockqd, bytes)?;
+                    let (_, qr): (QDesc, OperationResult) = safe_wait(&mut libos, qt)?;
+                    match qr {
+                        OperationResult::Push => (),
+                        _ => {
+                            // Close socket if error.
+                            // FIXME: https://github.com/demikernel/demikernel/issues/633
+                            anyhow::bail!("push() has failed")
+                        },
+                    }
+                    // Close connection.
+                    safe_close_active(&mut libos, sockqd)?;
 
-            bob_barrier.wait();
-            Ok(())
-        })?;
+                    bob_barrier.wait();
+                    Ok(())
+                })?;
 
         // It is safe to use unwrap here because there should not be any reason that we can't join the thread and if there
         // is, there is nothing to clean up here on the main thread.
@@ -956,98 +988,104 @@ mod test {
         let bob_barrier: Arc<Barrier> = Arc::new(Barrier::new(2));
         let alice_barrier: Arc<Barrier> = bob_barrier.clone();
 
-        let alice: JoinHandle<Result<()>> = thread::Builder::new().name(format!("alice")).spawn(move || {
-            let mut libos: DummyLibOS = match DummyLibOS::new(ALICE_CONFIG_PATH, alice_tx, bob_rx) {
-                Ok(libos) => libos,
-                Err(e) => anyhow::bail!("Could not create inetstack: {:?}", e),
-            };
+        let alice: JoinHandle<Result<()>> =
+            thread::Builder::new()
+                .name(format!("tcp_bad_pop::alice"))
+                .spawn(move || {
+                    let mut libos: DummyLibOS = match DummyLibOS::new(ALICE_CONFIG_PATH, alice_tx, bob_rx) {
+                        Ok(libos) => libos,
+                        Err(e) => anyhow::bail!("Could not create inetstack: {:?}", e),
+                    };
 
-            let local: SocketAddr = SocketAddr::new(ALICE_IP, PORT_NUMBER);
+                    let local: SocketAddr = SocketAddr::new(ALICE_IP, PORT_NUMBER);
 
-            // Open connection.
-            let sockqd: QDesc = safe_socket(&mut libos)?;
-            safe_bind(&mut libos, sockqd, local)?;
-            safe_listen(&mut libos, sockqd)?;
-            let qt: QToken = safe_accept(&mut libos, sockqd)?;
-            let (_, qr): (QDesc, OperationResult) = safe_wait(&mut libos, qt)?;
-            let qd: QDesc = match qr {
-                OperationResult::Accept((qd, addr)) if addr.ip() == &BOB_IP => qd,
-                _ => {
-                    // Close socket if error.
-                    // FIXME: https://github.com/demikernel/demikernel/issues/633
-                    anyhow::bail!("accept() has failed")
-                },
-            };
+                    // Open connection.
+                    let sockqd: QDesc = safe_socket(&mut libos)?;
+                    safe_bind(&mut libos, sockqd, local)?;
+                    safe_listen(&mut libos, sockqd)?;
+                    let qt: QToken = safe_accept(&mut libos, sockqd)?;
+                    let (_, qr): (QDesc, OperationResult) = safe_wait(&mut libos, qt)?;
+                    let qd: QDesc = match qr {
+                        OperationResult::Accept((qd, addr)) if addr.ip() == &BOB_IP => qd,
+                        _ => {
+                            // Close socket if error.
+                            // FIXME: https://github.com/demikernel/demikernel/issues/633
+                            anyhow::bail!("accept() has failed")
+                        },
+                    };
 
-            // Pop from bad socket.
-            match libos.pop(QDesc::from(2000), None) {
-                Ok(_) => {
-                    // Close socket if not error.
-                    // FIXME: https://github.com/demikernel/demikernel/issues/633
-                    anyhow::bail!("pop() form bad socket should fail.")
-                },
-                Err(_) => (),
-            };
+                    // Pop from bad socket.
+                    match libos.pop(QDesc::from(2000), None) {
+                        Ok(_) => {
+                            // Close socket if not error.
+                            // FIXME: https://github.com/demikernel/demikernel/issues/633
+                            anyhow::bail!("pop() form bad socket should fail.")
+                        },
+                        Err(_) => (),
+                    };
 
-            // Pop data.
-            let qt: QToken = safe_pop(&mut libos, qd)?;
-            let (qd, qr): (QDesc, OperationResult) = safe_wait(&mut libos, qt)?;
-            match qr {
-                OperationResult::Pop(_, _) => (),
-                _ => {
-                    // Close socket if error.
-                    // FIXME: https://github.com/demikernel/demikernel/issues/633
-                    anyhow::bail!("pop() has has failed {:?}", qr)
-                },
-            }
+                    // Pop data.
+                    let qt: QToken = safe_pop(&mut libos, qd)?;
+                    let (qd, qr): (QDesc, OperationResult) = safe_wait(&mut libos, qt)?;
+                    match qr {
+                        OperationResult::Pop(_, _) => (),
+                        _ => {
+                            // Close socket if error.
+                            // FIXME: https://github.com/demikernel/demikernel/issues/633
+                            anyhow::bail!("pop() has has failed {:?}", qr)
+                        },
+                    }
 
-            // Close connection.
-            safe_close_active(&mut libos, qd)?;
-            safe_close_passive(&mut libos, sockqd)?;
+                    // Close connection.
+                    safe_close_active(&mut libos, qd)?;
+                    safe_close_passive(&mut libos, sockqd)?;
 
-            alice_barrier.wait();
-            Ok(())
-        })?;
+                    alice_barrier.wait();
+                    Ok(())
+                })?;
 
-        let bob: JoinHandle<Result<()>> = thread::Builder::new().name(format!("bob")).spawn(move || {
-            let mut libos: DummyLibOS = match DummyLibOS::new(BOB_CONFIG_PATH, bob_tx, alice_rx) {
-                Ok(libos) => libos,
-                Err(e) => anyhow::bail!("Could not create inetstack: {:?}", e),
-            };
+        let bob: JoinHandle<Result<()>> =
+            thread::Builder::new()
+                .name(format!("tcp_bad_pop::bob"))
+                .spawn(move || {
+                    let mut libos: DummyLibOS = match DummyLibOS::new(BOB_CONFIG_PATH, bob_tx, alice_rx) {
+                        Ok(libos) => libos,
+                        Err(e) => anyhow::bail!("Could not create inetstack: {:?}", e),
+                    };
 
-            let remote: SocketAddr = SocketAddr::new(ALICE_IP, PORT_NUMBER);
+                    let remote: SocketAddr = SocketAddr::new(ALICE_IP, PORT_NUMBER);
 
-            // Open connection.
-            let sockqd: QDesc = safe_socket(&mut libos)?;
-            let qt: QToken = safe_connect(&mut libos, sockqd, remote)?;
-            let (_, qr): (QDesc, OperationResult) = safe_wait(&mut libos, qt)?;
-            match qr {
-                OperationResult::Connect => (),
-                _ => {
-                    // Close socket if error.
-                    // FIXME: https://github.com/demikernel/demikernel/issues/633
-                    anyhow::bail!("connect() has failed")
-                },
-            }
+                    // Open connection.
+                    let sockqd: QDesc = safe_socket(&mut libos)?;
+                    let qt: QToken = safe_connect(&mut libos, sockqd, remote)?;
+                    let (_, qr): (QDesc, OperationResult) = safe_wait(&mut libos, qt)?;
+                    match qr {
+                        OperationResult::Connect => (),
+                        _ => {
+                            // Close socket if error.
+                            // FIXME: https://github.com/demikernel/demikernel/issues/633
+                            anyhow::bail!("connect() has failed")
+                        },
+                    }
 
-            let bytes = libos.prepare_dummy_buffer(32)?;
-            let qt: QToken = safe_push(&mut libos, sockqd, bytes)?;
-            let (_, qr): (QDesc, OperationResult) = safe_wait(&mut libos, qt)?;
-            match qr {
-                OperationResult::Push => (),
-                _ => {
-                    // Close socket if error.
-                    // FIXME: https://github.com/demikernel/demikernel/issues/633
-                    anyhow::bail!("push() has failed")
-                },
-            }
+                    let bytes = libos.prepare_dummy_buffer(32)?;
+                    let qt: QToken = safe_push(&mut libos, sockqd, bytes)?;
+                    let (_, qr): (QDesc, OperationResult) = safe_wait(&mut libos, qt)?;
+                    match qr {
+                        OperationResult::Push => (),
+                        _ => {
+                            // Close socket if error.
+                            // FIXME: https://github.com/demikernel/demikernel/issues/633
+                            anyhow::bail!("push() has failed")
+                        },
+                    }
 
-            // Close connection.
-            safe_close_active(&mut libos, sockqd)?;
+                    // Close connection.
+                    safe_close_active(&mut libos, sockqd)?;
 
-            bob_barrier.wait();
-            Ok(())
-        })?;
+                    bob_barrier.wait();
+                    Ok(())
+                })?;
 
         // It is safe to use unwrap here because there should not be any reason that we can't join the thread and if there
         // is, there is nothing to clean up here on the main thread.


### PR DESCRIPTION
Currently, we are using the local sequence number to initialize the window size sequence number in the `Sender` struct. However, we then later compare it to the remote sequence number that comes in the TCP header to make a decisions about whether to update the sender window size. Closes #1518 