### PR TITLE
[network_simulator] Feature: Start sequence numbers at non-zero

### DIFF
--- a/network_simulator/input/tcp/accept/accept-blocking-1.pkt
+++ b/network_simulator/input/tcp/accept/accept-blocking-1.pkt
@@ -7,11 +7,11 @@
 +.2 accept(500, ..., ...) = 0
 
 // Receive SYN packet.
-+.2 TCP < S seq 0(0) win 65535 <mss 1450,wscale 0>
++.2 TCP < S seq 100(0) win 65535 <mss 1450,wscale 0>
 // Send SYN-ACK packet.
-+.0 TCP > S. seq 0(0) ack 1 win 65535 <mss 1450,wscale 0>
++.0 TCP > S. seq 12345(0) ack 101 win 65535 <mss 1450,wscale 0>
 // Receive ACK on SYN-ACK packet.
-+.2 TCP < . seq 1(0) ack 1 win 65535 <nop>
++.2 TCP < . seq 101(0) ack 12346 win 65535 <nop>
 
 // Succeed to accept connection.
 +.0 wait(500, ...) = 0

--- a/network_simulator/input/tcp/accept/accept-duplicate-syn.pkt
+++ b/network_simulator/input/tcp/accept/accept-duplicate-syn.pkt
@@ -7,15 +7,15 @@
 +.2 accept(500, ..., ...) = 0
 
 // Receive SYN packet.
-+.2 TCP < S seq 0(0) win 65535 <mss 1450,wscale 0>
++.2 TCP < S seq 100(0) win 65535 <mss 1450,wscale 0>
 // Send SYN-ACK packet.
-+.0 TCP > S. seq 0(0) ack 1 win 65535 <mss 1450,wscale 0>
++.0 TCP > S. seq 12345(0) ack 101 win 65535 <mss 1450,wscale 0>
 
 // Receive another SYN packet.
-+.1 TCP < S seq 0(0) win 65535 <mss 1450,wscale 0>
++.1 TCP < S seq 100(0) win 65535 <mss 1450,wscale 0>
 
 // Receive ACK on SYN-ACK packet.
-+.1 TCP < . seq 1(0) ack 1 win 65535 <nop>
++.1 TCP < . seq 101(0) ack 12346 win 65535 <nop>
 
 // Succeed to accept connection.
 +.0 wait(500, ...) = 0

--- a/network_simulator/input/tcp/accept/accept-large-window-size.pkt
+++ b/network_simulator/input/tcp/accept/accept-large-window-size.pkt
@@ -7,11 +7,11 @@
 +.2 accept(500, ..., ...) = 0
 
 // Receive SYN packet.
-+.2 TCP < S seq 0(0) win 65535 <mss 1450,wscale 14>
++.2 TCP < S seq 50000(0) win 65535 <mss 1450,wscale 14>
 // Send SYN-ACK packet.
-+.0 TCP > S. seq 0(0) ack 1 win 65535 <mss 1450,wscale 0>
++.0 TCP > S. seq 12345(0) ack 50001 win 65535 <mss 1450,wscale 0>
 // Receive ACK on SYN-ACK packet.
-+.2 TCP < . seq 1(0) ack 1 win 65535 <nop>
++.2 TCP < . seq 50001(0) ack 12346 win 65535 <nop>
 
 // Succeed to accept connection.
 +.0 wait(500, ...) = 0

--- a/network_simulator/input/tcp/accept/accept-refuse-1.pkt
+++ b/network_simulator/input/tcp/accept/accept-refuse-1.pkt
@@ -7,16 +7,18 @@
 +.2 accept(500, ..., ...) = 0
 
 // Receive ACK packet.
-+.2 TCP < . seq 0(0) ack 1 win 65535 <mss 1450,wscale 0>
-// Send a RST packet.
++.2 TCP < . seq 100(0) ack 1 win 65535 <mss 1450,wscale 0>
+// Send a RST packet. Since the incoming segment has an ACK field, the reset takes its
+// sequence number from the ACK field of the segment.
+// Reference: https://datatracker.ietf.org/doc/html/rfc793#section-3.4
 +.0 TCP > R. seq 1(0) ack 2 <nop>
 
 // Receive SYN packet.
-+.2 TCP < S seq 0(0) win 65535 <mss 1450,wscale 0>
++.2 TCP < S seq 100(0) win 65535 <mss 1450,wscale 0>
 // Send SYN-ACK packet.
-+.0 TCP > S. seq 0(0) ack 1 win 65535 <mss 1450,wscale 0>
++.0 TCP > S. seq 12345(0) ack 101 win 65535 <mss 1450,wscale 0>
 // Receive ACK on SYN-ACK packet.
-+.2 TCP < . seq 1(0) ack 1 win 65535 <nop>
++.2 TCP < . seq 101(0) ack 12346 win 65535 <nop>
 
 // Succeed to accept connection.
 +.0 wait(500, ...) = 0

--- a/network_simulator/input/tcp/accept/accept-refuse-2.pkt
+++ b/network_simulator/input/tcp/accept/accept-refuse-2.pkt
@@ -12,11 +12,11 @@
 +.0 TCP > R. seq 0(0) ack 28 <nop>
 
 // Receive SYN packet.
-+.2 TCP < S seq 0(0) win 65535 <mss 1450,wscale 0>
++.2 TCP < S seq 10(0) win 65535 <mss 1450,wscale 0>
 // Send SYN-ACK packet.
-+.0 TCP > S. seq 0(0) ack 1 win 65535 <mss 1450,wscale 0>
++.0 TCP > S. seq 12345(0) ack 11 win 65535 <mss 1450,wscale 0>
 // Receive ACK on SYN-ACK packet.
-+.2 TCP < . seq 1(0) ack 1 win 65535 <nop>
++.2 TCP < . seq 11(0) ack 12346 win 65535 <nop>
 
 // Succeed to accept connection.
 +.0 wait(500, ...) = 0

--- a/network_simulator/input/tcp/accept/accept-refuse-3.pkt
+++ b/network_simulator/input/tcp/accept/accept-refuse-3.pkt
@@ -14,9 +14,9 @@
 // Receive SYN packet.
 +.2 TCP < S seq 0(0) win 65535 <mss 1450,wscale 0>
 // Send SYN-ACK packet.
