### PR TITLE
[bindings] Enhancement: add an optional logging callback to demi_args_t

### DIFF
--- a/include/demi/types.h
+++ b/include/demi/types.h
@@ -138,6 +138,19 @@ extern "C"
     // Callback Function.
     typedef void (*demi_callback_t)(const char *, uint32_t, uint64_t);
 
+    // Log levels for demi_log_callback_t. These values correspond to the enum in flexi_logger crate.
+    typedef enum demi_log_level
+    {
+        DemiLogLevel_Error = 1,
+        DemiLogLevel_Warning = 2,
+        DemiLogLevel_Info = 3,
+        DemiLogLevel_Debug = 4,
+        DemiLogLevel_Trace = 5,
+    } demi_log_level_t;
+
+    // Logging callback. Arguments are: level, module name, module length, file name, file name length, line number, message, message length, 
+    typedef void (*demi_log_callback_t)(demi_log_level_t, const char*, uint32_t, const char*, uint32_t, uint32_t, const char*, uint32_t);
+
 /**
  * @brief Arguments for Demikernel.
  */
@@ -149,9 +162,10 @@ extern "C"
         struct __attribute__((__packed__)) demi_args
 #endif
     {
-        int argc;                 /**< Number of command-line arguments. */
-        char *const *argv;        /**< Command-line Arguments.           */
-        demi_callback_t callback; /**< Callback Function.                */
+        int argc;                        /**< Number of command-line arguments. */
+        char *const *argv;               /**< Command-line Arguments.           */
+        demi_callback_t callback;        /**< Callback Function.                */
+        demi_log_callback_t logCallback; /**< Logging Callback.                */
     };
 #ifdef _WIN32
 #pragma pack(pop)

--- a/src/rust/demikernel/bindings.rs
+++ b/src/rust/demikernel/bindings.rs
@@ -13,13 +13,17 @@ use crate::{
     },
     runtime::{
         fail::Fail,
-        logging,
-        types::{demi_args_t, demi_callback_t, demi_qresult_t, demi_qtoken_t, demi_sgarray_t, demi_sgaseg_t},
+        logging::{self, CallbackLogWriter},
+        types::{
+            demi_args_t, demi_callback_t, demi_log_callback_t, demi_qresult_t, demi_qtoken_t, demi_sgarray_t,
+            demi_sgaseg_t,
+        },
         QToken,
     },
     SocketOption,
 };
