### PR TITLE
inetstack: layer4: tcp: sender: remove dup check

### DIFF
--- a/src/inetstack/protocols/layer4/tcp/established/sender.rs
+++ b/src/inetstack/protocols/layer4/tcp/established/sender.rs
@@ -458,12 +458,6 @@ impl Sender {
             );
         }
 
-        if cb.sender.unacked_queue.len() > 0 {
-            trace!(
-                "send_segment(): unacked_queue.len() = {:?}",
-                cb.sender.unacked_queue.len()
-            );
-        }
         cb.sender.unacked_queue.push(unacked_segment);
 
         // Set the retransmit timer.


### PR DESCRIPTION
This check is duplicate, and seems like an artifact of prior merge issue.