### PR TITLE
demikernel: omit return whenever implicit expr return is possible

### DIFF
--- a/src/collections/hashttlcache.rs
+++ b/src/collections/hashttlcache.rs
@@ -126,7 +126,7 @@ where
     }
 
     pub fn get(&self, key: &K) -> Option<&V> {
-        return self.map.get(key).map(|r| &r.value);
+        self.map.get(key).map(|r| &r.value)
     }
 
     #[cfg(test)]

--- a/src/demikernel/bindings.rs
+++ b/src/demikernel/bindings.rs
@@ -758,7 +758,7 @@ pub extern "C" fn demi_getsockopt(
         },
         Err(e) => {
             trace!("demi_getsockopt(): {:?}", e);
-            return e.errno;
+            e.errno
         },
     }
 }
@@ -809,11 +809,11 @@ pub extern "C" fn demi_getpeername(qd: c_int, addr: *mut SockAddr, addrlen: *mut
                 );
             }
 
-            return 0;
+            0
         },
         Err(e) => {
             trace!("demi_getpeername() failed: {:?}", e);
-            return e.errno;
+            e.errno
         },
     }
 }
@@ -865,7 +865,7 @@ fn sockaddr_to_socketaddr(saddr: *const sockaddr, size: Socklen) -> Result<Socke
 
     match saddr.as_socket() {
         Some(saddr) => Ok(saddr),
-        None => return Err(Fail::new(libc::ENOTSUP, "communication domain not supported")),
+        None => Err(Fail::new(libc::ENOTSUP, "communication domain not supported")),
     }
 }
 

--- a/src/inetstack/protocols/layer4/tcp/established/receiver.rs
+++ b/src/inetstack/protocols/layer4/tcp/established/receiver.rs
@@ -484,7 +484,7 @@ impl Receiver {
             },
         }
         cb.state = State::Closed;
-        return Err(Fail::new(libc::ECONNRESET, "remote reset connection"));
+        Err(Fail::new(libc::ECONNRESET, "remote reset connection"))
     }
 
     // Check the SYN bit.

--- a/src/inetstack/protocols/layer4/tcp/socket.rs
+++ b/src/inetstack/protocols/layer4/tcp/socket.rs
@@ -123,7 +123,7 @@ impl SharedTcpSocket {
         match self.state {
             SocketState::Established(ref mut socket) => {
                 let (_, remote_endpoint): (SocketAddrV4, SocketAddrV4) = socket.endpoints();
-                return Ok(remote_endpoint);
+                Ok(remote_endpoint)
             },
             _ => {
                 let cause: String = String::from("socket is not in established state");

--- a/src/runtime/condition_variable.rs
+++ b/src/runtime/condition_variable.rs
@@ -149,7 +149,7 @@ impl Future for YieldPoint {
             YieldState::Yielded if num_ready > 0 => {
                 self_.cond_var.num_ready -= 1;
                 self_.state = YieldState::Running;
-                return Poll::Ready(());
+                Poll::Ready(())
             },
             _ => Poll::Pending,
         }


### PR DESCRIPTION
Implicit return is more idiomatic and we should reserve `return` only for early returns.