### PR TITLE
demikernel: avoid unnecessary conversions using into()

### DIFF
--- a/src/catnap/linux/transport.rs
+++ b/src/catnap/linux/transport.rs
@@ -73,7 +73,7 @@ impl SharedCatnapTransport {
         // Create epoll socket.
         // Linux ignores the size argument to epoll, it just has to be more than 0.
         let epoll_fd: RawFd = match unsafe { libc::epoll_create(10) } {
-            fd if fd >= 0 => fd.into(),
+            fd if fd >= 0 => fd,
             _ => {
                 let errno: libc::c_int = unsafe { *libc::__errno_location() };
                 panic!("could not create epoll socket: {:?}", errno);

--- a/src/demikernel/bindings.rs
+++ b/src/demikernel/bindings.rs
@@ -61,7 +61,7 @@ pub extern "C" fn demi_init(args: *const demi_args_t) -> c_int {
     trace!("demi_init()");
 
     let libos_name: LibOSName = match LibOSName::from_env() {
-        Ok(libos_name) => libos_name.into(),
+        Ok(libos_name) => libos_name,
         Err(e) => panic!("{:?}", e),
     };
 

--- a/src/inetstack/protocols/layer4/tcp/isn_generator.rs
+++ b/src/inetstack/protocols/layer4/tcp/isn_generator.rs
@@ -30,10 +30,10 @@ impl IsnGenerator {
         let crc: crc::Crc<u32> = crc::Crc::<u32>::new(&crc::CRC_32_CKSUM);
         let mut digest = crc.digest();
         digest.update(&remote.ip().octets());
-        let remote_port: u16 = remote.port().into();
+        let remote_port: u16 = remote.port();
         digest.update(&remote_port.to_be_bytes());
         digest.update(&local.ip().octets());
-        let local_port: u16 = local.port().into();
+        let local_port: u16 = local.port();
         digest.update(&local_port.to_be_bytes());
         digest.update(&self.nonce.to_be_bytes());
         let digest = digest.finalize();

--- a/src/runtime/scheduler/group.rs
+++ b/src/runtime/scheduler/group.rs
@@ -79,7 +79,7 @@ impl TaskGroup {
         // The pin slab index can be reverse-computed in a page index and an offset within the page.
         let pin_slab_index: usize = self.tasks.insert(task)?;
 
-        self.add_new_pages_up_to_pin_slab_index(pin_slab_index.into());
+        self.add_new_pages_up_to_pin_slab_index(pin_slab_index);
 
         // Initialize the appropriate page offset.
         let (waker_page_ref, waker_page_offset): (&WakerPageRef, usize) = {


### PR DESCRIPTION
These conversions are redundant because they are trying to convert into the same type. So removed all such instances from the codebase.