### PR TITLE
demikernel: improvements around string format!

### DIFF
--- a/src/catnap/linux/transport.rs
+++ b/src/catnap/linux/transport.rs
@@ -411,7 +411,7 @@ impl NetworkTransport for SharedCatnapTransport {
             Ok(addr) => match addr.as_socket_ipv4() {
                 Some(ipv4_addr) => Ok(ipv4_addr),
                 None => {
-                    let cause: String = format!("invalid IPv4 address");
+                    let cause: String = String::from("invalid IPv4 address");
                     error!("getpeername(): {}", cause);
                     Err(Fail::new(libc::EINVAL, &cause))
                 },

--- a/src/demikernel/bindings.rs
+++ b/src/demikernel/bindings.rs
@@ -750,8 +750,7 @@ pub extern "C" fn demi_getsockopt(
                     }
                 },
                 _ => {
-                    let cause: String = format!("Only SO_LINGER is supported right now");
-                    error!("demi_setsockopt(): {}", cause);
+                    error!("demi_setsockopt(): Only SO_LINGER is supported right now");
                     return libc::EINVAL;
                 },
             };

--- a/src/demikernel/config.rs
+++ b/src/demikernel/config.rs
@@ -177,7 +177,7 @@ impl Config {
         };
 
         if local_ipv4_addr.is_unspecified() || local_ipv4_addr.is_broadcast() {
-            let cause: String = format!("Invalid IPv4 address");
+            let cause: String = String::from("Invalid IPv4 address");
             error!("local_ipv4_addr(): {:?}", cause);
             return Err(Fail::new(libc::EINVAL, &cause));
         }
