### PR TITLE
demikernel: remove unnecessary borrows

### DIFF
--- a/src/catnap/linux/transport.rs
+++ b/src/catnap/linux/transport.rs
@@ -469,7 +469,7 @@ impl NetworkTransport for SharedCatnapTransport {
 
         // Update socket state.
         self.data_from_sd(sd).move_socket_to_passive();
-        self.register_epoll(&sd, libc::EPOLLIN as u32)?;
+        self.register_epoll(sd, libc::EPOLLIN as u32)?;
 
         Ok(())
     }
@@ -508,7 +508,7 @@ impl NetworkTransport for SharedCatnapTransport {
     /// with an error.
     async fn connect(&mut self, sd: &mut Self::SocketDescriptor, remote: SocketAddr) -> Result<(), Fail> {
         self.data_from_sd(sd).move_socket_to_active();
-        self.register_epoll(&sd, (libc::EPOLLIN | libc::EPOLLOUT) as u32)?;
+        self.register_epoll(sd, (libc::EPOLLIN | libc::EPOLLOUT) as u32)?;
 
         loop {
             match self.socket_from_sd(sd).connect(&remote.into()) {

--- a/src/demikernel/bindings.rs
+++ b/src/demikernel/bindings.rs
@@ -446,13 +446,11 @@ pub extern "C" fn demi_wait_any(
         timeout
     );
 
-    // Check for invalid storage location for queue result.
     if qr_out.is_null() {
         warn!("qr_out is a null pointer");
         return libc::EINVAL;
     }
 
-    // Check arguments.
     if num_qts < 0 {
         return libc::EINVAL;
     }
@@ -468,8 +466,7 @@ pub extern "C" fn demi_wait_any(
         Some(unsafe { Duration::new((*timeout).tv_sec as u64, (*timeout).tv_nsec as u32) })
     };
 
-    // Issue wait_any operation.
-    let ret: Result<i32, Fail> = do_syscall(|libos| match libos.wait_any(&qts, duration) {
+    let ret: Result<i32, Fail> = do_syscall(|libos| match libos.wait_any(qts, duration) {
         Ok((ix, qr)) => {
             unsafe {
                 *qr_out = qr;

--- a/src/inetstack/protocols/layer3/mod.rs
+++ b/src/inetstack/protocols/layer3/mod.rs
@@ -63,7 +63,7 @@ impl SharedLayer3Endpoint {
 
         Ok(SharedLayer3Endpoint(SharedObject::new(Layer3Endpoint {
             arp: arp.clone(),
-            icmpv4: SharedIcmpv4Peer::new(&config, runtime, layer2_endpoint.clone(), arp, rng_seed)?,
+            icmpv4: SharedIcmpv4Peer::new(config, runtime, layer2_endpoint.clone(), arp, rng_seed)?,
             local_ipv4_addr: config.local_ipv4_addr()?,
             layer2_endpoint,
         })))

--- a/src/inetstack/protocols/layer4/tcp/active_open.rs
+++ b/src/inetstack/protocols/layer4/tcp/active_open.rs
@@ -261,7 +261,7 @@ impl SharedActiveOpenSocket {
                 if r == State::Closed {
                     let cause: &str = "Closing socket while connecting";
                     warn!("{}", cause);
-                    return Err(Fail::new(libc::ECONNABORTED, &cause));
+                    return Err(Fail::new(libc::ECONNABORTED, cause));
                 }
             },
             r = recv_queue.pop(Some(handshake_timeout)).fuse() => match r {

--- a/src/inetstack/protocols/layer4/tcp/established/mod.rs
+++ b/src/inetstack/protocols/layer4/tcp/established/mod.rs
@@ -98,7 +98,7 @@ impl SharedEstablishedSocket {
                     "{}: scale={:?} window={:?}",
                     cause, sender_window_scale_bits, sender_window_size_bytes
                 );
-                return Err(Fail::new(libc::EINVAL, &cause));
+                return Err(Fail::new(libc::EINVAL, cause));
             },
             _ if sender_window_size_bytes > MAX_WINDOW_SIZE_WITH_SCALING => {
                 let cause = "Sender window too large";
@@ -106,7 +106,7 @@ impl SharedEstablishedSocket {
                     "{}: scale={:?} window={:?}",
                     cause, sender_window_scale_bits, sender_window_size_bytes
                 );
-                return Err(Fail::new(libc::EINVAL, &cause));
+                return Err(Fail::new(libc::EINVAL, cause));
             },
             _ => (),
         };
@@ -119,7 +119,7 @@ impl SharedEstablishedSocket {
                     "{}: scale={:?} window={:?}",
                     cause, receiver_window_scale_bits, receiver_window_size_bytes
                 );
-                return Err(Fail::new(libc::EINVAL, &cause));
+                return Err(Fail::new(libc::EINVAL, cause));
             },
             _ if receiver_window_size_bytes > MAX_WINDOW_SIZE_WITH_SCALING => {
                 let cause = "Receiver window too large";
@@ -127,7 +127,7 @@ impl SharedEstablishedSocket {
                     "{}: scale={:?} window={:?}",
                     cause, receiver_window_scale_bits, receiver_window_size_bytes
                 );
-                return Err(Fail::new(libc::EINVAL, &cause));
+                return Err(Fail::new(libc::EINVAL, cause));
             },
             _ => (),
         };

--- a/src/inetstack/protocols/layer4/tcp/header.rs
+++ b/src/inetstack/protocols/layer4/tcp/header.rs
@@ -396,7 +396,7 @@ impl TcpHeader {
 
         // Alright, we've fully filled out the header, time to compute the checksum.
         if !tx_checksum_offload {
-            let checksum: u16 = tcp_checksum(src_ipv4_addr, dst_ipv4_addr, &hdr_buf[..], &payload);
+            let checksum: u16 = tcp_checksum(src_ipv4_addr, dst_ipv4_addr, &hdr_buf[..], payload);
             hdr_buf[16..18].copy_from_slice(&checksum.to_be_bytes());
         } else {
             hdr_buf[16] = 0;

--- a/src/inetstack/protocols/layer4/tcp/passive_open.rs
+++ b/src/inetstack/protocols/layer4/tcp/passive_open.rs
@@ -375,7 +375,7 @@ impl SharedPassiveSocket {
                 (_, tcp_hdr, _) if tcp_hdr.ack => {
                     let cause = "invalid SYN+ACK seq num";
                     warn!("{}: {:?}", cause, tcp_hdr);
-                    return Err(Fail::new(EBADMSG, &cause));
+                    return Err(Fail::new(EBADMSG, cause));
                 },
                 // We got a duplicate SYN, so ignore it.
                 (_, tcp_hdr, _) if tcp_hdr.syn && tcp_hdr.seq_num == remote_isn => {

--- a/src/runtime/memory/demibuffer.rs
+++ b/src/runtime/memory/demibuffer.rs
@@ -495,7 +495,7 @@ impl DemiBuffer {
         match self.get_tag() {
             Tag::Heap => {
                 if let Some(check) = self.as_metadata().pool.as_ref() {
-                    Rc::ptr_eq(&check, pool.pool())
+                    Rc::ptr_eq(check, pool.pool())
                 } else {
                     false
                 }

--- a/src/runtime/memory/mod.rs
+++ b/src/runtime/memory/mod.rs
@@ -123,7 +123,7 @@ pub fn clone_sgarray(sga: &demi_sgarray_t) -> Result<DemiBuffer, Fail> {
     mem::forget(buf);
 
     // Check whether the limits of the buffer have changed.
-    check_demi_buf_limits(&sga, &mut clone)?;
+    check_demi_buf_limits(sga, &mut clone)?;
 
     // Return the clone.
     Ok(clone)


### PR DESCRIPTION
These instances were creating reference to reference which is not needed. The compiler is immediately dereferencing the variables as soon as they are passed. So remove all such instances from the codebase.