### PR TITLE
demikernel: use shorter assign op pattern

### DIFF
--- a/src/inetstack/protocols/layer4/tcp/passive_open.rs
+++ b/src/inetstack/protocols/layer4/tcp/passive_open.rs
@@ -305,7 +305,7 @@ impl SharedPassiveSocket {
                 },
                 Err(Fail { errno, cause: _ }) if errno == ETIMEDOUT => {
                     if handshake_retries > 0 {
-                        handshake_retries = handshake_retries - 1;
+                        handshake_retries -= 1;
                         continue;
                     } else {
                         self.ready

--- a/src/runtime/condition_variable.rs
+++ b/src/runtime/condition_variable.rs
@@ -71,7 +71,7 @@ impl SharedConditionVariable {
 
     /// Wake all waiting coroutines.
     pub fn broadcast(&mut self) {
-        self.num_ready = self.num_ready + self.waiters.len();
+        self.num_ready += self.waiters.len();
         for (_, waiter) in self.waiters.drain(..) {
             waiter.wake_by_ref();
         }

--- a/src/runtime/memory/demibuffer.rs
+++ b/src/runtime/memory/demibuffer.rs
@@ -549,7 +549,7 @@ impl DemiBuffer {
         // Step 2: detach the indirect buffer.
         metadata.buf_addr = null_mut();
         metadata.buf_len = 0;
-        metadata.ol_flags = metadata.ol_flags & !METADATA_F_INDIRECT;
+        metadata.ol_flags &= !METADATA_F_INDIRECT;
 
         // Step 3: reconstitute the direct DemiBuffer.
         let direct: NonNull<MetaData> = NonNull::from(direct);
@@ -1179,7 +1179,7 @@ impl Drop for DemiBuffer {
                             // Restore buf_addr and buf_len to their unattached values.
                             metadata.buf_addr = null_mut();
                             metadata.buf_len = 0;
-                            metadata.ol_flags = metadata.ol_flags & !METADATA_F_INDIRECT;
+                            metadata.ol_flags &= !METADATA_F_INDIRECT;
 
                             // Drop our reference to the direct buffer, and free it if ours was the last one.
                             if direct.dec_refcnt() == 0 {

--- a/src/runtime/timer.rs
+++ b/src/runtime/timer.rs
@@ -72,7 +72,7 @@ pub struct SharedTimer(SharedObject<Timer>);
 
 impl YieldPointId {
     pub fn increment(&mut self) {
-        self.0 = self.0 + 1;
+        self.0 += 1;
     }
 }
 


### PR DESCRIPTION
Use `a += b` instead of `a = a + b`. This makes lines shorter and faster to read. So why not use it while the language supports this feature.