-+.0 TCP > S. seq 0(0) ack 1 win 65535 <mss 1450,wscale 0>
++.0 TCP > S. seq 12345(0) ack 1 win 65535 <mss 1450,wscale 0>
 // Receive ACK on SYN-ACK packet.
-+.2 TCP < . seq 1(0) ack 1 win 65535 <nop>
++.2 TCP < . seq 1(0) ack 12346 win 65535 <nop>
 
 // Succeed to accept connection.
 +.0 wait(500, ...) = 0

--- a/network_simulator/input/tcp/accept/accept-refuse-4.pkt
+++ b/network_simulator/input/tcp/accept/accept-refuse-4.pkt
@@ -12,11 +12,11 @@
 +.0 TCP > R. seq 0(0) ack 1 <nop>
 
 // Receive SYN packet.
-+.2 TCP < S seq 0(0) win 65535 <mss 1450,wscale 0>
++.2 TCP < S seq 20000(0) win 65535 <mss 1450,wscale 0>
 // Send SYN-ACK packet.
-+.0 TCP > S. seq 0(0) ack 1 win 65535 <mss 1450,wscale 0>
++.0 TCP > S. seq 12345(0) ack 20001 win 65535 <mss 1450,wscale 0>
 // Receive ACK on SYN-ACK packet.
-+.2 TCP < . seq 1(0) ack 1 win 65535 <nop>
++.2 TCP < . seq 20001(0) ack 12346 win 65535 <nop>
 
 // Succeed to accept connection.
 +.0 wait(500, ...) = 0

--- a/network_simulator/input/tcp/accept/accept-refuse-5.pkt
+++ b/network_simulator/input/tcp/accept/accept-refuse-5.pkt
@@ -12,11 +12,11 @@
 +.0 TCP > R. seq 0(0) ack 1 <nop>
 
 // Receive SYN packet.
-+.2 TCP < S seq 0(0) win 65535 <mss 1450,wscale 0>
++.2 TCP < S seq 12345(0) win 65535 <mss 1450,wscale 0>
 // Send SYN-ACK packet.
-+.0 TCP > S. seq 0(0) ack 1 win 65535 <mss 1450,wscale 0>
++.0 TCP > S. seq 12345(0) ack 12346 win 65535 <mss 1450,wscale 0>
 // Receive ACK on SYN-ACK packet.
-+.2 TCP < . seq 1(0) ack 1 win 65535 <nop>
++.2 TCP < . seq 12346(0) ack 12346 win 65535 <nop>
 
 // Succeed to accept connection.
 +.0 wait(500, ...) = 0

--- a/network_simulator/input/tcp/accept/accept-refuse-6.pkt
+++ b/network_simulator/input/tcp/accept/accept-refuse-6.pkt
@@ -12,11 +12,11 @@
 +.0 TCP > R. seq 0(0) ack 1 <nop>
 
 // Receive SYN packet.
-+.2 TCP < S seq 0(0) win 65535 <mss 1450,wscale 0>
++.2 TCP < S seq 10(0) win 65535 <mss 1450,wscale 0>
 // Send SYN-ACK packet.
-+.0 TCP > S. seq 0(0) ack 1 win 65535 <mss 1450,wscale 0>
++.0 TCP > S. seq 12345(0) ack 11 win 65535 <mss 1450,wscale 0>
 // Receive ACK on SYN-ACK packet.
-+.2 TCP < . seq 1(0) ack 1 win 65535 <nop>
++.2 TCP < . seq 11(0) ack 12346 win 65535 <nop>
 
 // Succeed to accept connection.
 +.0 wait(500, ...) = 0

--- a/network_simulator/input/tcp/accept/accept-syn-ack-retransmission.pkt
+++ b/network_simulator/input/tcp/accept/accept-syn-ack-retransmission.pkt
@@ -7,13 +7,13 @@
 +.2 accept(500, ..., ...) = 0
 
 // Receive SYN packet.
-+.2 TCP < S seq 0(0) win 65535 <mss 1450,wscale 0>
++.2 TCP < S seq 10000(0) win 65535 <mss 1450,wscale 0>
 // Send SYN-ACK packet.
-+.0 TCP > S. seq 0(0) ack 1 win 65535 <mss 1450,wscale 0>
++.0 TCP > S. seq 12345(0) ack 10001 win 65535 <mss 1450,wscale 0>
 // Send SYN-ACK packet.
-+3 TCP > S. seq 0(0) ack 1 win 65535 <mss 1450,wscale 0>
++3 TCP > S. seq 12345(0) ack 10001 win 65535 <mss 1450,wscale 0>
 // Receive ACK on SYN-ACK packet.
-+.1 TCP < . seq 1(0) ack 1 win 65535 <nop>
++.1 TCP < . seq 1001(0) ack 12346 win 65535 <nop>
 
 // Succeed to accept connection.
 +.0 wait(500, ...) = 0

--- a/network_simulator/input/tcp/accept/accept-syn-carrying-data.pkt
+++ b/network_simulator/input/tcp/accept/accept-syn-carrying-data.pkt
@@ -7,11 +7,11 @@
 +.2 accept(500, ..., ...) = 0
 
 // Receive a data-carrying SYN segment.
-+.2 TCP < S seq 0(1000) win 65535 <mss 1450,wscale 0>
++.2 TCP < S seq 100(1000) win 65535 <mss 1450,wscale 0>
 // Send SYN-ACK segment, that does not ack the received data.
-+.0 TCP > S. seq 0(0) ack 1 win 65535 <mss 1450,wscale 0>
++.0 TCP > S. seq 12345(0) ack 101 win 65535 <mss 1450,wscale 0>
 // Receive ACK on SYN-ACK segment.
-+.2 TCP < . seq 1(0) ack 1 win 65535 <nop>
++.2 TCP < . seq 101(0) ack 12346 win 65535 <nop>
 
 // Succeed to accept connection.
 +.0 wait(500, ...) = 0

--- a/network_simulator/input/tcp/close/close-blocking.pkt
+++ b/network_simulator/input/tcp/close/close-blocking.pkt
@@ -1,21 +1,21 @@
 // Test for blocking close.
 
 // Establish a connection.
- +.0 socket(..., SOCK_STREAM, IPPROTO_TCP) = 500
++.0 socket(..., SOCK_STREAM, IPPROTO_TCP) = 500
 +.2 connect(500, ..., ...) = 0
 
