### PR TITLE
[catnip] Enhancement: remove unnecessary assert

### DIFF
--- a/src/rust/catnip/runtime/mod.rs
+++ b/src/rust/catnip/runtime/mod.rs
@@ -356,14 +356,11 @@ impl PhysicalLayer for SharedDPDKRuntime {
         let mut out = ArrayVec::new();
         let mut packets: [*mut rte_mbuf; RECEIVE_BATCH_SIZE] = unsafe { mem::zeroed() };
         let nb_rx = unsafe { rte_eth_rx_burst(self.port_id, 0, packets.as_mut_ptr(), RECEIVE_BATCH_SIZE as u16) };
-        assert!(nb_rx as usize <= RECEIVE_BATCH_SIZE);
 
-        {
-            for &packet in &packets[..nb_rx as usize] {
-                // Safety: `packet` is a valid pointer to a properly initialized `rte_mbuf` struct.
-                let buf: DemiBuffer = unsafe { DemiBuffer::from_mbuf(packet) };
-                out.push(buf);
-            }
+        for &packet in &packets[..nb_rx as usize] {
+            // Safety: `packet` is a valid pointer to a properly initialized `rte_mbuf` struct.
+            let buf: DemiBuffer = unsafe { DemiBuffer::from_mbuf(packet) };
+            out.push(buf);
         }
 
         Ok(out)


### PR DESCRIPTION
This assert ensures that the DPDK api is doing what is promises. This is not something that Demikernel should be confirming, it's the responsibility of the DPDK tests.