### PR TITLE
[ci] Bug Fix: correct checkout sequence to get latest code

### DIFF
--- a/tools/ci/task/linux.py
+++ b/tools/ci/task/linux.py
@@ -14,7 +14,7 @@ class BaseLinuxTask(BaseTask):
 
 class CheckoutOnLinux(BaseLinuxTask):
     def __init__(self, host: str, repository: str, branch: str):
-        cmd: str = f"cd {repository} && git pull origin && git checkout {branch}"
+        cmd: str = f"cd {repository} && git fetch origin && git checkout {branch} && git reset --hard {branch}"
         super().__init__(host, cmd)
 
 

--- a/tools/ci/task/windows.py
+++ b/tools/ci/task/windows.py
@@ -30,7 +30,7 @@ class BaseWindowsTask(BaseTask):
 class CheckoutOnWindows(BaseWindowsTask):
     def __init__(self, host: str, repository: str, branch: str):
         env_cmd = BaseWindowsTask._build_env_cmd()
-        cmd: str = f"cd {repository} ; {env_cmd} ; git pull origin ; git checkout {branch}"
+        cmd: str = f"cd {repository} ; {env_cmd} ; git fetch origin ; git checkout {branch}; git reset --hard {branch}"
         super().__init__(host, cmd)
 
 
@@ -54,5 +54,5 @@ class RunOnWindows(BaseWindowsTask):
 class CleanupOnWindows(BaseWindowsTask):
     def __init__(self, host: str, repository: str, is_sudo: bool, branch: str):
         env_cmd = BaseWindowsTask._build_env_cmd()
-        cmd: str = f"cd {repository} ; {env_cmd} ; nmake clean ; git checkout ; git clean -fdx"
+        cmd: str = f"cd {repository} ; {env_cmd} ; nmake clean ; git checkout {branch}; git clean -fdx"
         super().__init__(host, cmd)


### PR DESCRIPTION
The checkout sequence was incorrect because the pull was only applied to the current branch before switching to the target. This problem was clearly visible in case of reused branch names.

Also, the Windows cleanup did not correctly checkout the target branch name, so correct that.