### PR TITLE
runtime: remove unnecessary lifetime annotations

### DIFF
--- a/src/runtime/memory/demibuffer.rs
+++ b/src/runtime/memory/demibuffer.rs
@@ -931,9 +931,9 @@ fn allocate_metadata_data<'a>(direct_data_size: u16) -> (&'a mut MaybeUninit<Met
 ///
 /// # Safety:
 /// `buffer` must be suitably aligned for and large enough to hold a [`MetaData`].
-unsafe fn split_buffer_for_metadata<'a>(
-    buffer: &'a mut [MaybeUninit<u8>],
-) -> (&'a mut MaybeUninit<MetaData>, &'a mut [MaybeUninit<u8>]) {
+unsafe fn split_buffer_for_metadata(
+    buffer: &mut [MaybeUninit<u8>],
+) -> (&mut MaybeUninit<MetaData>, &mut [MaybeUninit<u8>]) {
     assert!(buffer.len() >= size_of::<MetaData>());
 
     let (metadata_buf, data_buf) = buffer.split_at_mut(size_of::<MetaData>());

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -517,7 +517,7 @@ impl<T> Deref for SharedObject<T> {
 /// judiciously across coroutines with the understanding that the shared object may change/be mutated whenever the
 /// coroutine yields.
 impl<T> DerefMut for SharedObject<T> {
-    fn deref_mut<'a>(&'a mut self) -> &'a mut Self::Target {
+    fn deref_mut(&mut self) -> &mut Self::Target {
         let ptr: *mut T = Rc::as_ptr(&self.0) as *mut T;
         unsafe { &mut *ptr }
     }
@@ -535,7 +535,7 @@ impl<T> AsRef<T> for SharedObject<T> {
 /// and should be considered unsafe. However, it is safe to use in Demikernel if and only if we only run one coroutine
 /// at a time.
 impl<T> AsMut<T> for SharedObject<T> {
-    fn as_mut<'a>(&'a mut self) -> &'a mut T {
+    fn as_mut(&mut self) -> &mut T {
         let ptr: *mut T = Rc::as_ptr(&self.0) as *mut T;
         unsafe { &mut *ptr }
     }
@@ -556,7 +556,7 @@ impl<T: ?Sized> Deref for SharedBox<T> {
 }
 
 impl<T: ?Sized> DerefMut for SharedBox<T> {
-    fn deref_mut<'a>(&'a mut self) -> &'a mut Self::Target {
+    fn deref_mut(&mut self) -> &mut Self::Target {
         self.0.deref_mut().as_mut()
     }
 }

--- a/src/runtime/queue/mod.rs
+++ b/src/runtime/queue/mod.rs
@@ -139,7 +139,7 @@ impl IoQueueTable {
 //======================================================================================================================
 
 /// Downcasts a [IoQueue] reference to a concrete queue type reference `&T`.
-pub fn downcast_queue_ptr<'a, T: IoQueue>(boxed_queue_ptr: &'a Box<dyn IoQueue>) -> Result<&'a T, Fail> {
+pub fn downcast_queue_ptr<T: IoQueue>(boxed_queue_ptr: &Box<dyn IoQueue>) -> Result<&T, Fail> {
     // 1. Get reference to queue inside the box.
     let queue_ptr: &dyn IoQueue = boxed_queue_ptr.as_ref();
     // 2. Cast that reference to a void pointer for downcasting.
@@ -155,7 +155,7 @@ pub fn downcast_queue_ptr<'a, T: IoQueue>(boxed_queue_ptr: &'a Box<dyn IoQueue>)
     }
 }
 
-pub fn downcast_mut_ptr<'a, T: IoQueue>(boxed_queue_ptr: &'a mut Box<dyn IoQueue>) -> Result<&'a mut T, Fail> {
+pub fn downcast_mut_ptr<T: IoQueue>(boxed_queue_ptr: &mut Box<dyn IoQueue>) -> Result<&mut T, Fail> {
     // 1. Get reference to queue inside the box.
     let queue_ptr: &mut dyn IoQueue = boxed_queue_ptr.as_mut();
     // 2. Cast that reference to a void pointer for downcasting.


### PR DESCRIPTION
The additional lifetimes make the code look more complicated, while there is nothing out of the ordinary going on. Removing them leads to more readable code and the Rust compiler's lifetime elision rules will take care of the rest.