### PR TITLE
demikernel: remove casts to the same type

### DIFF
--- a/src/catnap/linux/active_socket.rs
+++ b/src/catnap/linux/active_socket.rs
@@ -73,7 +73,7 @@ impl ActiveSocketData {
                 Ok(nbytes) => {
                     trace!("data pushed ({:?}/{:?} bytes)", nbytes, buf.len());
                     expect_ok!(
-                        buf.adjust(nbytes as usize),
+                        buf.adjust(nbytes),
                         "OS should not have sent more bytes than in the buffer"
                     );
                     if buf.is_empty() {
@@ -113,7 +113,7 @@ impl ActiveSocketData {
         {
             // Operation completed.
             Ok((nbytes, socketaddr)) => {
-                if let Err(e) = buf.trim(buf.len() - nbytes as usize) {
+                if let Err(e) = buf.trim(buf.len() - nbytes) {
                     self.recv_queue.push(Err(e));
                 } else {
                     trace!("data popped ({:?} bytes)", nbytes);

--- a/src/collections/pin_slab.rs
+++ b/src/collections/pin_slab.rs
@@ -290,8 +290,7 @@ fn calculate_key(key: usize) -> Option<(usize, usize, usize)> {
         return None;
     }
 
-    let slot: usize =
-        ((mem::size_of::<usize>() * 8) as usize - key.leading_zeros() as usize).saturating_sub(FIRST_SLOT_MASK);
+    let slot: usize = ((mem::size_of::<usize>() * 8) - key.leading_zeros() as usize).saturating_sub(FIRST_SLOT_MASK);
 
     let (start, end): (usize, usize) = if key < FIRST_SLOT_SIZE {
         (0, FIRST_SLOT_SIZE)

--- a/src/inetstack/protocols/layer3/icmpv4/header.rs
+++ b/src/inetstack/protocols/layer3/icmpv4/header.rs
@@ -77,7 +77,7 @@ impl Icmpv4Header {
         buf[2] = 0;
         buf[3] = 0;
         buf[4..8].copy_from_slice(&rest_of_header[..]);
-        let (hdr_buf, payload): (&[u8], &[u8]) = buf[..].split_at(ICMPV4_HEADER_SIZE as usize);
+        let (hdr_buf, payload): (&[u8], &[u8]) = buf[..].split_at(ICMPV4_HEADER_SIZE);
         let checksum: u16 = Self::compute_checksum(hdr_buf, payload);
         buf[2..4].copy_from_slice(&checksum.to_be_bytes());
     }

--- a/src/inetstack/protocols/layer3/icmpv4/peer.rs
+++ b/src/inetstack/protocols/layer3/icmpv4/peer.rs
@@ -191,7 +191,7 @@ impl SharedIcmpv4Peer {
 
         let t0: Instant = self.runtime.get_now();
         let pkt: DemiBuffer = DemiBuffer::new_with_headroom(
-            ICMPV4_ECHO_REQUEST_MESSAGE_SIZE as u16,
+            ICMPV4_ECHO_REQUEST_MESSAGE_SIZE,
             (ICMPV4_HEADER_SIZE + IPV4_HEADER_MIN_SIZE as usize + ETHERNET2_HEADER_SIZE) as u16,
         );
 

--- a/src/inetstack/protocols/layer3/ipv4/header.rs
+++ b/src/inetstack/protocols/layer3/ipv4/header.rs
@@ -91,7 +91,7 @@ impl Ipv4Header {
             ihl: IPV4_IHL_NO_OPTIONS,
             dscp: 0,
             ecn: 0,
-            total_length: IPV4_HEADER_MIN_SIZE as u16,
+            total_length: IPV4_HEADER_MIN_SIZE,
             identification: 0,
             flags: IPV4_CTRL_FLAG_DF,
             fragment_offset: 0,
@@ -122,7 +122,7 @@ impl Ipv4Header {
         // Internet header length.
         let ihl: u8 = buf[0] & 0xF;
         let hdr_size: u16 = (ihl as u16) << 2;
-        if hdr_size < IPV4_HEADER_MIN_SIZE as u16 {
+        if hdr_size < IPV4_HEADER_MIN_SIZE {
             return Err(Fail::new(EBADMSG, "ipv4 IHL is too small"));
         }
         if buf.len() < hdr_size as usize {

--- a/src/inetstack/protocols/layer4/tcp/active_open.rs
+++ b/src/inetstack/protocols/layer4/tcp/active_open.rs
@@ -166,7 +166,7 @@ impl SharedActiveOpenSocket {
                 } else {
                     remote_window_scale_bits
                 };
-                (self.tcp_config.get_window_scale() as u8, remote)
+                (self.tcp_config.get_window_scale(), remote)
             },
             None => (0, 0),
         };

--- a/src/inetstack/protocols/layer4/tcp/passive_open.rs
+++ b/src/inetstack/protocols/layer4/tcp/passive_open.rs
@@ -394,9 +394,9 @@ impl SharedPassiveSocket {
                         "remote windows scale larger than {:?} is incorrect, so setting to {:?}. See RFC 1323.",
                         MAX_WINDOW_SCALE, MAX_WINDOW_SCALE
                     );
-                    (self.tcp_config.get_window_scale() as u8, MAX_WINDOW_SCALE as u8)
+                    (self.tcp_config.get_window_scale(), MAX_WINDOW_SCALE as u8)
                 } else {
-                    (self.tcp_config.get_window_scale() as u8, remote_window_scale)
+                    (self.tcp_config.get_window_scale(), remote_window_scale)
                 }
             },
             None => (0, 0),

--- a/src/runtime/memory/demibuffer.rs
+++ b/src/runtime/memory/demibuffer.rs
@@ -447,7 +447,7 @@ impl DemiBuffer {
             ol_flags: 0,
             pkt_len: size as u32 - headroom as u32,
             data_len: size - headroom as u16,
-            buf_len: size as u16,
+            buf_len: size,
             next: None,
             pool: None,
         })));


### PR DESCRIPTION
Casting the the same type of the variable is unnecessary. So removed all such instances from the codebase, which also makes the code more readable.