### PR TITLE
githook: relax commit msg restrictions

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -9,7 +9,7 @@ if [ $(echo "$commit_msg_title" | wc -c) -gt $max_length ]; then
     exit 1
 fi
 
-if ! echo "$commit_msg" | grep -q -E 'Merge pull request|Merge branch|\[[[:alnum:]-]+\] (Workaround|Enhancement|Feature|Bug Fix): '; then
-	echo "Commit message does not match pattern: '[module-name] (Workaround|Enhancement|Feature|Bug Fix): Short Description"
+if ! echo "$commit_msg" | grep -q -E 'Merge pull request|Merge branch|.*: '; then
+	echo "Commit message does not match pattern: 'module-name: Short Description'"
     exit 1
 fi


### PR DESCRIPTION
While writing many commit messages, I realized that writing a (Workaround|Enhancement|Feature|Bug Fix) tag is unnecessary. We don't do any reporting on this, plus it's cumbersome to write. Better to add more context in the top commit msg instead. We should get rid of this restriction.