### PR TITLE
demikernel: replace manual ok() functionality with built in ok() fn

### DIFF
--- a/src/demikernel/config.rs
+++ b/src/demikernel/config.rs
@@ -169,10 +169,7 @@ impl Config {
             Self::get_typed_str_option(
                 self.get_global_config()?,
                 global_config::LOCAL_IPV4_ADDR,
-                |val: &str| match val.parse() {
-                    Ok(local_addr) => Some(local_addr),
-                    _ => None,
-                },
+                |val: &str| val.parse().ok(),
             )?
         };
 
@@ -192,10 +189,7 @@ impl Config {
             Self::get_typed_str_option(
                 self.get_global_config()?,
                 global_config::LOCAL_LINK_ADDR,
-                |val: &str| match MacAddress::parse_canonical_str(val) {
-                    Ok(local_addr) => Some(local_addr),
-                    _ => None,
-                },
+                |val: &str| MacAddress::parse_canonical_str(val).ok(),
             )
         }
     }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -419,11 +419,7 @@ impl SharedDemiRuntime {
 
                 // OperationTasks return a value to the application, so we must stash these for later. Otherwise, we
                 // just discard the return value of the completed coroutine.
-                if let Ok(operation_task) = OperationTask::try_from(boxed_task.as_any()) {
-                    Some(operation_task)
-                } else {
-                    None
-                }
+                OperationTask::try_from(boxed_task.as_any()).ok()
             })
             .collect()
     }


### PR DESCRIPTION
This makes the code more readable, terse and less error prone in future without loss of current functionality.