### PR TITLE
demikernel: use default derive instead of impl Default

### DIFF
--- a/src/inetstack/config/udp.rs
+++ b/src/inetstack/config/udp.rs
@@ -11,7 +11,7 @@ use crate::{demikernel::config::Config, runtime::fail::Fail};
 // Structures
 //======================================================================================================================
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct UdpConfig {
     rx_checksum: bool,
     tx_checksum: bool,
@@ -36,19 +36,6 @@ impl UdpConfig {
 
     pub fn get_tx_checksum_offload(&self) -> bool {
         self.tx_checksum
-    }
-}
-
-//======================================================================================================================
-// Trait Implementations
-//======================================================================================================================
-
-impl Default for UdpConfig {
-    fn default() -> Self {
-        UdpConfig {
-            rx_checksum: false,
-            tx_checksum: false,
-        }
     }
 }
 

--- a/src/inetstack/protocols/layer4/tcp/established/congestion_control/options.rs
+++ b/src/inetstack/protocols/layer4/tcp/established/congestion_control/options.rs
@@ -11,7 +11,7 @@ pub enum OptionValue {
     String(String),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct Options {
     inner: HashMap<String, OptionValue>,
 }
@@ -59,11 +59,5 @@ impl Options {
 
     pub fn insert_string(&mut self, key: String, value: String) {
         self.inner.insert(key, OptionValue::String(value));
-    }
-}
-
-impl Default for Options {
-    fn default() -> Self {
-        Self { inner: HashMap::new() }
     }
 }

--- a/src/runtime/network/mod.rs
+++ b/src/runtime/network/mod.rs
@@ -26,6 +26,7 @@ use ::std::{
 // Structures
 //======================================================================================================================
 
+#[derive(Default)]
 pub struct SocketIdToQDescMap {
     mappings: HashMap<SocketId, QDesc>,
 }
@@ -55,18 +56,6 @@ impl SocketIdToQDescMap {
             }
         }
         false
-    }
-}
-
-//======================================================================================================================
-// Traits
-//======================================================================================================================
-
-impl Default for SocketIdToQDescMap {
-    fn default() -> Self {
-        Self {
-            mappings: HashMap::<SocketId, QDesc>::new(),
-        }
     }
 }
 


### PR DESCRIPTION
Implementing the Default trait in these cases is unnecessary. Using built in default derive is more concise and less error prone.