### PR TITLE
[tcp-echo] Enhancement: simplify metric logging

### DIFF
--- a/examples/tcp-echo/client.rs
+++ b/examples/tcp-echo/client.rs
@@ -87,6 +87,8 @@ impl TcpEchoClient {
         nrequests: Option<usize>,
         connect_handler: fn(&mut TcpEchoClient, &demi_qresult_t) -> Result<()>,
     ) -> Result<()> {
+        println!("HEADERS:tx,rx,rps,p50,p90,p99,p99.9,p99.99,p99.999,p99.9999,p100");
+
         let mut last_log: Instant = Instant::now();
 
         loop {
@@ -113,20 +115,22 @@ impl TcpEchoClient {
                     let time_elapsed: f64 = (Instant::now() - last_log).as_secs() as f64;
                     let rps: f64 = self.nechoed as f64 / time_elapsed;
                     println!(
-                        "INFO: {:?} requests, {:2?} rps, p50: {:?} ns, p90: {:?} ns, p99: {:?} ns, p99.9: {:?} ns, p99.99: {:?} ns, p99.999: {:?} ns, p99.9999: {:?} ns, p100: {:?} ns",
+                        "METRICS:{:?},{:?},{:2?},{:?},{:?},{:?},{:?},{:?},{:?},{:?},{:?}",
+                        self.npushed,
                         self.nechoed,
                         rps,
-                        self.stats.percentile(50f64)?.unwrap().start(),
-                        self.stats.percentile(90f64)?.unwrap().start(),
-                        self.stats.percentile(99f64)?.unwrap().start(),
-                        self.stats.percentile(99.9f64)?.unwrap().start(),
-                        self.stats.percentile(99.99f64)?.unwrap().start(),
-                        self.stats.percentile(99.999f64)?.unwrap().start(),
-                        self.stats.percentile(99.9999f64)?.unwrap().start(),
-                        self.stats.percentile(100f64)?.unwrap().start(),
+                        self.stats.percentile(50.0)?.unwrap().start(),
+                        self.stats.percentile(90.0)?.unwrap().start(),
+                        self.stats.percentile(99.0)?.unwrap().start(),
+                        self.stats.percentile(99.9)?.unwrap().start(),
+                        self.stats.percentile(99.99)?.unwrap().start(),
+                        self.stats.percentile(99.999)?.unwrap().start(),
+                        self.stats.percentile(99.9999)?.unwrap().start(),
+                        self.stats.percentile(100.0)?.unwrap().start(),
                     );
                     last_log = Instant::now();
                     self.nechoed = 0;
+                    self.npushed = 0;
                 }
             }
 


### PR DESCRIPTION
The current log format makes it harder to parse the output using automated scripts, and these metrics are not suitable for human consumption any preprocessing.

Now the header is just printed once, while the line markers are printed in each line so that grep can be used on the log files easily.

"npushed" is now reset at each log interval, so that we can keep track of how many packets were tx and rx in each log cycle.