-// Send SYN packet.
-+.0 TCP > S seq 0(0) win 65535 <mss 1450, wscale 0>
+// Send SYN packet. Starting sequence number is last ephemeral port.
++.0 TCP > S seq 65535(0) win 65535 <mss 1450, wscale 0>
 // Receive SYN-ACK packet.
-+.1 TCP < S. seq 0(0) ack 1 win 65535 <mss 1450, wscale 0>
++.1 TCP < S. seq 1000(0) ack 65536 win 65535 <mss 1450, wscale 0>
 
 // Succeed to establish connection.
 +.0 wait(500, ...) = 0
 
 // Send ACK on SYN-ACK packet.
-+.0 TCP > . seq 1(0) ack 1 win 65535 <nop>
++.0 TCP > . seq 65536(0) ack 1001 win 65535 <nop>
 
 // Succeed to disconnect.
 +.1 close(500) = 0
-+.0 TCP > F. seq 1(0) ack 1 win 65535 <nop>
-+.1 TCP < . seq 1(0) ack 2 win 65535 <nop>
++.0 TCP > F. seq 65536(0) ack 1001 win 65535 <nop>
++.1 TCP < . seq 1001(0) ack 65537 win 65535 <nop>

--- a/network_simulator/input/tcp/close/close-local-retransmission.pkt
+++ b/network_simulator/input/tcp/close/close-local-retransmission.pkt
@@ -5,27 +5,27 @@
 +.2 connect(500, ..., ...) = 0
 
 // Send SYN segment.
-+.0 TCP > S seq 0(0) win 65535 <mss 1450, wscale 0>
++.0 TCP > S seq 65535(0) win 65535 <mss 1450, wscale 0>
 // Receive SYN-ACK segment.
-+.1 TCP < S. seq 0(0) ack 1 win 65535 <mss 1450, wscale 0>
++.1 TCP < S. seq 100000(0) ack 65536 win 65535 <mss 1450, wscale 0>
 
 // Succeed to establish connection.
 +.0 wait(500, ...) = 0
 
 // Send ACK on SYN-ACK segment.
-+.0 TCP > . seq 1(0) ack 1 win 65535 <nop>
++.0 TCP > . seq 65536(0) ack 100001 win 65535 <nop>
 
 // Send data.
 +.1 write(500, ..., 1000) = 1000
 
 // Send data packet.
-+0 TCP > P. seq 1(1000) ack 1 win 65535 <nop>
++0 TCP > P. seq 65536(1000) ack 100001 win 65535 <nop>
 
-// Send data packet.
-+4 TCP > P. seq 1(1000) ack 1 win 65535 <nop>
+// Resend data packet.
++4 TCP > P. seq 65536(1000) ack 100001 win 65535 <nop>
 
 // Receive ACK on data packet.
-+.1 TCP < . seq 1(0) ack 1001 win 65535 <nop>
++.1 TCP < . seq 100001(0) ack 66536 win 65535 <nop>
 
 // Send completes
 +.0 wait(500, ...) = 9
@@ -34,16 +34,16 @@
 +.0 close(500) = 0
 
 // Send FIN segment.
-+.0 TCP > F. seq 1001(0) ack 1 win 65535 <nop>
++.0 TCP > F. seq 66536(0) ack 100001 win 65535 <nop>
 
 // Send FIN again since no ack on it yet.
-+4 TCP > F. seq 1001(0) ack 1 win 65535 <nop>
++4 TCP > F. seq 66536(0) ack 100001 win 65535 <nop>
 
 // Receive FIN segment.
-+.1 TCP < F. seq 1(0) ack 1002 win 65535 <nop>
++.1 TCP < F. seq 100001(0) ack 66537 win 65535 <nop>
 
 // Succeed to close connection immediately because we set linger to 0.
 +0 wait(500, ...) = 0
 
 // Send ACK on FIN segment.
-+.0 TCP > . seq 1002(0) ack 2 win 65534 <nop>
++.0 TCP > . seq 66537(0) ack 100002 win 65534 <nop>

--- a/network_simulator/input/tcp/close/close-local.pkt
+++ b/network_simulator/input/tcp/close/close-local.pkt
@@ -5,30 +5,30 @@
 +.2 connect(500, ..., ...) = 0
 
 // Send SYN segment.
-+.0 TCP > S seq 0(0) win 65535 <mss 1450, wscale 0>
++.0 TCP > S seq 65535(0) win 65535 <mss 1450, wscale 0>
 // Receive SYN-ACK segment.
-+.1 TCP < S. seq 0(0) ack 1 win 65535 <mss 1450, wscale 0>
++.1 TCP < S. seq 2000(0) ack 65536 win 65535 <mss 1450, wscale 0>
 
 // Succeed to establish connection.
 +.0 wait(500, ...) = 0
 
 // Send ACK on SYN-ACK segment.
-+.0 TCP > . seq 1(0) ack 1 win 65535 <nop>
++.0 TCP > . seq 65536(0) ack 2001 win 65535 <nop>
 
 // Close connection.
 +.2 close(500) = 0
 
 // Send FIN segment.
-+.0 TCP > F. seq 1(0) ack 1 win 65535 <nop>
++.0 TCP > F. seq 65536(0) ack 2001 win 65535 <nop>
 // Receive ACK on FIN segment.
-+.1 TCP < . seq 1(0) ack 2 win 65535 <nop>
++.1 TCP < . seq 2001(0) ack 65537 win 65535 <nop>
 
 // Receive FIN segment.
-+.1 TCP < F. seq 1(0) ack 2 win 65535 <nop>
++.1 TCP < F. seq 2001(0) ack 65537 win 65535 <nop>
 
 // Succeed to close connection immediately because we have linger set to 0.
 +0 wait(500, ...) = 0
 
 // Send ACK on FIN segment.
-+.0 TCP > . seq 2(0) ack 2 win 65534 <nop>
++.0 TCP > . seq 65537(0) ack 2002 win 65534 <nop>
 

--- a/network_simulator/input/tcp/close/close-out-of-order-fin.pkt
+++ b/network_simulator/input/tcp/close/close-out-of-order-fin.pkt
@@ -1,51 +1,49 @@
 // Tests for remote close with an out of order FIN.
 
 // Establish a connection.
