### PR TITLE
[bindings] Bug Fix: tweak and fix minor behavior in headers/bindings

### DIFF
--- a/include/demi/cc.h
+++ b/include/demi/cc.h
@@ -12,6 +12,7 @@
 #define _In_opt_
 #define _In_reads_(s)
 #define _In_reads_bytes_(b)
+#define _Inout_
 #define _Out_
 #define _Out_writes_to_(s, c)
 #define _Deref_pre_z_

--- a/include/demi/libos.h
+++ b/include/demi/libos.h
@@ -156,27 +156,28 @@ extern "C"
     /**
      * @brief Gets socket options.
      *
-     * @param qd     Target I/O queue descriptor.
-     * @param level  Protocol level at which the option resides.
+     * @param qd      Target I/O queue descriptor.
+     * @param level   Protocol level at which the option resides.
      * @param optname Socket option for which the value is to be retrieved.
-     * @param optval Pointer to the buffer containing the option value.
-     * @param optlen Size of the buffer containing the option value.
+     * @param optval  Pointer to the buffer containing the option value.
+     * @param optlen  On input, specified the size of the buffer containing the option value. Upon successful
+     *                completion, updated to indicate the number of bytes written to optval.
      *
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
-    ATTR_NONNULL(4)
-    extern int demi_getsockopt(_In_ int qd, _In_ int level, _In_ int optname, _Out_writes_to_(optlen, *optlen) void *optval, _In_ socklen_t *optlen);
-
+    ATTR_NONNULL(4, 5)
+    extern int demi_getsockopt(_In_ int qd, _In_ int level, _In_ int optname, _Out_writes_to_(*optlen, *optlen) void *optval, _Inout_ socklen_t *optlen);
     /**
      * @brief Returns the address of the peer connected to qd.
      *
      * @param addr    Peer address is returned in this parameter.
-     * @param addrlen Indicates the amount of space pointed to by addr
+     * @param addrlen Indicates the amount of space pointed to by addr; updated on success to indicate the number of
+     *                bytes written to addr.
      *
      * @return On success, zero is returned. On failure, a possitive error code is returned.
      */
-    ATTR_NONNULL(2)
-    extern int demi_getpeername(_In_ int qd, _Out_writes_to_(addrlen, *addrlen) struct sockaddr *addr, _In_ socklen_t *addrlen);
+    ATTR_NONNULL(2, 3)
+    extern int demi_getpeername(_In_ int qd, _Out_writes_to_(*addrlen, *addrlen) struct sockaddr *addr, _Inout_ socklen_t *addrlen);
 
 #ifdef __cplusplus
 }

--- a/include/demi/types.h
+++ b/include/demi/types.h
@@ -15,6 +15,10 @@
 
 #ifdef _WIN32
 #include <WinSock2.h>
+
+// NB push the structure packing onto the stack with a label to ensure we correctly restore it at the end of the
+// header.
+#pragma pack(push, demi0)
 #endif
 
 #ifdef __cplusplus
@@ -155,6 +159,11 @@ extern "C"
 
 #ifdef __cplusplus
 }
+#endif
+
+#ifdef _WIN32
+// Restore the original packing alignment.
+#pragma pack(pop, demi0)
 #endif
 
 #endif /* DEMI_TYPES_H_IS_INCLUDED */

--- a/src/rust/demikernel/bindings.rs
+++ b/src/rust/demikernel/bindings.rs
@@ -395,7 +395,10 @@ pub extern "C" fn demi_wait(qr_out: *mut demi_qresult_t, qt: demi_qtoken_t, time
             0
         },
         Err(e) => {
-            trace!("demi_wait() failed: {:?}", e);
+            // EDTIMEDOUT is not a "failure" per se; don't trace.
+            if e.errno != libc::ETIMEDOUT {
+                trace!("demi_wait() failed: {:?}", e);
+            }
             e.errno
         },
     });
@@ -455,7 +458,10 @@ pub extern "C" fn demi_wait_any(
             0
         },
         Err(e) => {
-            trace!("demi_wait_any() failed: {:?}", e);
+            // EDTIMEDOUT is not a "failure" per se; don't trace.
+            if e.errno != libc::ETIMEDOUT {
+                trace!("demi_wait_any() failed: {:?}", e);
+            }
             e.errno
         },
     });
@@ -510,6 +516,7 @@ pub extern "C" fn demi_wait_next_n(
     let ret: Result<i32, Fail> = do_syscall(|libos| match libos.wait_next_n(wait_callback, duration) {
         Ok(()) => 0,
         Err(e) => {
+            // EDTIMEDOUT is not a "failure" per se; don't trace.
             if e.errno != libc::ETIMEDOUT {
                 trace!("demi_wait_any() failed: {:?}", e)
             };
@@ -638,7 +645,7 @@ pub extern "C" fn demi_setsockopt(
     let ret: Result<(), Fail> = match do_syscall(|libos| libos.set_socket_option(qd.into(), opt)) {
         Ok(result) => result,
         Err(e) => {
-            trace!("demi_getsockopt(): {:?}", e);
+            trace!("demi_setsockopt(): {:?}", e);
             return e.errno;
         },
     };
@@ -646,7 +653,7 @@ pub extern "C" fn demi_setsockopt(
     match ret {
         Ok(_) => 0,
         Err(e) => {
-            trace!("demi_getsockopt(): {:?}", e);
+            trace!("demi_setsockopt(): {:?}", e);
             e.errno
         },
     }
@@ -753,7 +760,7 @@ pub extern "C" fn demi_getpeername(qd: c_int, addr: *mut SockAddr, addrlen: *mut
 
     let expected_len = mem::size_of::<SockAddrIn>() as Socklen;
 
-    if unsafe { *addrlen != expected_len } {
+    if unsafe { *addrlen < expected_len } {
         warn!("demi_getpeername(): addrlen does not match size of SockAddrIn");
         return libc::EINVAL;
     }


### PR DESCRIPTION
This PR fixes and tweaks a few things:
- Fix attributes and SAL annotations and getpeername and getsockopt
- Add a safety `#pragma pack` to types.h so we don't accidentally forget to restore packing for C clients
- Fix error message wording to indicate the correct method
- Stop tracing when a wait times out; this is not really an error condition
- Be more permissive in allowing the client to pass overlarge buffers to getpeername