-use ::libc::{c_int, c_void};
+use ::flexi_logger::Logger;
+use ::libc::{c_int, c_void, sockaddr};
 use ::socket2::SockAddr;
 use ::std::{
     cell::RefCell,
@@ -28,7 +32,6 @@ use ::std::{
     ptr, slice,
     time::Duration,
 };
-use libc::sockaddr;
 
 thread_local! {
     static THREAD_LOCAL_LIBOS: RefCell<Option<LibOS>> = RefCell::new(None);
@@ -37,7 +40,24 @@ thread_local! {
 #[allow(unused)]
 #[no_mangle]
 pub extern "C" fn demi_init(args: *const demi_args_t) -> c_int {
-    logging::initialize();
+    // Initialize logging before anything else.
+    let log_callback: Option<demi_log_callback_t> = if args.is_null() {
+        None
+    } else {
+        let args: &demi_args_t = unsafe { &*args };
+        args.log_callback
+    };
+
+    if log_callback.is_none() {
+        logging::initialize();
+    } else {
+        logging::custom_initialize(move || {
+            Logger::try_with_env()
+                .unwrap()
+                .log_to_writer(Box::new(CallbackLogWriter::new(log_callback.unwrap())))
+        });
+    }
+
     trace!("demi_init()");
 
     let libos_name: LibOSName = match LibOSName::from_env() {

--- a/src/rust/runtime/logging.rs
+++ b/src/rust/runtime/logging.rs
@@ -5,8 +5,10 @@
 // Imports
 //======================================================================================================================
 
-use ::flexi_logger::{with_thread, Logger, LoggerHandle};
+use ::flexi_logger::{with_thread, writers::LogWriter, Logger, LoggerHandle};
 use ::std::sync::OnceLock;
+
+use crate::runtime::types::demi_log_callback_t;
 
 //======================================================================================================================
 // Static Variables
@@ -14,6 +16,51 @@ use ::std::sync::OnceLock;
 
 /// Guardian to the logging initialize function.
 static LOG_HANDLE: OnceLock<LoggerHandle> = OnceLock::new();
+
+//======================================================================================================================
+// Structures
+//======================================================================================================================
+/// A LogWriter type which calls a C callback function to log messages.
+pub struct CallbackLogWriter {
+    callback: demi_log_callback_t,
+}
+
+//=====================================================================================================================
+// Associated Functions
+//=====================================================================================================================
+impl CallbackLogWriter {
+    /// Creates a new `CallbackLogWriter` instance.
+    pub fn new(callback: demi_log_callback_t) -> Self {
+        Self { callback }
+    }
+}
+
+//======================================================================================================================
+// Trait Implementations
+//======================================================================================================================
+impl LogWriter for CallbackLogWriter {
+    fn write(&self, _now: &mut flexi_logger::DeferredNow, record: &log::Record) -> std::io::Result<()> {
+        let module: &str = record.module_path().unwrap_or("{unnamed}");
+        let file: &str = record.file().unwrap_or("{unknown file}");
+        let message: String = record.args().to_string();
+        ((self.callback)(
+            record.level() as i32,
+            module.as_ptr() as *const std::ffi::c_char,
+            module.len() as u32,
+            file.as_ptr() as *const std::ffi::c_char,
+            file.len() as u32,
+            record.line().unwrap_or(0),
+            message.as_ptr() as *const std::ffi::c_char,
+            message.len() as u32,
+        ));
+
+        Ok(())
+    }
+
+    fn flush(&self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
 
 //======================================================================================================================
 // Standalone Functions

--- a/src/rust/runtime/types/mod.rs
+++ b/src/rust/runtime/types/mod.rs
@@ -24,12 +24,25 @@ pub use self::{
 /// A callback function.
 pub type demi_callback_t = extern "C" fn(*const std::ffi::c_char, u32, u64);
 
+/// Logging callback function.
+pub type demi_log_callback_t = extern "C" fn(
+    std::ffi::c_int,
+    *const std::ffi::c_char,
+    u32,
+    *const std::ffi::c_char,
+    u32,
+    u32,
+    *const std::ffi::c_char,
+    u32,
+);
+
 /// Demikernel Arguments
 #[repr(C, packed)]
 pub struct demi_args_t {
     pub argc: core::ffi::c_int,
     pub argv: *const *const core::ffi::c_char,
     pub callback: Option<demi_callback_t>,
+    pub log_callback: Option<demi_log_callback_t>,
 }
 
 impl Default for demi_args_t {
@@ -38,6 +51,7 @@ impl Default for demi_args_t {
             argc: 0,
             argv: std::ptr::null(),
             callback: None,
+            log_callback: None,
         }
     }
 }
@@ -60,7 +74,8 @@ mod test {
         const DEMIARGS_CALLBACK_SIZE: usize = 8;
 
         // The expected size of the `DemiArgs` structure.
-        const DEMIARGS_SIZE: usize = DEMIARGS_ARGC_SIZE + DEMIARGS_ARGV_SIZE + DEMIARGS_CALLBACK_SIZE;
+        const DEMIARGS_SIZE: usize =
+            DEMIARGS_ARGC_SIZE + DEMIARGS_ARGV_SIZE + DEMIARGS_CALLBACK_SIZE + DEMIARGS_CALLBACK_SIZE;
 
         // Check if the sizes match.
         assert_eq!(std::mem::size_of::<crate::runtime::types::demi_args_t>(), DEMIARGS_SIZE);

--- a/tests/c/sizes.c
+++ b/tests/c/sizes.c
@@ -65,7 +65,7 @@
 #define DEMI_ARGS_ARGC_SIZE 4
 #define DEMI_ARGS_ARGV_SIZE 8
 #define DEMI_ARGS_CALLBACK_SIZE 8
-#define DEMI_ARGS_SIZE (DEMI_ARGS_ARGC_SIZE + DEMI_ARGS_ARGV_SIZE + DEMI_ARGS_CALLBACK_SIZE)
+#define DEMI_ARGS_SIZE (DEMI_ARGS_ARGC_SIZE + DEMI_ARGS_ARGV_SIZE + DEMI_ARGS_CALLBACK_SIZE + DEMI_ARGS_CALLBACK_SIZE)
 
 /*====================================================================================================================*
  * Private Functions                                                                                                  *


### PR DESCRIPTION
This PR adds a callback function to `demi_args_t`. If specified by the caller, it will be invoked by flexi_logger for all logging calls, as oppose to printing to stdout.