- +.0 socket(..., SOCK_STREAM, IPPROTO_TCP) = 500
++.0 socket(..., SOCK_STREAM, IPPROTO_TCP) = 500
 +.2 connect(500, ..., ...) = 0
 
 // Send SYN segment.
-+.0 TCP > S seq 0(0) win 65535 <mss 1450, wscale 0>
++.0 TCP > S seq 65535(0) win 65535 <mss 1450, wscale 0>
 // Receive SYN-ACK segment.
-+.1 TCP < S. seq 0(0) ack 1 win 65535 <mss 1450, wscale 0>
++.1 TCP < S. seq 50(0) ack 65536 win 65535 <mss 1450, wscale 0>
 
 // Succeed to establish connection.
 +.0 wait(500, ...) = 0
 
 // Send ACK on SYN-ACK segment.
-+.0 TCP > . seq 1(0) ack 1 win 65535 <nop>
-
++.0 TCP > . seq 65536(0) ack 51 win 65535 <nop>
 
 // Send data.
 +.1 write(500, ..., 1000) = 1000
 
 // Send data packet.
-+0 TCP > P. seq 1(1000) ack 1 win 65535 <nop>
++0 TCP > P. seq 65536(1000) ack 51 win 65535 <nop>
 
 // Receive out of order FIN segment.
-+.1 TCP < F. seq 1001(0) ack 1001 win 65535 <nop>
++.1 TCP < F. seq 1051(0) ack 66536 win 65535 <nop>
 
-// Send finished because out of order FIN acked the data .
+// Send finished because out of order FIN acked the data.
 +.0 wait(500, ...) = 0
 
 // Send ACK packet for out of order data.
-+.0 TCP > . seq 1001(0) ack 1 win 65535 <nop>
++.0 TCP > . seq 66536(0) ack 51 win 65535 <nop>
 
 // Receive data packet
-+.1 TCP < P. seq 1(1000) ack 1001 win 65535 <nop>
-
++.1 TCP < P. seq 51(1000) ack 66536 win 65535 <nop>
 
 // Send ACK packet for data and FIN.
-+.0 TCP > . seq 1001(0) ack 1002 win 64534 <nop>
++.0 TCP > . seq 66536(0) ack 1052 win 64534 <nop>
 
 // Close connection.
 +.2 close(500) = 0
 
 // Send FIN segment.
-+.0 TCP > F. seq 1001(0) ack 1002 win 64534 <nop>
++.0 TCP > F. seq 66536(0) ack 1052 win 64534 <nop>
 
 // Receive ACK on FIN segment.
-+.1 TCP < . seq 1002(0) ack 1002 win 64534 <nop>
++.1 TCP < . seq 1052(0) ack 66537 win 64534 <nop>
 
 // Succeed to close connection immediately.
 +.0 wait(500, ...) = 0

--- a/network_simulator/input/tcp/close/close-remote-retransmission.pkt
+++ b/network_simulator/input/tcp/close/close-remote-retransmission.pkt
@@ -1,39 +1,40 @@
 // Tests for remote close.
 
 // Establish a connection.
- +.0 socket(..., SOCK_STREAM, IPPROTO_TCP) = 500
++.0 socket(..., SOCK_STREAM, IPPROTO_TCP) = 500
 +.2 connect(500, ..., ...) = 0
 
 // Send SYN segment.
-+.0 TCP > S seq 0(0) win 65535 <mss 1450, wscale 0>
++.0 TCP > S seq 65535(0) win 65535 <mss 1450, wscale 0>
 // Receive SYN-ACK segment.
-+.1 TCP < S. seq 0(0) ack 1 win 65535 <mss 1450, wscale 0>
++.1 TCP < S. seq 1000(0) ack 65536 win 65535 <mss 1450, wscale 0>
 
 // Succeed to establish connection.
 +.0 wait(500, ...) = 0
 
 // Send ACK on SYN-ACK segment.
-+.0 TCP > . seq 1(0) ack 1 win 65535 <nop>
++.0 TCP > . seq 65536(0) ack 1001 win 65535 <nop>
 
 // Receive FIN segment.
-+.1 TCP < F. seq 1(0) ack 1 win 65535 <nop>
++.1 TCP < F. seq 1001(0) ack 65536 win 65535 <nop>
+
 // Send ACK on FIN segment.
-+.0 TCP > . seq 1(0) ack 2 win 65534 <nop>
++.0 TCP > . seq 65536(0) ack 1002 win 65534 <nop>
 
 // Close connection.
 +.2 close(500) = 0
 
 // Send FIN segment.
-+.0 TCP > F. seq 1(0) ack 2 win 65534 <nop>
++.0 TCP > F. seq 65536(0) ack 1002 win 65534 <nop>
 
 // Re-send FIN segment.
-+1 TCP > F. seq 1(0) ack 2 win 65534 <nop>
++1 TCP > F. seq 65536(0) ack 1002 win 65534 <nop>
 
 // Re-send FIN segment.
-+3 TCP > F. seq 1(0) ack 2 win 65534 <nop>
++3 TCP > F. seq 65536(0) ack 1002 win 65534 <nop>
 
 // Receive ACK on FIN segment.
-+.1 TCP < . seq 2(0) ack 2 win 65535 <nop>
++.1 TCP < . seq 1002(0) ack 65537 win 65535 <nop>
 
 // Succeed to close connection immediately.
 +.0 wait(500, ...) = 0

--- a/network_simulator/input/tcp/close/close-remote.pkt
+++ b/network_simulator/input/tcp/close/close-remote.pkt
@@ -5,28 +5,28 @@
 +.2 connect(500, ..., ...) = 0
 
 // Send SYN segment.
-+.0 TCP > S seq 0(0) win 65535 <mss 1450, wscale 0>
++.0 TCP > S seq 65535(0) win 65535 <mss 1450, wscale 0>
 // Receive SYN-ACK segment.
-+.1 TCP < S. seq 0(0) ack 1 win 65535 <mss 1450, wscale 0>
++.1 TCP < S. seq 50000(0) ack 65536 win 65535 <mss 1450, wscale 0>
 
 // Succeed to establish connection.
 +.0 wait(500, ...) = 0
 
 // Send ACK on SYN-ACK segment.
