### PR TITLE
ci: workflows: do not comment perf stats on PR page

### DIFF
--- a/.github/workflows/catnap.yml
+++ b/.github/workflows/catnap.yml
@@ -148,12 +148,6 @@ jobs:
           --branch origin/$branch_name \
           --libos $LIBOS \
           --log-dir ./catnap_release_pipeline_logs)
-        if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-          echo "MESSAGE<<$EOF" >> $GITHUB_OUTPUT
-          echo "$stats" >> $GITHUB_OUTPUT
-          echo "$EOF" >> $GITHUB_OUTPUT
-        fi
     - name: Archive Performance Data
       uses: actions/upload-artifact@v4
       with:
@@ -161,16 +155,3 @@ jobs:
         path: |
           **/perf_data.csv
           **/flamegraph.svg
-    - name: Report Statistics
-      if: github.event_name == 'pull_request'
-      uses: actions/github-script@v7
-      with:
-        github-token: ${{secrets.GITHUB_TOKEN}}
-        script: |
-          const message = `${{ steps.parse-stats.outputs.MESSAGE }}`
-          github.rest.issues.createComment({
-            issue_number: context.issue.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: message
-          })

--- a/.github/workflows/catnip.yml
+++ b/.github/workflows/catnip.yml
@@ -192,12 +192,6 @@ jobs:
           --branch origin/$branch_name \
           --libos $LIBOS \
           --log-dir ./catnip_release_pipeline_logs)
-        if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-          echo "MESSAGE<<$EOF" >> $GITHUB_OUTPUT
-          echo "$stats" >> $GITHUB_OUTPUT
-          echo "$EOF" >> $GITHUB_OUTPUT
-        fi
     - name: Archive Performance Data
       uses: actions/upload-artifact@v4
       with:
@@ -205,16 +199,3 @@ jobs:
         path: |
           **/perf_data.csv
           **/flamegraph.svg
-    - name: Report Statistics
-      if: github.event_name == 'pull_request'
-      uses: actions/github-script@v7
-      with:
-        github-token: ${{secrets.GITHUB_TOKEN}}
-        script: |
-          const message = `${{ steps.parse-stats.outputs.MESSAGE }}`
-          github.rest.issues.createComment({
-            issue_number: context.issue.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: message
-          })

--- a/.github/workflows/catpowder.yml
+++ b/.github/workflows/catpowder.yml
@@ -184,12 +184,6 @@ jobs:
           --branch origin/$branch_name \
           --libos $LIBOS \
           --log-dir ./catpowder_release_pipeline_logs)
-        if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-          echo "MESSAGE<<$EOF" >> $GITHUB_OUTPUT
-          echo "$stats" >> $GITHUB_OUTPUT
-          echo "$EOF" >> $GITHUB_OUTPUT
-        fi
     - name: Archive Performance Data
       uses: actions/upload-artifact@v4
       with:
@@ -197,16 +191,3 @@ jobs:
         path: |
           **/perf_data.csv
           **/flamegraph.svg
-    - name: Report Statistics
-      if: github.event_name == 'pull_request'
-      uses: actions/github-script@v7
-      with:
-        github-token: ${{secrets.GITHUB_TOKEN}}
-        script: |
-          const message = `${{ steps.parse-stats.outputs.MESSAGE }}`
-          github.rest.issues.createComment({
-            issue_number: context.issue.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: message
-          })

--- a/tools/perf.py
+++ b/tools/perf.py
@@ -27,8 +27,6 @@ def __read_args() -> argparse.Namespace:
 def __build_report(args):
     commit_id = git.get_head_commit(args.branch)
 
-    # This information is printed to the console and will be used by the
-    # workflow to post a comment on the PR.
     print('libos = ' + args.libos)
     print('commit id = ' + commit_id)
 
@@ -144,7 +142,6 @@ def __print_perf_data(perf_df):
     ]
 
     out_df = perf_df.sort_values(by=sort_by_columns, ascending=False)[columns_to_display]
-    # This print will be used by the workflow to post a comment on the PR.
     print(out_df.to_markdown(floatfmt='.2f', index=False))
 
 


### PR DESCRIPTION
The PR page was getting unnecessarily long and the info is not consumable via a web page anyways. We can definitely run offline data mining jobs from the archived logs if needed