### PR TITLE
demikernel: remove unnecessary question mark and Ok()

### DIFF
--- a/src/inetstack/protocols/layer4/tcp/active_open.rs
+++ b/src/inetstack/protocols/layer4/tcp/active_open.rs
@@ -193,7 +193,7 @@ impl SharedActiveOpenSocket {
             "Window scale: local {}, remote {}",
             local_window_scale_bits, remote_window_scale_bits
         );
-        Ok(SharedEstablishedSocket::new(
+        SharedEstablishedSocket::new(
             self.local,
             self.remote,
             self.runtime.clone(),
@@ -211,7 +211,7 @@ impl SharedActiveOpenSocket {
             mss,
             congestion_control::None::new,
             None,
-        )?)
+        )
     }
 
     pub async fn connect(mut self) -> Result<SharedEstablishedSocket, Fail> {

--- a/src/runtime/queue/mod.rs
+++ b/src/runtime/queue/mod.rs
@@ -78,12 +78,12 @@ impl IoQueueTable {
 
     /// Gets/borrows a reference to the queue metadata associated with an I/O queue descriptor.
     pub fn get<'a, T: IoQueue>(&'a self, qd: &QDesc) -> Result<&'a T, Fail> {
-        Ok(downcast_queue_ptr::<T>(self.get_queue_ref(qd)?)?)
+        downcast_queue_ptr::<T>(self.get_queue_ref(qd)?)
     }
 
     /// Gets/borrows a mutable reference to the queue metadata associated with an I/O queue descriptor
     pub fn get_mut<'a, T: IoQueue>(&'a mut self, qd: &QDesc) -> Result<&'a mut T, Fail> {
-        Ok(downcast_mut_ptr::<T>(self.get_mut_queue_ref(qd)?)?)
+        downcast_mut_ptr::<T>(self.get_mut_queue_ref(qd)?)
     }
 
     /// Releases the entry associated with an I/O queue descriptor.
@@ -96,7 +96,7 @@ impl IoQueueTable {
                 return Err(Fail::new(libc::EBADF, &cause));
             },
         };
-        Ok(downcast_queue::<T>(self.table.remove(internal_id.into()))?)
+        downcast_queue::<T>(self.table.remove(internal_id.into()))
     }
 
     /// Gets an iterator over all registered queues.


### PR DESCRIPTION
There’s no reason to use ? to short-circuit when execution of the body will end there anyway.