### PR TITLE
[config] Bug Fix: respect env var for MSS value

### DIFF
--- a/linux.mk
+++ b/linux.mk
@@ -202,7 +202,6 @@ clean: clean-examples clean-tests clean-libs
 
 export CONFIG_PATH ?= $(HOME)/config.yaml
 export MTU ?= 1500
-export MSS ?= 1500
 export PEER ?= server
 export TEST ?= udp-push-pop
 export TEST_INTEGRATION ?= tcp-tests

--- a/src/rust/demikernel/config.rs
+++ b/src/rust/demikernel/config.rs
@@ -507,7 +507,7 @@ impl Config {
     }
 
     pub fn mss(&self) -> Result<usize, Fail> {
-        Self::get_int_option(self.get_inetstack_config()?, inetstack_config::MSS)
+        self.get_int_env_or_option(inetstack_config::MSS, Self::get_inetstack_config)
     }
 
     pub fn tcp_checksum_offload(&self) -> Result<bool, Fail> {

--- a/windows.mk
+++ b/windows.mk
@@ -248,10 +248,6 @@ CONFIG_PATH = $(USERPROFILE)/config.yaml
 MTU = 1500
 !endif
 
-!ifndef MSS
-MSS = 1500
-!endif
-
 !ifndef PEER
 PEER = server
 !endif


### PR DESCRIPTION
The MSS value should be configurable by setting an env var so that the parameter sweep tests can be performed correctly.