-+.0 TCP > . seq 1(0) ack 1 win 65535 <nop>
++.0 TCP > . seq 65536(0) ack 50001 win 65535 <nop>
 
 // Receive FIN segment.
-+.1 TCP < F. seq 1(0) ack 1 win 65535 <nop>
++.1 TCP < F. seq 50001(0) ack 65536 win 65535 <nop>
 // Send ACK on FIN segment.
-+.0 TCP > . seq 1(0) ack 2 win 65534 <nop>
++.0 TCP > . seq 65536(0) ack 50002 win 65534 <nop>
 
 // Close connection.
 +.2 close(500) = 0
 
 // Send FIN segment.
-+.0 TCP > F. seq 1(0) ack 2 win 65534 <nop>
++.0 TCP > F. seq 65536(0) ack 50002 win 65534 <nop>
 // Receive ACK on FIN segment.
-+.1 TCP < . seq 2(0) ack 2 win 65535 <nop>
++.1 TCP < . seq 50002(0) ack 65537 win 65535 <nop>
 
 // Succeed to close connection immediately.
 +.0 wait(500, ...) = 0

--- a/network_simulator/input/tcp/close/close-simultaneous.pkt
+++ b/network_simulator/input/tcp/close/close-simultaneous.pkt
@@ -1,31 +1,31 @@
 // Tests for simultaneous close.
 
 // Establish a connection.
- +.0 socket(..., SOCK_STREAM, IPPROTO_TCP) = 500
++.0 socket(..., SOCK_STREAM, IPPROTO_TCP) = 500
 +.2 connect(500, ..., ...) = 0
 
 // Send SYN segment.
-+.0 TCP > S seq 0(0) win 65535 <mss 1450, wscale 0>
++.0 TCP > S seq 65535(0) win 65535 <mss 1450, wscale 0>
 // Receive SYN-ACK segment.
-+.1 TCP < S. seq 0(0) ack 1 win 65535 <mss 1450, wscale 0>
++.1 TCP < S. seq 100(0)  ack 65536 win 65535 <mss 1450, wscale 0>
 
 // Succeed to establish connection.
 +.0 wait(500, ...) = 0
 
 // Send ACK on SYN-ACK segment.
-+.0 TCP > . seq 1(0) ack 1 win 65535 <nop>
++.0 TCP > . seq 65536(0) ack 101 win 65535 <nop>
 
 // Close connection.
 +.2 close(500) = 0
 
 // Send FIN segment.
-+.0 TCP > F. seq 1(0) ack 1 win 65535 <nop>
++.0 TCP > F. seq 65536(0) ack 101 win 65535 <nop>
 // Receive ACK on FIN segment.
-+.1 TCP < F. seq 1(0) ack 2 win 65535 <nop>
++.1 TCP < F. seq 101(0) ack 65537 win 65535 <nop>
 
 // Succeed to close connection immediately because we have linger set to 0.
 +0 wait(500, ...) = 0
 
 // Send ACK on FIN segment.
-+.0 TCP > . seq 2(0) ack 2 win 65534 <nop>
++.0 TCP > . seq 65537(0) ack 102 win 65534 <nop>
 

--- a/network_simulator/input/tcp/connect/connect-blocking.pkt
+++ b/network_simulator/input/tcp/connect/connect-blocking.pkt
@@ -5,12 +5,12 @@
 +.2 connect(500, ..., ...) = 0
 
 // Send SYN packet.
-+.0 TCP > S seq 0(0) win 65535 <mss 1450, wscale 0>
++.0 TCP > S seq 65535(0) win 65535 <mss 1450, wscale 0>
 // Receive SYN-ACK packet.
-+.1 TCP < S. seq 0(0) ack 1 win 65535 <mss 1450, wscale 0>
++.1 TCP < S. seq 60000(0) ack 65536 win 65535 <mss 1450, wscale 0>
 
 // Succeed to establish connection.
 +.0 wait(500, ...) = 0
 
 // Send ACK on SYN-ACK packet.
-+.0 TCP > . seq 1(0) ack 1 win 65535 <nop>
++.0 TCP > . seq 65536(0) ack 60001 win 65535 <nop>

--- a/network_simulator/input/tcp/connect/connect-early-reset.pkt
+++ b/network_simulator/input/tcp/connect/connect-early-reset.pkt
@@ -5,9 +5,9 @@
 +.2 connect(500, ..., ...) = 0
 
 // Send SYN packet.
-+.0 TCP > S seq 0(0) win 65535 <mss 1450, wscale 0>
++.0 TCP > S seq 65535(0) win 65535 <mss 1450, wscale 0>
 // Receive a connection reset.
-+.1 TCP < R. seq 0(0) ack 1 win 65535 <mss 1450, wscale 0>
++.1 TCP < R. seq 0(0) ack 65536 win 65535 <mss 1450, wscale 0>
 
 // Fail to connect.
 +.0 wait(500, ...) = ECONNREFUSED

--- a/network_simulator/input/tcp/connect/connect-refused.pkt
+++ b/network_simulator/input/tcp/connect/connect-refused.pkt
@@ -5,19 +5,19 @@
 +.1 connect(500, ..., ...) = 0
 
 // Send SYN packet.
-+.0 TCP > S seq 0(0) win 65535 <mss 1450, wscale 0>
++.0 TCP > S seq 65535(0) win 65535 <mss 1450, wscale 0>
 
 // Retransmit SYN packet (1).
-+3 TCP > S seq 0(0) win 65535 <mss 1450, wscale 0>
++3 TCP > S seq 65535(0) win 65535 <mss 1450, wscale 0>
 
 // Retransmit SYN packet (2).
-+3 TCP > S seq 0(0) win 65535 <mss 1450, wscale 0>
++3 TCP > S seq 65535(0) win 65535 <mss 1450, wscale 0>
 
 // Retransmit SYN packet (3).
-+3 TCP > S seq 0(0) win 65535 <mss 1450, wscale 0>
++3 TCP > S seq 65535(0) win 65535 <mss 1450, wscale 0>
 
 // Retransmit SYN packet (4).
-+3 TCP > S seq 0(0) win 65535 <mss 1450, wscale 0>
++3 TCP > S seq 65535(0) win 65535 <mss 1450, wscale 0>
 
 // Fail to connect.
 +3 wait(500, ...) = ECONNREFUSED

