### PR TITLE
[libos] Bug Fix: fix bug in send queue for pushto operations

### DIFF
--- a/src/rust/demikernel/libos/network/libos.rs
+++ b/src/rust/demikernel/libos/network/libos.rs
@@ -313,7 +313,7 @@ impl<T: NetworkTransport> SharedNetworkLibOS<T> {
                 .insert_nonpolling_coroutine("ioc::network::libos::push", coroutine)
         };
 
-        queue.push(coroutine_constructor, buf)
+        queue.push(coroutine_constructor, buf, None)
     }
 
     /// Asynchronous code to push [buf] to a SharedNetworkQueue and its underlying POSIX socket. This function returns a
@@ -328,7 +328,7 @@ impl<T: NetworkTransport> SharedNetworkLibOS<T> {
             Err(e) => return (qd, OperationResult::Failed(e)),
         };
         // Wait for push to complete.
-        match queue.push_coroutine(None).await {
+        match queue.push_coroutine().await {
             Ok(()) => (qd, OperationResult::Push),
             Err(e) => {
                 warn!("push() qd={:?}: {:?}", qd, &e);
@@ -350,19 +350,19 @@ impl<T: NetworkTransport> SharedNetworkLibOS<T> {
 
         let mut queue: SharedNetworkQueue<T> = self.get_shared_queue(&qd)?;
         let coroutine_constructor = || -> Result<QToken, Fail> {
-            let coroutine = Box::pin(self.clone().pushto_coroutine(qd, remote).fuse());
+            let coroutine = Box::pin(self.clone().pushto_coroutine(qd).fuse());
             self.runtime
                 .clone()
                 .insert_nonpolling_coroutine("ioc::network::libos::pushto", coroutine)
         };
 
-        queue.push(coroutine_constructor, buf)
+        queue.push(coroutine_constructor, buf, Some(remote))
     }
 
     /// Asynchronous code to pushto [buf] to [remote] on a SharedNetworkQueue and its underlying POSIX socket. This function
     /// returns a coroutine that runs asynchronously to pushto a queue and its underlying POSIX socket and performs any
     /// necessary multi-queue operations at the LibOS-level after the pushto succeeds or fails.
-    async fn pushto_coroutine(self, qd: QDesc, remote: SocketAddr) -> (QDesc, OperationResult) {
+    async fn pushto_coroutine(self, qd: QDesc) -> (QDesc, OperationResult) {
         // Grab the queue, make sure it hasn't been closed in the meantime.
         // This will bump the Rc refcount so the coroutine can have it's own reference to the shared queue data
         // structure and the SharedNetworkQueue will not be freed until this coroutine finishes.
@@ -371,7 +371,7 @@ impl<T: NetworkTransport> SharedNetworkLibOS<T> {
             Err(e) => return (qd, OperationResult::Failed(e)),
         };
         // Wait for push to complete.
-        match queue.push_coroutine(Some(remote)).await {
+        match queue.push_coroutine().await {
             Ok(()) => (qd, OperationResult::Push),
             Err(e) => {
                 warn!("pushto() qd={:?}: {:?}", qd, &e);

--- a/src/rust/demikernel/libos/network/queue.rs
+++ b/src/rust/demikernel/libos/network/queue.rs
@@ -26,6 +26,14 @@ use ::std::{
 };
 
 //======================================================================================================================
+// Constants
+//======================================================================================================================
+
+/// The default capacity of the push queue on construction, used to preallocate in order to remove the allocation cost
+/// from the data path.
+const DEFAULT_PUSH_QUEUE_CAPACITY: usize = 16;
+
+//======================================================================================================================
 // Structures
 //======================================================================================================================
 
@@ -44,7 +52,7 @@ pub struct NetworkQueue<T: NetworkTransport> {
     remote: Option<SocketAddr>,
     /// Queue for outgoing packets. This ensures packets go out in order regardless of the scheduling of the push
     /// coroutine.
-    push_queue: VecDeque<DemiBuffer>,
+    push_queue: VecDeque<(DemiBuffer, Option<SocketAddr>)>,
     /// Underlying network transport.
     transport: T,
 }
@@ -76,7 +84,7 @@ impl<T: NetworkTransport> SharedNetworkQueue<T> {
             socket,
             local: None,
             remote: None,
-            push_queue: VecDeque::new(),
+            push_queue: VecDeque::with_capacity(DEFAULT_PUSH_QUEUE_CAPACITY),
             transport: transport.clone(),
         })))
     }
@@ -179,7 +187,7 @@ impl<T: NetworkTransport> SharedNetworkQueue<T> {
             socket: new_socket,
             local: None,
             remote: Some(saddr),
-            push_queue: VecDeque::new(),
+            push_queue: VecDeque::with_capacity(DEFAULT_PUSH_QUEUE_CAPACITY),
             transport: self.transport.clone(),
         })))
     }
@@ -272,21 +280,26 @@ impl<T: NetworkTransport> SharedNetworkQueue<T> {
 
     /// Schedule a coroutine to push to this queue. This function contains all of the single-queue,
     /// asynchronous code necessary to run push a buffer and any single-queue functionality after the push completes.
-    pub fn push<F>(&mut self, coroutine_constructor: F, buf: DemiBuffer) -> Result<QToken, Fail>
+    pub fn push<F>(
+        &mut self,
+        coroutine_constructor: F,
+        buf: DemiBuffer,
+        addr: Option<SocketAddr>,
+    ) -> Result<QToken, Fail>
     where
         F: FnOnce() -> Result<QToken, Fail>,
     {
         self.state_machine.may_push()?;
-        self.push_queue.push_back(buf);
+        self.push_queue.push_back((buf, addr));
         coroutine_constructor()
     }
 
     /// Asynchronously push data to the queue. This function contains all of the single-queue, asynchronous code
     /// necessary to push to the queue and any single-queue functionality after the push completes.
-    pub async fn push_coroutine(&mut self, addr: Option<SocketAddr>) -> Result<(), Fail> {
+    pub async fn push_coroutine(&mut self) -> Result<(), Fail> {
         self.state_machine.may_push()?;
 
-        let mut buf: DemiBuffer = self
+        let (mut buf, addr): (DemiBuffer, Option<SocketAddr>) = self
             .push_queue
             .pop_front()
             .expect("push_coroutine(): push queue should not be empty");


### PR DESCRIPTION
This PR fixes a bug in `pushto` operations: the destination address and packet are no longer correlated after the addition of the send_queue field to SharedNetworkQueue. This change puts the destination address in the send_queue along with the DemiBuffer so that they flow together.