### PR TITLE
[script] Bug Fix: remove unnecessary pip install

### DIFF
--- a/scripts/setup/debian.sh
+++ b/scripts/setup/debian.sh
@@ -9,7 +9,3 @@ PACKAGES="librdmacm-dev libmnl-dev build-essential clang libnuma-dev pkg-config 
 
 apt-get update
 apt-get -y install $PACKAGES
-
-# This dependency is only needed on machines that drive the
-# Azure Tables script for continuous integration.
-pip3 install azure-data-tables


### PR DESCRIPTION
The current CI workflows don't write to Azure Tables, so the Python package that supports this integration is no longer needed.

Moreover, this causes warnings on manual triggers of this script on machines which don't use Python Virtual Environments.