--- a/network_simulator/input/tcp/pop/pop-blocking.pkt
+++ b/network_simulator/input/tcp/pop/pop-blocking.pkt
@@ -7,11 +7,11 @@
 +.2 accept(500, ..., ...) = 0
 
 // Receive SYN packet.
-+.2 TCP < S seq 0(0) win 65535 <mss 1450,wscale 0>
++.2 TCP < S seq 10(0) win 65535 <mss 1450,wscale 0>
 // Send SYN-ACK packet.
-+.0 TCP > S. seq 0(0) ack 1 win 65535 <mss 1450,wscale 0>
++.0 TCP > S. seq 12345(0) ack 11 win 65535 <mss 1450,wscale 0>
 // Receive ACK on SYN-ACK packet.
-+.2 TCP < . seq 1(0) ack 1 win 65535 <nop>
++.2 TCP < . seq 11(0) ack 12346 win 65535 <nop>
 
 // Succeed to accept connection.
 +.0 wait(500, ...) = 0
@@ -20,10 +20,10 @@
 +.1 read(501, ..., 1000) = 1000
 
 // Receive data packet.
-+.1 TCP < P. seq 1(1000) ack 1 win 65535 <nop>
++.1 TCP < P. seq 11(1000) ack 12346 win 65535 <nop>
 
 // Data read.
 +.0 wait(501, ...) = 0
 
 // Send ACK packet.
-+.6 TCP > . seq 1(0) ack 1001 win 65535 <nop>
++.6 TCP > . seq 12346(0) ack 1011 win 65535 <nop>

--- a/network_simulator/input/tcp/pop/pop-push-blocking.pkt
+++ b/network_simulator/input/tcp/pop/pop-push-blocking.pkt
@@ -7,11 +7,11 @@
 +.2 accept(500, ..., ...) = 0
 
 // Receive SYN packet.
-+.2 TCP < S seq 0(0) win 65535 <mss 1450,wscale 0>
++.2 TCP < S seq 5000(0) win 65535 <mss 1450,wscale 0>
 // Send SYN-ACK packet.
-+.0 TCP > S. seq 0(0) ack 1 win 65535 <mss 1450,wscale 0>
++.0 TCP > S. seq 12345(0) ack 5001 win 65535 <mss 1450,wscale 0>
 // Receive ACK on SYN-ACK packet.
-+.2 TCP < . seq 1(0) ack 1 win 65535 <nop>
++.2 TCP < . seq 5001(0) ack 12346 win 65535 <nop>
 
 // Succeed to accept connection.
 +.0 wait(500, ...) = 0
@@ -20,21 +20,21 @@
 +.1 read(501, ..., 1000) = 1000
 
 // Receive data packet.
-+.1 TCP < P. seq 1(1000) ack 1 win 65535 <nop>
++.1 TCP < P. seq 5001(1000) ack 12346 win 65535 <nop>
 
 // Data read.
 +.0 wait(501, ...) = 0
 
 // Send ACK packet.
-+.6 TCP > . seq 1(0) ack 1001 win 65535 <nop>
++.6 TCP > . seq 12346(0) ack 6001 win 65535 <nop>
 
 // Send data.
 +.1 write(501, ..., 1000) = 1000
 
 // Send data packet.
-+.1 TCP > P. seq 1(1000) ack 1001 win 65535 <nop>
++.1 TCP > P. seq 12346(1000) ack 6001 win 65535 <nop>
 // Receive ACK on data packet.
-+.1 TCP < . seq 1001(0) ack 1001 win 65535 <nop>
++.1 TCP < . seq 6001(0) ack 13346 win 65535 <nop>
 
 // Data sent.
 +.0 wait(501, ...) = 0

--- a/network_simulator/input/tcp/pop/pop-reordering.pkt
+++ b/network_simulator/input/tcp/pop/pop-reordering.pkt
@@ -7,11 +7,11 @@
 +.2 accept(500, ..., ...) = 0
 
 // Receive SYN packet.
-+.2 TCP < S seq 0(0) win 65535 <mss 1450,wscale 0>
++.2 TCP < S seq 10000(0) win 65535 <mss 1450,wscale 0>
 // Send SYN-ACK packet.
-+.0 TCP > S. seq 0(0) ack 1 win 65535 <mss 1450,wscale 0>
++.0 TCP > S. seq 12345(0) ack 10001 win 65535 <mss 1450,wscale 0>
 // Receive ACK on SYN-ACK packet.
-+.2 TCP < . seq 1(0) ack 1 win 65535 <nop>
++.2 TCP < . seq 10001(0) ack 12346 win 65535 <nop>
 
 // Succeed to accept connection.
 +.0 wait(500, ...) = 0
@@ -20,19 +20,19 @@
 +.1 read(501, ..., 1000) = 1000
 
 // Receive out of order data packet.
-+.1 TCP < P. seq 1001(1000) ack 1 win 65535 <nop>
++.1 TCP < P. seq 11001(1000) ack 12346 win 65535 <nop>
 
 // Send ACK packet.
-+.0 TCP > . seq 1(0) ack 1 win 65535 <nop>
++.0 TCP > . seq 12346(0) ack 10001 win 65535 <nop>
 
 // Receive in order data packet.
-+.1 TCP < P. seq 1(1000) ack 1 win 65535 <nop>
++.1 TCP < P. seq 10001(1000) ack 12346 win 65535 <nop>
 
 // Data read.
 +.0 wait(501, ...) = 0
 
 // Send ACK packet
-+.6 TCP > . seq 1(0) ack 2001 win 63535 <nop>
++.6 TCP > . seq 12346(0) ack 12001 win 63535 <nop>
 
 // Read data.
 +.1 read(501, ..., 1000) = 1000

--- a/network_simulator/input/tcp/pop/pop-retransmission.pkt
+++ b/network_simulator/input/tcp/pop/pop-retransmission.pkt
@@ -7,11 +7,11 @@
 +.2 accept(500, ..., ...) = 0
 
 // Receive SYN packet.
-+.2 TCP < S seq 0(0) win 65535 <mss 1450,wscale 0>
++.2 TCP < S seq 1000000(0) win 65535 <mss 1450,wscale 0>
 // Send SYN-ACK packet.
-+.0 TCP > S. seq 0(0) ack 1 win 65535 <mss 1450,wscale 0>
++.0 TCP > S. seq 12345(0) ack 1000001 win 65535 <mss 1450,wscale 0>
 // Receive ACK on SYN-ACK packet.