@@ -263,7 +263,7 @@ impl Config {
                 let link_addr: MacAddress = match k.as_str() {
                     Some(link_string) => MacAddress::parse_canonical_str(link_string)?,
                     None => {
-                        let cause: String = format!("Couldn't parse ARP table link_addr in config");
+                        let cause: String = String::from("Couldn't parse ARP table link_addr in config");
                         error!("arp_table(): {:?}", cause);
                         return Err(Fail::new(libc::EINVAL, &cause));
                     },

--- a/src/demikernel/libos/network/libos.rs
+++ b/src/demikernel/libos/network/libos.rs
@@ -300,7 +300,7 @@ impl<T: NetworkTransport> SharedNetworkLibOS<T> {
     pub fn push(&mut self, qd: QDesc, sga: &demi_sgarray_t) -> Result<QToken, Fail> {
         let buf: DemiBuffer = clone_sgarray(sga)?;
         if buf.len() == 0 {
-            let cause: String = format!("zero-length buffer");
+            let cause: String = String::from("zero-length buffer");
             warn!("push(): {}", cause);
             return Err(Fail::new(libc::EINVAL, &cause));
         };

--- a/src/demikernel/libos/network/queue.rs
+++ b/src/demikernel/libos/network/queue.rs
@@ -93,7 +93,7 @@ impl<T: NetworkTransport> SharedNetworkQueue<T> {
     pub fn set_socket_option(&mut self, option: SocketOption) -> Result<(), Fail> {
         // Ensure that option can be set, depending on the state of the socket.
         if let Err(_) = self.state_machine.ensure_not_closing() {
-            let cause: String = format!("cannot set socket-level options when socket is closing");
+            let cause: String = String::from("cannot set socket-level options when socket is closing");
             warn!("set_socket_option(): {}", cause);
             return Err(Fail::new(libc::EBUSY, &cause));
         }

--- a/src/inetstack/protocols/layer3/arp/peer.rs
+++ b/src/inetstack/protocols/layer3/arp/peer.rs
@@ -138,8 +138,7 @@ impl SharedArpPeer {
             let header: ArpHeader = match ArpHeader::parse_and_consume(buf) {
                 Ok(header) => header,
                 Err(e) => {
-                    let cause: String = format!("could not parse ARP header:");
-                    warn!("arp_cache::poll(): {} {:?}", &cause, e);
+                    warn!("arp_cache::poll(): could not parse ARP header: {:?}", e);
                     continue;
                 },
             };
@@ -172,9 +171,7 @@ impl SharedArpPeer {
             // from RFC 826: ?Am I the target protocol address?
             if header.get_destination_protocol_addr() != self.local_ipv4_addr {
                 if !merge_flag {
-                    // we didn't do something.
-                    let cause: String = format!("unrecognized IP address");
-                    warn!("arp_cache::poll(): {}", &cause);
+                    warn!("arp_cache::poll(): unrecognized IP address");
                 }
                 trace!(
                     "poll(): dropping arp packet (link_addr={:?}, ipv4_addr={:?})",

--- a/src/inetstack/protocols/layer3/icmpv4/peer.rs
+++ b/src/inetstack/protocols/layer3/icmpv4/peer.rs
@@ -245,7 +245,7 @@ impl SharedIcmpv4Peer {
                 Ok(self.runtime.get_now() - t0)
             },
             Err(_) => {
-                let message: String = format!("timer expired");
+                let message: String = String::from("timer expired");
                 self.inflight.remove(&(id, seq_num));
                 error!("ping(): {}", message);
                 Err(Fail::new(libc::ETIMEDOUT, &message))

--- a/src/inetstack/protocols/layer3/mod.rs
+++ b/src/inetstack/protocols/layer3/mod.rs
@@ -81,8 +81,7 @@ impl SharedLayer3Endpoint {
                     let header = match Ipv4Header::parse_and_strip(&mut packet) {
                         Ok(header) => header,
                         Err(e) => {
-                            let cause: String = format!("Invalid destination address: {:?}", e);
-                            warn!("dropping packet: {}", cause);
+                            warn!("dropping packet: Invalid destination address: {:?}", e);
                             continue;
                         },
                     };
@@ -90,8 +89,7 @@ impl SharedLayer3Endpoint {
 
                     // Check that the destination matches our IP address; otherwise, discard.
                     if header.get_dest_addr() != self.local_ipv4_addr && !header.get_dest_addr().is_broadcast() {
-                        let cause: String = format!("Invalid destination address");
-                        warn!("dropping packet: {}", cause);
+                        warn!("dropping packet: Invalid destination address");
                         continue;
                     }
 
@@ -100,8 +98,10 @@ impl SharedLayer3Endpoint {
                         || header.get_src_addr().is_multicast()
                         || header.get_src_addr().is_unspecified()
                     {
-                        let cause: String = format!("invalid remote address (remote={})", header.get_src_addr());
-                        warn!("dropping packet: {}", &cause);
+                        warn!(
+                            "dropping packet: Invalid remote address (remote={})",
+                            header.get_src_addr()
+                        );
                         continue;
                     }
 

--- a/src/inetstack/protocols/layer4/mod.rs
+++ b/src/inetstack/protocols/layer4/mod.rs
@@ -126,7 +126,7 @@ impl Peer {
         match sd {
             Socket::Tcp(socket) => self.tcp.set_socket_option(socket, option),
             Socket::Udp(_) => {
-                let cause: String = format!("Socket options are not supported on UDP sockets");
+                let cause: String = String::from("Socket options are not supported on UDP sockets");
                 error!("get_socket_option(): {}", cause);
                 Err(Fail::new(libc::ENOTSUP, &cause))
             },
@@ -139,7 +139,7 @@ impl Peer {
         match sd {
             Socket::Tcp(socket) => self.tcp.get_socket_option(socket, option),
             Socket::Udp(_) => {
-                let cause: String = format!("Socket options are not supported on UDP sockets");
+                let cause: String = String::from("Socket options are not supported on UDP sockets");
                 error!("get_socket_option(): {}", cause);
                 Err(Fail::new(libc::ENOTSUP, &cause))
             },
@@ -150,7 +150,7 @@ impl Peer {
         match sd {
             Socket::Tcp(socket) => self.tcp.getpeername(socket),
             Socket::Udp(_) => {
-                let cause: String = format!("Getting peer address is not supported on UDP sockets");
+                let cause: String = String::from("Getting peer address is not supported on UDP sockets");
                 error!("getpeername(): {}", cause);
                 Err(Fail::new(libc::ENOTSUP, &cause))
             },
@@ -219,7 +219,7 @@ impl Peer {
         match sd {
             Socket::Tcp(socket) => self.tcp.listen(socket, backlog),
             _ => {
-                let cause: String = format!("opperation not supported");
+                let cause: String = String::from("opperation not supported");
                 error!("listen(): {}", cause);
                 Err(Fail::new(libc::ENOTSUP, &cause))
             },
@@ -250,7 +250,7 @@ impl Peer {
             },
             // This queue descriptor does not concern a TCP socket.
             _ => {
-                let cause: String = format!("opperation not supported");
+                let cause: String = String::from("opperation not supported");
                 error!("accept(): {}", cause);
                 Err(Fail::new(libc::ENOTSUP, &cause))
             },

--- a/src/inetstack/protocols/layer4/tcp/active_open.rs
+++ b/src/inetstack/protocols/layer4/tcp/active_open.rs
@@ -105,14 +105,14 @@ impl SharedActiveOpenSocket {
 
         // Check if our peer is refusing our connection request.
         if header.rst {
-            let cause: String = format!("connection refused");
+            let cause: String = String::from("connection refused");
             error!("process_ack(): {}", cause);
             return Err(Fail::new(libc::ECONNREFUSED, &cause));
         }
 
         // Bail if we didn't receive a SYN packet.
         if !header.syn {
-            let cause: String = format!("is not a syn packet");
+            let cause: String = String::from("is not a syn packet");
             error!("process_ack(): {}", cause);
             return Err(Fail::new(libc::EAGAIN, &cause));
         }
@@ -280,7 +280,7 @@ impl SharedActiveOpenSocket {
             }
         }
 
-        let cause: String = format!("connection handshake timed out");
+        let cause: String = String::from("connection handshake timed out");
         error!("connect(): {}", cause);
         Err(Fail::new(libc::ECONNREFUSED, &cause))
     }

--- a/src/inetstack/protocols/layer4/tcp/established/mod.rs
+++ b/src/inetstack/protocols/layer4/tcp/established/mod.rs
@@ -195,7 +195,7 @@ impl SharedEstablishedSocket {
             State::Established => self.local_close().await,
             State::CloseWait => self.remote_already_closed().await,
             _ => {
-                let cause: String = format!("socket is already closing");
+                let cause: String = String::from("socket is already closing");
                 error!("close(): {}", cause);
                 Err(Fail::new(libc::EBADF, &cause))
             },

--- a/src/inetstack/protocols/layer4/tcp/established/receiver.rs
+++ b/src/inetstack/protocols/layer4/tcp/established/receiver.rs
@@ -398,7 +398,7 @@ impl Receiver {
                         trace!("check_segment_in_window(): send ack on duplicate segment");
                         Sender::send_ack(cb, layer3_endpoint);
                     }
-                    let cause: String = format!("duplicate packet");
+                    let cause: String = String::from("duplicate packet");
                     error!("check_segment_in_window(): {}", cause);
                     return Err(Fail::new(libc::EBADMSG, &cause));
                 } else {
@@ -425,7 +425,7 @@ impl Receiver {
                         trace!("check_segment_in_window(): send ack on out-of-window segment");
                         Sender::send_ack(cb, layer3_endpoint);
                     }
-                    let cause: String = format!("packet outside of receive window");
+                    let cause: String = String::from("packet outside of receive window");
                     error!("check_segment_in_window(): {}", cause);
                     return Err(Fail::new(libc::EBADMSG, &cause));
                 }
@@ -496,7 +496,7 @@ impl Receiver {
             // TODO: RFC 5961 "Blind Reset Attack Using the SYN Bit" prevention would have us always ACK and drop here.
 
             // Receiving a SYN here is an error.
-            let cause: String = format!("Received in-window SYN on established connection.");
+            let cause: String = String::from("Received in-window SYN on established connection.");
             error!("{}", cause);
             // TODO: Send Reset.
             // TODO: Return all outstanding Receive and Send requests with "reset" responses.
@@ -512,7 +512,7 @@ impl Receiver {
     fn check_and_process_ack(cb: &mut ControlBlock, header: &TcpHeader, now: Instant) -> Result<(), Fail> {
         if !header.ack {
             // All segments on established connections should be ACKs.  Drop this segment.
-            let cause: String = format!("Received non-ACK segment on established connection");
+            let cause: String = String::from("Received non-ACK segment on established connection");
             error!("{}", cause);
             return Err(Fail::new(libc::EBADMSG, &cause));
         }

--- a/src/inetstack/protocols/layer4/tcp/socket.rs
+++ b/src/inetstack/protocols/layer4/tcp/socket.rs
@@ -126,7 +126,7 @@ impl SharedTcpSocket {
                 return Ok(remote_endpoint);
             },
             _ => {
-                let cause: String = format!("socket is not in established state");
+                let cause: String = String::from("socket is not in established state");
                 error!("getpeername(): {}", &cause);
                 Err(Fail::new(libc::ENOTCONN, &cause))
             },
@@ -234,7 +234,7 @@ impl SharedTcpSocket {
             },
             // Closing a closing socket.
             SocketState::Closing(_) => {
-                let cause: String = format!("cannot close a socket that is closing");
+                let cause: String = String::from("cannot close a socket that is closing");
                 error!("do_close(): {}", &cause);
                 Err(Fail::new(libc::ENOTSUP, &cause))
             },
@@ -262,7 +262,7 @@ impl SharedTcpSocket {
             },
             // Closing a closing socket.
             SocketState::Closing(_) => {
-                let cause: String = format!("cannot close a socket that is closing");
+                let cause: String = String::from("cannot close a socket that is closing");
                 error!("do_close(): {}", &cause);
                 Err(Fail::new(libc::ENOTSUP, &cause))
             },

--- a/src/inetstack/protocols/layer4/udp/peer.rs
+++ b/src/inetstack/protocols/layer4/udp/peer.rs
@@ -70,7 +70,7 @@ impl SharedUdpPeer {
     /// Binds a UDP socket to a local endpoint address.
     pub fn bind(&mut self, socket: &mut SharedUdpSocket, addr: SocketAddrV4) -> Result<(), Fail> {
         if let Some(_) = socket.local() {
-            let cause: String = format!("cannot bind to already bound socket");
+            let cause: String = String::from("cannot bind to already bound socket");
             error!("bind(): {}", cause);
             return Err(Fail::new(libc::EADDRINUSE, &cause));
         }
@@ -103,7 +103,7 @@ impl SharedUdpPeer {
         // TODO: Allocate ephemeral port if not bound.
         // FIXME: https://github.com/microsoft/demikernel/issues/973
         if !socket.is_bound() {
-            let cause: String = format!("queue is not bound");
+            let cause: String = String::from("queue is not bound");
             error!("pushto(): {}", &cause);
             return Err(Fail::new(libc::ENOTSUP, &cause));
         }
@@ -131,8 +131,7 @@ impl SharedUdpPeer {
             match UdpHeader::parse_and_strip(&src_ipv4_addr, &self.local_ipv4_addr, &mut buf, self.checksum_offload) {
                 Ok(header) => header,
                 Err(e) => {
-                    let cause: String = format!("dropping packet: unable to parse UDP header");
-                    warn!("{}: {:?}", cause, e);
+                    warn!("dropping packet: unable to parse UDP header: {:?}", e);
                     return;
                 },
             };
@@ -153,8 +152,7 @@ impl SharedUdpPeer {
                         // port. However, we simply drop the datagram as this could be a port-scan attack, and not
                         // sending an ICMP message is a valid action. See https://www.rfc-editor.org/rfc/rfc792 for more
                         // details.
-                        let cause: String = format!("dropping packet: port not bound");
-                        warn!("{}: {:?}", cause, local);
+                        warn!("dropping packet: port not bound: {:?}", local);
                         return;
                     },
                 }

--- a/src/inetstack/protocols/layer4/udp/socket.rs
+++ b/src/inetstack/protocols/layer4/udp/socket.rs
@@ -74,7 +74,7 @@ impl SharedUdpSocket {
         let remote: SocketAddrV4 = if let Some(remote) = remote {
             unwrap_socketaddr(remote)?
         } else {
-            let cause: String = format!("udp socket requires a remote address");
+            let cause: String = String::from("udp socket requires a remote address");
             error!("pushto(): {}", &cause);
             return Err(Fail::new(libc::ENOTSUP, &cause));
         };
@@ -82,7 +82,7 @@ impl SharedUdpSocket {
         let port: u16 = if let Some(addr) = self.local() {
             addr.port()
         } else {
-            let cause: String = format!("queue is not bound");
+            let cause: String = String::from("queue is not bound");
             error!("pushto(): {}", &cause);
             return Err(Fail::new(libc::ENOTSUP, &cause));
         };

--- a/src/runtime/memory/demibuffer.rs
+++ b/src/runtime/memory/demibuffer.rs
@@ -760,7 +760,7 @@ impl DemiBuffer {
     fn split(&mut self, split_front: bool, offset: usize) -> Result<Self, Fail> {
         // Check if this is a multi-segment buffer.
         if self.is_multi_segment() {
-            let cause: String = format!("cannot split a multi-segment buffer");
+            let cause: String = String::from("cannot split a multi-segment buffer");
             error!("split_front(): {}", &cause);
             return Err(Fail::new(libc::EINVAL, &cause));
         }

--- a/src/runtime/memory/mod.rs
+++ b/src/runtime/memory/mod.rs
@@ -59,7 +59,7 @@ pub fn sgaalloc<M: DemiMemoryAllocator>(size: usize, mem_alloc: &M) -> Result<de
 
     // We can't allocate a zero-sized buffer.
     if size == 0 {
-        let cause: String = format!("cannot allocate a zero-sized buffer");
+        let cause: String = String::from("cannot allocate a zero-sized buffer");
         error!("sgaalloc(): {}", cause);
         return Err(Fail::new(libc::EINVAL, &cause));
     }

--- a/src/runtime/network/ring/state.rs
+++ b/src/runtime/network/ring/state.rs
@@ -59,7 +59,7 @@ impl RingStateMachine {
     pub fn prepare(&mut self, op: RingControlOperation) -> Result<(), Fail> {
         let next: RingState = self.get_next_state(op)?;
         if next != RingState::Closing && self.next.is_some() {
-            return Err(fail(op, &(format!("ring is busy")), libc::EBUSY));
+            return Err(fail(op, &format!("ring is busy"), libc::EBUSY));
         }
         self.next = Some(next);
         Ok(())
@@ -89,7 +89,7 @@ impl RingStateMachine {
     fn from_opened(&self, op: RingControlOperation) -> Result<RingState, Fail> {
         match op {
             RingControlOperation::Close => Ok(RingState::Closing),
-            RingControlOperation::Closed => Err(fail(op, &(format!("ring is closed")), libc::EBADF)),
+            RingControlOperation::Closed => Err(fail(op, &format!("ring is closed"), libc::EBADF)),
         }
     }
 
@@ -104,15 +104,15 @@ impl RingStateMachine {
     /// Attempts to transition from the [RingState::Closed].
     fn from_closed(&self, op: RingControlOperation) -> Result<RingState, Fail> {
         match op {
-            RingControlOperation::Close => Err(fail(op, &(format!("ring is closed")), libc::EBADF)),
-            RingControlOperation::Closed => Err(fail(op, &(format!("ring is closed")), libc::EBADF)),
+            RingControlOperation::Close => Err(fail(op, &format!("ring is closed"), libc::EBADF)),
+            RingControlOperation::Closed => Err(fail(op, &format!("ring is closed"), libc::EBADF)),
         }
     }
 
     /// Ensures that the target [RingState] is not [RingState::Closing].
     fn ensure_not_closing(&self) -> Result<(), Fail> {
         if self.current == RingState::Closing {
-            let cause: String = format!("ring is closing");
+            let cause: String = String::from("ring is closing");
             error!("ensure_not_closing(): {}", cause);
             return Err(Fail::new(libc::EBADF, &cause));
         }
@@ -122,7 +122,7 @@ impl RingStateMachine {
     /// Ensures that the target [RingState] is not [RingState::Closed].
     fn ensure_not_closed(&self) -> Result<(), Fail> {
         if self.current == RingState::Closed {
-            let cause: String = format!("ring is closed");
+            let cause: String = String::from("ring is closed");
             error!("ensure_not_clossed(): {}", cause);
             return Err(Fail::new(libc::EBADF, &cause));
         }

--- a/src/runtime/network/socket/state.rs
+++ b/src/runtime/network/socket/state.rs
@@ -167,7 +167,7 @@ impl SocketStateMachine {
         // Already prepared and not committed or aborted yet.
         if let Some(pending) = self.next {
             if next != SocketState::Closing && pending != next {
-                return Err(fail(op, &(format!("socket is busy")), libc::EBUSY));
+                return Err(fail(op, &format!("socket is busy"), libc::EBUSY));
             }
         }
 
@@ -211,19 +211,19 @@ impl SocketStateMachine {
             // Should this be possible without going through the Connecting state?
             SocketOp::Established => Ok(SocketState::ActiveEstablished),
             SocketOp::Close => Ok(SocketState::Closing),
-            SocketOp::Closed => Err(fail(op, &(format!("socket is busy")), libc::EBUSY)),
+            SocketOp::Closed => Err(fail(op, &format!("socket is busy"), libc::EBUSY)),
         }
     }
 
     /// Attempts to transition from bound state.
     fn bound_state(&self, op: SocketOp) -> Result<SocketState, Fail> {
         match op {
-            SocketOp::Bind => Err(fail(op, &(format!("socket is already bound")), libc::EINVAL)),
+            SocketOp::Bind => Err(fail(op, &format!("socket is already bound"), libc::EINVAL)),
             SocketOp::Listen => Ok(SocketState::PassiveListening),
             SocketOp::Connect => Ok(SocketState::ActiveConnecting),
             SocketOp::Established => Ok(SocketState::ActiveConnecting),
             SocketOp::Close => Ok(SocketState::Closing),
-            SocketOp::Closed => Err(fail(op, &(format!("socket is busy")), libc::EBUSY)),
+            SocketOp::Closed => Err(fail(op, &format!("socket is busy"), libc::EBUSY)),
         }
     }
 
@@ -231,23 +231,23 @@ impl SocketStateMachine {
     fn listening_state(&self, op: SocketOp) -> Result<SocketState, Fail> {
         match op {
             SocketOp::Bind | SocketOp::Established => {
-                Err(fail(op, &(format!("socket is already listening")), libc::EINVAL))
+                Err(fail(op, &format!("socket is already listening"), libc::EINVAL))
             },
-            SocketOp::Listen => Err(fail(op, &(format!("socket is already listening")), libc::EADDRINUSE)),
-            SocketOp::Connect => Err(fail(op, &(format!("socket is already listening")), libc::EOPNOTSUPP)),
+            SocketOp::Listen => Err(fail(op, &format!("socket is already listening"), libc::EADDRINUSE)),
+            SocketOp::Connect => Err(fail(op, &format!("socket is already listening"), libc::EOPNOTSUPP)),
             SocketOp::Close => Ok(SocketState::Closing),
-            SocketOp::Closed => Err(fail(op, &(format!("socket is busy")), libc::EBUSY)),
+            SocketOp::Closed => Err(fail(op, &format!("socket is busy"), libc::EBUSY)),
         }
     }
 
     /// Attempts to transition from connecting state.
     fn connecting_state(&self, op: SocketOp) -> Result<SocketState, Fail> {
         match op {
-            SocketOp::Bind => Err(fail(op, &(format!("socket is already connecting")), libc::EINVAL)),
-            SocketOp::Listen => Err(fail(op, &(format!("socket is already connecting")), libc::EADDRINUSE)),
+            SocketOp::Bind => Err(fail(op, &format!("socket is already connecting"), libc::EINVAL)),
+            SocketOp::Listen => Err(fail(op, &format!("socket is already connecting"), libc::EADDRINUSE)),
             SocketOp::Connect => Err(fail(
                 op,
-                &(format!("socket already is already connecting ")),
+                &format!("socket already is already connecting "),
                 libc::EINPROGRESS,
             )),
             SocketOp::Established => Ok(SocketState::ActiveEstablished),
@@ -263,7 +263,7 @@ impl SocketStateMachine {
     fn established_state(&self, op: SocketOp) -> Result<SocketState, Fail> {
         match op {
             SocketOp::Bind | SocketOp::Listen | SocketOp::Connect | SocketOp::Established => {
-                Err(fail(op, &(format!("socket is already connected")), libc::EISCONN))
+                Err(fail(op, &format!("socket is already connected"), libc::EISCONN))
             },
             SocketOp::Close => Ok(SocketState::Closing),
             SocketOp::Closed => Ok(SocketState::Closed),
@@ -275,7 +275,7 @@ impl SocketStateMachine {
         match op {
             SocketOp::Close => Ok(SocketState::Closing),
             SocketOp::Closed => Ok(SocketState::Closed),
-            _ => Err(fail(op, &(format!("socket is closing")), libc::EBADF)),
+            _ => Err(fail(op, &format!("socket is closing"), libc::EBADF)),
         }
     }
 
@@ -284,13 +284,13 @@ impl SocketStateMachine {
         if op == SocketOp::Closed || op == SocketOp::Close {
             Ok(SocketState::Closed)
         } else {
-            Err(fail(op, &(format!("socket is closed")), libc::EBADF))
+            Err(fail(op, &format!("socket is closed"), libc::EBADF))
         }
     }
 
     fn ensure_bound(&self) -> Result<(), Fail> {
         if self.current.get() != SocketState::Bound {
-            let cause: String = format!("socket is not bound");
+            let cause: String = String::from("socket is not bound");
             error!("ensure_bound(): {}", cause);
             return Err(Fail::new(libc::EDESTADDRREQ, &cause));
         }
@@ -299,7 +299,7 @@ impl SocketStateMachine {
 
     fn ensure_listening(&self) -> Result<(), Fail> {
         if self.current.get() != SocketState::PassiveListening {
-            let cause: String = format!("socket is not listening");
+            let cause: String = String::from("socket is not listening");
             error!("ensure_listening(): {}", cause);
             return Err(Fail::new(libc::EINVAL, &cause));
         }
@@ -308,7 +308,7 @@ impl SocketStateMachine {
 
     fn ensure_established(&self) -> Result<(), Fail> {
         if self.current.get() != SocketState::ActiveEstablished {
-            let cause: String = format!("socket is not connected");
+            let cause: String = String::from("socket is not connected");
             error!("ensure_connected(): {}", cause);
             return Err(Fail::new(libc::ENOTCONN, &cause));
         }
@@ -317,7 +317,7 @@ impl SocketStateMachine {
 
     pub fn ensure_not_closing(&self) -> Result<(), Fail> {
         if self.current.get() == SocketState::Closing {
-            let cause: String = format!("socket is closing");
+            let cause: String = String::from("socket is closing");
             error!("ensure_not_closing(): {}", cause);
             return Err(Fail::new(libc::EBADF, &cause));
         }
@@ -326,7 +326,7 @@ impl SocketStateMachine {
 
     fn ensure_not_closed(&self) -> Result<(), Fail> {
         if self.current.get() == SocketState::Closed {
-            let cause: String = format!("socket is closed");
+            let cause: String = String::from("socket is closed");
             error!("ensure_not_closed(): {}", cause);
             return Err(Fail::new(libc::EBADF, &cause));
         }

--- a/src/runtime/queue/mod.rs
+++ b/src/runtime/queue/mod.rs
@@ -148,7 +148,7 @@ pub fn downcast_queue_ptr<'a, T: IoQueue>(boxed_queue_ptr: &'a Box<dyn IoQueue>)
     match void_ptr.downcast_ref::<T>() {
         Some(ptr) => Ok(ptr),
         None => {
-            let cause: String = format!("invalid queue type");
+            let cause: String = String::from("invalid queue type");
             error!("downcast_queue_ptr(): {}", &cause);
             Err(Fail::new(libc::EINVAL, &cause))
         },
@@ -164,7 +164,7 @@ pub fn downcast_mut_ptr<'a, T: IoQueue>(boxed_queue_ptr: &'a mut Box<dyn IoQueue
     match void_ptr.downcast_mut::<T>() {
         Some(ptr) => Ok(ptr),
         None => {
-            let cause: String = format!("invalid queue type");
+            let cause: String = String::from("invalid queue type");
             error!("downcast_mut_ptr(): {}", &cause);
             Err(Fail::new(libc::EINVAL, &cause))
         },
@@ -177,7 +177,7 @@ pub fn downcast_queue<T: IoQueue>(boxed_queue: Box<dyn IoQueue>) -> Result<T, Fa
     match boxed_queue.as_any().downcast::<T>() {
         Ok(queue) => Ok(*queue),
         Err(_) => {
-            let cause: String = format!("invalid queue type");
+            let cause: String = String::from("invalid queue type");
             error!("downcast_queue(): {}", &cause);
             Err(Fail::new(libc::EINVAL, &cause))
         },


### PR DESCRIPTION
There are 3 types of changes

- Replace format! with String::from because it's more idiomatic and slightly better performing for simple cases.
- Remove unnecessary parentheses around format.
- Remove format! completely where it was just used to create a single use variable that was then used in warn etc.