### PR TITLE
runtime: network: states: remove unneeded string format!() calls

### DIFF
--- a/src/runtime/network/ring/state.rs
+++ b/src/runtime/network/ring/state.rs
@@ -59,7 +59,7 @@ impl RingStateMachine {
     pub fn prepare(&mut self, op: RingControlOperation) -> Result<(), Fail> {
         let next: RingState = self.get_next_state(op)?;
         if next != RingState::Closing && self.next.is_some() {
-            return Err(fail(op, &format!("ring is busy"), libc::EBUSY));
+            return Err(fail(op, "ring is busy", libc::EBUSY));
         }
         self.next = Some(next);
         Ok(())
@@ -89,7 +89,7 @@ impl RingStateMachine {
     fn from_opened(&self, op: RingControlOperation) -> Result<RingState, Fail> {
         match op {
             RingControlOperation::Close => Ok(RingState::Closing),
-            RingControlOperation::Closed => Err(fail(op, &format!("ring is closed"), libc::EBADF)),
+            RingControlOperation::Closed => Err(fail(op, "ring is closed", libc::EBADF)),
         }
     }
 
@@ -104,8 +104,7 @@ impl RingStateMachine {
     /// Attempts to transition from the [RingState::Closed].
     fn from_closed(&self, op: RingControlOperation) -> Result<RingState, Fail> {
         match op {
-            RingControlOperation::Close => Err(fail(op, &format!("ring is closed"), libc::EBADF)),
-            RingControlOperation::Closed => Err(fail(op, &format!("ring is closed"), libc::EBADF)),
+            RingControlOperation::Close | RingControlOperation::Closed => Err(fail(op, "ring is closed", libc::EBADF)),
         }
     }
 

--- a/src/runtime/network/socket/state.rs
+++ b/src/runtime/network/socket/state.rs
@@ -167,7 +167,7 @@ impl SocketStateMachine {
         // Already prepared and not committed or aborted yet.
         if let Some(pending) = self.next {
             if next != SocketState::Closing && pending != next {
-                return Err(fail(op, &format!("socket is busy"), libc::EBUSY));
+                return Err(fail(op, "socket is busy", libc::EBUSY));
             }
         }
 
@@ -206,50 +206,44 @@ impl SocketStateMachine {
     fn unbound_state(&self, op: SocketOp) -> Result<SocketState, Fail> {
         match op {
             SocketOp::Bind => Ok(SocketState::Bound),
-            SocketOp::Listen => Err(fail(op, &format!("socket is not bound"), libc::EDESTADDRREQ)),
+            SocketOp::Listen => Err(fail(op, "socket is not bound", libc::EDESTADDRREQ)),
             SocketOp::Connect => Ok(SocketState::ActiveConnecting),
             // Should this be possible without going through the Connecting state?
             SocketOp::Established => Ok(SocketState::ActiveEstablished),
             SocketOp::Close => Ok(SocketState::Closing),
-            SocketOp::Closed => Err(fail(op, &format!("socket is busy"), libc::EBUSY)),
+            SocketOp::Closed => Err(fail(op, "socket is busy", libc::EBUSY)),
         }
     }
 
     /// Attempts to transition from bound state.
     fn bound_state(&self, op: SocketOp) -> Result<SocketState, Fail> {
         match op {
-            SocketOp::Bind => Err(fail(op, &format!("socket is already bound"), libc::EINVAL)),
+            SocketOp::Bind => Err(fail(op, "socket is already bound", libc::EINVAL)),
             SocketOp::Listen => Ok(SocketState::PassiveListening),
             SocketOp::Connect => Ok(SocketState::ActiveConnecting),
             SocketOp::Established => Ok(SocketState::ActiveConnecting),
             SocketOp::Close => Ok(SocketState::Closing),
-            SocketOp::Closed => Err(fail(op, &format!("socket is busy"), libc::EBUSY)),
+            SocketOp::Closed => Err(fail(op, "socket is busy", libc::EBUSY)),
         }
     }
 
     /// Attempts to transition from listening state.
     fn listening_state(&self, op: SocketOp) -> Result<SocketState, Fail> {
         match op {
-            SocketOp::Bind | SocketOp::Established => {
-                Err(fail(op, &format!("socket is already listening"), libc::EINVAL))
-            },
-            SocketOp::Listen => Err(fail(op, &format!("socket is already listening"), libc::EADDRINUSE)),
-            SocketOp::Connect => Err(fail(op, &format!("socket is already listening"), libc::EOPNOTSUPP)),
+            SocketOp::Bind | SocketOp::Established => Err(fail(op, "socket is already listening", libc::EINVAL)),
+            SocketOp::Listen => Err(fail(op, "socket is already listening", libc::EADDRINUSE)),
+            SocketOp::Connect => Err(fail(op, "socket is already listening", libc::EOPNOTSUPP)),
             SocketOp::Close => Ok(SocketState::Closing),
-            SocketOp::Closed => Err(fail(op, &format!("socket is busy"), libc::EBUSY)),
+            SocketOp::Closed => Err(fail(op, "socket is busy", libc::EBUSY)),
         }
     }
 
     /// Attempts to transition from connecting state.
     fn connecting_state(&self, op: SocketOp) -> Result<SocketState, Fail> {
         match op {
-            SocketOp::Bind => Err(fail(op, &format!("socket is already connecting"), libc::EINVAL)),
-            SocketOp::Listen => Err(fail(op, &format!("socket is already connecting"), libc::EADDRINUSE)),
-            SocketOp::Connect => Err(fail(
-                op,
-                &format!("socket already is already connecting "),
-                libc::EINPROGRESS,
-            )),
+            SocketOp::Bind => Err(fail(op, "socket is already connecting", libc::EINVAL)),
+            SocketOp::Listen => Err(fail(op, "socket is already connecting", libc::EADDRINUSE)),
+            SocketOp::Connect => Err(fail(op, "socket already is already connecting", libc::EINPROGRESS)),
             SocketOp::Established => Ok(SocketState::ActiveEstablished),
             SocketOp::Close => Ok(SocketState::Closing),
             // We may enter the closed state from other states because either the state machine was incorrectly rolled
@@ -263,7 +257,7 @@ impl SocketStateMachine {
     fn established_state(&self, op: SocketOp) -> Result<SocketState, Fail> {
         match op {
             SocketOp::Bind | SocketOp::Listen | SocketOp::Connect | SocketOp::Established => {
-                Err(fail(op, &format!("socket is already connected"), libc::EISCONN))
+                Err(fail(op, "socket is already connected", libc::EISCONN))
             },
             SocketOp::Close => Ok(SocketState::Closing),
             SocketOp::Closed => Ok(SocketState::Closed),
@@ -275,7 +269,7 @@ impl SocketStateMachine {
         match op {
             SocketOp::Close => Ok(SocketState::Closing),
             SocketOp::Closed => Ok(SocketState::Closed),
-            _ => Err(fail(op, &format!("socket is closing"), libc::EBADF)),
+            _ => Err(fail(op, "socket is closing", libc::EBADF)),
         }
     }
 
@@ -284,7 +278,7 @@ impl SocketStateMachine {
         if op == SocketOp::Closed || op == SocketOp::Close {
             Ok(SocketState::Closed)
         } else {
-            Err(fail(op, &format!("socket is closed"), libc::EBADF))
+            Err(fail(op, "socket is closed", libc::EBADF))
         }
     }
 


### PR DESCRIPTION
Using format!() for such cases is unnecessary and inefficient. Using string literals is a better option.

Also, merged arms to avoid duplication, but more importantly to make it evident that we handle both cases in the same way. This will also uncover any issues if at all because it draws attention to itself.