-+.2 TCP < . seq 1(0) ack 1 win 65535 <nop>
++.2 TCP < . seq 10000001(0) ack 12346 win 65535 <nop>
 
 // Succeed to accept connection.
 +.0 wait(500, ...) = 0
@@ -20,14 +20,14 @@
 +.1 read(501, ..., 1000) = 1000
 
 // Receive data packet.
-+.1 TCP < P. seq 1(1000) ack 1 win 65535 <nop>
++.1 TCP < P. seq 1000001(1000) ack 12346 win 65535 <nop>
 
 // Data read.
 +.0 wait(501, ...) = 0
 
 // Receive data packet again.
-+.1 TCP < P. seq 1(1000) ack 1 win 65535 <nop>
++.1 TCP < P. seq 1000001(1000) ack 12346 win 65535 <nop>
 
 // Send ACK packet.
-+.0 TCP > . seq 1(0) ack 1001 win 65535 <nop>
++.0 TCP > . seq 12346(0) ack 1001001 win 65535 <nop>
 

--- a/network_simulator/input/tcp/push/push-blocking.pkt
+++ b/network_simulator/input/tcp/push/push-blocking.pkt
@@ -7,11 +7,11 @@
 +.2 accept(500, ..., ...) = 0
 
 // Receive SYN packet.
-+.2 TCP < S seq 0(0) win 65535 <mss 1450,wscale 0>
++.2 TCP < S seq 10(0) win 65535 <mss 1450,wscale 0>
 // Send SYN-ACK packet.
-+.0 TCP > S. seq 0(0) ack 1 win 65535 <mss 1450,wscale 0>
++.0 TCP > S. seq 12345(0) ack 11 win 65535 <mss 1450,wscale 0>
 // Receive ACK on SYN-ACK packet.
-+.2 TCP < . seq 1(0) ack 1 win 65535 <nop>
++.2 TCP < . seq 11(0) ack 12346 win 65535 <nop>
 
 // Succeed to accept connection.
 +.0 wait(500, ...) = 0
@@ -20,9 +20,9 @@
 +.1 write(501, ..., 1000) = 1000
 
 // Send data packet.
-+.0 TCP > P. seq 1(1000) ack 1 win 65535 <nop>
++.0 TCP > P. seq 12346(1000) ack 11 win 65535 <nop>
 // Receive ACK on data packet.
-+.1 TCP < . seq 1(0) ack 1001 win 65535 <nop>
++.1 TCP < . seq 11(0) ack 13346 win 65535 <nop>
 
 // Data sent.
 +.0 wait(501, ...) = 0

--- a/network_simulator/input/tcp/push/push-pop-blocking.pkt
+++ b/network_simulator/input/tcp/push/push-pop-blocking.pkt
@@ -7,11 +7,11 @@
 +.2 accept(500, ..., ...) = 0
 
 // Receive SYN packet.
-+.2 TCP < S seq 0(0) win 65535 <mss 1450,wscale 0>
++.2 TCP < S seq 1000(0) win 65535 <mss 1450,wscale 0>
 // Send SYN-ACK packet.
-+.0 TCP > S. seq 0(0) ack 1 win 65535 <mss 1450,wscale 0>
++.0 TCP > S. seq 12345(0) ack 1001 win 65535 <mss 1450,wscale 0>
 // Receive ACK on SYN-ACK packet.
-+.2 TCP < . seq 1(0) ack 1 win 65535 <nop>
++.2 TCP < . seq 1001(0) ack 12346 win 65535 <nop>
 
 // Succeed to accept connection.
 +.0 wait(500, ...) = 0
@@ -20,9 +20,9 @@
 +.1 write(501, ..., 1000) = 1000
 
 // Send data packet.
-+.0 TCP > P. seq 1(1000) ack 1 win 65535 <nop>
++.0 TCP > P. seq 12346(1000) ack 1001 win 65535 <nop>
 // Receive ACK on data packet.
-+.1 TCP < . seq 1(0) ack 1001 win 65535 <nop>
++.1 TCP < . seq 1001(0) ack 13346 win 65535 <nop>
 
 // Data sent.
 +.0 wait(501, ...) = 0
@@ -31,10 +31,10 @@
 +.1 read(501, ..., 1000) = 1000
 
 // Receive data packet.
-+.1 TCP < P. seq 1(1000) ack 1001 win 65535 <nop>
++.1 TCP < P. seq 1001(1000) ack 13346 win 65535 <nop>
 
 // Data read.
 +.0 wait(501, ...) = 0
 
 // Send ACK on data packet.
-+.6 TCP > . seq 1001(0) ack 1001 win 64535 <nop>
++.6 TCP > . seq 13346(0) ack 2001 win 64535 <nop>

--- a/network_simulator/input/tcp/push/push-retransmission-2.pkt
+++ b/network_simulator/input/tcp/push/push-retransmission-2.pkt
@@ -7,11 +7,11 @@
 +.2 accept(500, ..., ...) = 0
 
 // Receive SYN packet.
-+.2 TCP < S seq 0(0) win 65535 <mss 1450,wscale 0>
++.2 TCP < S seq 10000(0) win 65535 <mss 1450,wscale 0>
 // Send SYN-ACK packet.
-+.0 TCP > S. seq 0(0) ack 1 win 65535 <mss 1450,wscale 0>
++.0 TCP > S. seq 12345(0) ack 10001 win 65535 <mss 1450,wscale 0>
 // Receive ACK on SYN-ACK packet.
-+.2 TCP < . seq 1(0) ack 1 win 65535 <nop>
++.2 TCP < . seq 10001(0) ack 12346 win 65535 <nop>
 
 // Succeed to accept connection.
 +.0 wait(500, ...) = 0
@@ -20,29 +20,29 @@
 +.1 write(501, ..., 1000) = 1000
 
 // Send data packet.
-+0 TCP > P. seq 1(1000) ack 1 win 65535 <nop>
++0 TCP > P. seq 12346(1000) ack 10001 win 65535 <nop>
 
 
 // Send more data.
 +.1 write(501, ..., 1000) = 1000
 
 // Send data packet.
-+0 TCP > P. seq 1001(1000) ack 1 win 65535 <nop>
++0 TCP > P. seq 13346(1000) ack 10001 win 65535 <nop>
 
 // Retransmit first data packet.
