### PR TITLE
demikernel: use is_empty() instead of len() comparisons to 0

### DIFF
--- a/src/catnap/linux/active_socket.rs
+++ b/src/catnap/linux/active_socket.rs
@@ -117,7 +117,7 @@ impl ActiveSocketData {
                     self.recv_queue.push(Err(e));
                 } else {
                     trace!("data popped ({:?} bytes)", nbytes);
-                    if buf.len() == 0 {
+                    if buf.is_empty() {
                         self.closed = true;
                     }
                     self.recv_queue.push(Ok((socketaddr.as_socket(), buf)));

--- a/src/demikernel/libos/network/libos.rs
+++ b/src/demikernel/libos/network/libos.rs
@@ -299,7 +299,7 @@ impl<T: NetworkTransport> SharedNetworkLibOS<T> {
     /// begins.
     pub fn push(&mut self, qd: QDesc, sga: &demi_sgarray_t) -> Result<QToken, Fail> {
         let buf: DemiBuffer = clone_sgarray(sga)?;
-        if buf.len() == 0 {
+        if buf.is_empty() {
             let cause: String = String::from("zero-length buffer");
             warn!("push(): {}", cause);
             return Err(Fail::new(libc::EINVAL, &cause));
@@ -344,7 +344,7 @@ impl<T: NetworkTransport> SharedNetworkLibOS<T> {
         trace!("pushto() qd={:?}", qd);
 
         let buf: DemiBuffer = clone_sgarray(sga)?;
-        if buf.len() == 0 {
+        if buf.is_empty() {
             return Err(Fail::new(libc::EINVAL, "zero-length buffer"));
         }
 

--- a/src/inetstack/protocols/layer4/tcp/established/receiver.rs
+++ b/src/inetstack/protocols/layer4/tcp/established/receiver.rs
@@ -187,7 +187,7 @@ impl Receiver {
         }
 
         // Store whether the packet has data here because processing it will consume the DemiBuffer.
-        let has_data: bool = data.len() > 0;
+        let has_data: bool = !data.is_empty();
         if has_data {
             Self::process_data(cb, layer3_endpoint, data, seg_start, seg_end, seg_len)?;
         }

--- a/src/inetstack/protocols/layer4/tcp/established/sender.rs
+++ b/src/inetstack/protocols/layer4/tcp/established/sender.rs
@@ -260,7 +260,7 @@ impl Sender {
 
         // Place the buffer in the unsent queue.
         if let Some(buf) = buf.take() {
-            if cb.sender.unacked_queue.len() > 0 {
+            if !cb.sender.unacked_queue.is_empty() {
                 trace!("push(): total unacked segments={:?}", cb.sender.unacked_queue.len());
             }
             if !buf.is_empty() {
@@ -341,7 +341,7 @@ impl Sender {
                 // We have some window, try to send some or all of the segment.
                 let _: usize = Self::send_segment(cb, layer3_endpoint, now, &mut buffer);
                 // If the buffer is now empty, then we sent all of it.
-                if buffer.len() == 0 {
+                if buffer.is_empty() {
                     return Ok(());
                 }
                 // Otherwise, wait until something limiting the window changes and then try again to finish sending
@@ -451,7 +451,7 @@ impl Sender {
             initial_tx: Some(now),
         };
 
-        if cb.sender.unacked_queue.len() > 0 {
+        if !cb.sender.unacked_queue.is_empty() {
             trace!(
                 "send_segment(): unacked_queue.len() = {:?}",
                 cb.sender.unacked_queue.len()

--- a/src/runtime/memory/memory_pool.rs
+++ b/src/runtime/memory/memory_pool.rs
@@ -244,7 +244,7 @@ impl BufferCursor {
 
 impl<'a> PackingIterator<'a> {
     pub fn new(buffer: &'a mut [MaybeUninit<u8>], page_size: NonZeroUsize, layout: Layout) -> Result<Self, Fail> {
-        if buffer.len() == 0 {
+        if buffer.is_empty() {
             return Err(Fail::new(libc::EINVAL, "memory buffer too short"));
         }
 


### PR DESCRIPTION
Some structures can answer .is_empty() much faster than calculating their length. So it is good to get into the habit of using .is_empty(), and having it is cheap. Besides, it makes the intent clearer than a manual comparison in some contexts.