-+4 TCP > P. seq 1(1000) ack 1 win 65535 <nop>
++4 TCP > P. seq 12346(1000) ack 10001 win 65535 <nop>
 
 // Receive ACK on first data packet.
-+.1 TCP < . seq 1(0) ack 1001 win 65535 <nop>
++.1 TCP < . seq 10001(0) ack 13346 win 65535 <nop>
 
 // Data sent.
 +.0 wait(501, ...) = 0
 
 // Retransmit second data packet.
-+.1 TCP > P. seq 1001(1000) ack 1 win 65535 <nop>
++.1 TCP > P. seq 13346(1000) ack 10001 win 65535 <nop>
 
 // Receive ACK on second data packet.
-+.1 TCP < . seq 1(0) ack 2001 win 65535 <nop>
++.1 TCP < . seq 10001(0) ack 14346 win 65535 <nop>
 
 // Data sent.
 +.0 wait(501, ...) = 0

--- a/network_simulator/input/tcp/push/push-retransmission.pkt
+++ b/network_simulator/input/tcp/push/push-retransmission.pkt
@@ -7,11 +7,11 @@
 +.2 accept(500, ..., ...) = 0
 
 // Receive SYN packet.
-+.2 TCP < S seq 0(0) win 65535 <mss 1450,wscale 0>
++.2 TCP < S seq 100000(0) win 65535 <mss 1450,wscale 0>
 // Send SYN-ACK packet.
-+.0 TCP > S. seq 0(0) ack 1 win 65535 <mss 1450,wscale 0>
++.0 TCP > S. seq 12345(0) ack 100001 win 65535 <mss 1450,wscale 0>
 // Receive ACK on SYN-ACK packet.
-+.2 TCP < . seq 1(0) ack 1 win 65535 <nop>
++.2 TCP < . seq 100001(0) ack 12346 win 65535 <nop>
 
 // Succeed to accept connection.
 +.0 wait(500, ...) = 0
@@ -20,11 +20,11 @@
 +.1 write(501, ..., 1000) = 1000
 
 // Send data packet.
-+0 TCP > P. seq 1(1000) ack 1 win 65535 <nop>
++0 TCP > P. seq 12346(1000) ack 100001 win 65535 <nop>
 // Send data packet.
-+4 TCP > P. seq 1(1000) ack 1 win 65535 <nop>
++4 TCP > P. seq 12346(1000) ack 100001 win 65535 <nop>
 // Receive ACK on data packet.
-+.1 TCP < . seq 1(0) ack 1001 win 65535 <nop>
++.1 TCP < . seq 100001(0) ack 13346 win 65535 <nop>
 
 // Data sent.
 +.0 wait(501, ...) = 0

--- a/src/rust/inetstack/protocols/layer4/tcp/established/receiver.rs
+++ b/src/rust/inetstack/protocols/layer4/tcp/established/receiver.rs
@@ -129,6 +129,10 @@ impl Receiver {
             (self.window_scale_shift_bits == 0 && bytes_unread <= MAX_WINDOW_SIZE_WITHOUT_SCALING)
                 || bytes_unread <= MAX_WINDOW_SIZE_WITH_SCALING
         );
+        debug!(
+            "Receive window size: bytes_unread={:?} buffer_size_bytes={:?} ",
+            bytes_unread, self.buffer_size_bytes
+        );
         self.buffer_size_bytes - bytes_unread
     }
 

--- a/src/rust/inetstack/protocols/layer4/tcp/isn_generator.rs
+++ b/src/rust/inetstack/protocols/layer4/tcp/isn_generator.rs
@@ -20,8 +20,9 @@ impl IsnGenerator {
     }
 
     #[cfg(test)]
-    pub fn generate(&mut self, _local: &SocketAddrV4, _remote: &SocketAddrV4) -> SeqNumber {
-        SeqNumber::from(0)
+    /// Use the local port as the initial sequence number
+    pub fn generate(&mut self, local: &SocketAddrV4, _remote: &SocketAddrV4) -> SeqNumber {
+        SeqNumber::from(local.port() as u32)
     }
 
     #[cfg(not(test))]

--- a/src/rust/inetstack/protocols/layer4/tcp/passive_open.rs
+++ b/src/rust/inetstack/protocols/layer4/tcp/passive_open.rs
@@ -380,7 +380,7 @@ impl SharedPassiveSocket {
                     return Err(Fail::new(EBADMSG, &cause));
                 },
                 // We got a duplicate SYN, so ignore it.
-                (_, tcp_hdr, _) if tcp_hdr.syn && tcp_hdr.ack_num == local_isn => {
+                (_, tcp_hdr, _) if tcp_hdr.syn && tcp_hdr.seq_num == remote_isn => {
                     debug!("Received duplicate SYN: {:?}", tcp_hdr)
                 },
                 // We didn't get any kind of expected packet.

--- a/src/rust/inetstack/test_helpers/engine.rs
+++ b/src/rust/inetstack/test_helpers/engine.rs
@@ -67,8 +67,8 @@ impl SharedEngine {
         for _ in 0..MAX_LOOP_ITERATIONS {
             // Run all foreground tasks until they are done and then run the background tasks once.
             // This function should either time out or complete a task (which will be stored for later).
-            match self.get_runtime().wait_next_n(|_, _, _| false, Duration::ZERO) {
-                Ok(()) => (),
+            match self.get_runtime().wait_any(&[], Duration::ZERO) {
+                Ok(_) => unreachable!("Should not have completed a task without qtokens passed in"),
                 Err(e) => assert_eq!(e.errno, libc::ETIMEDOUT),
             };
             match self.layer1_endpoint.pop_all_frames() {


### PR DESCRIPTION
This closes #1520.

It also fixes two bugs that were not caught by our previous tests.
1. Recently we switched to two layers of storing operations in the runtime, one in the wait_next_n call which stores completed tasks and another in wait_any, which stores the operation results. Because we were using the wait_next_n call to run the scheduler in pop_frame, we were not storing any completed operation results. By switching to the wait_any call, we can ensure that the results are stored for later retrieval.
2. We were not correctly detecting duplicate SYN packets because both the local and remote sequence numbers were identical and started at 0. We were using the local sequence number to check instead of the remote one.