### PR TITLE
demikernel: do not use clone if copy trait is derived

### DIFF
--- a/src/catnap/linux/active_socket.rs
+++ b/src/catnap/linux/active_socket.rs
@@ -65,7 +65,7 @@ impl ActiveSocketData {
             }
             // Try to send the buffer.
             let io_result: Result<usize, io::Error> = match addr {
-                Some(addr) => self.socket.send_to(&buf, &addr.clone().into()),
+                Some(addr) => self.socket.send_to(&buf, &addr.into()),
                 None => self.socket.send(&buf),
             };
             match io_result {

--- a/src/demikernel/libos/network/libos.rs
+++ b/src/demikernel/libos/network/libos.rs
@@ -127,7 +127,7 @@ impl<T: NetworkTransport> SharedNetworkLibOS<T> {
         self.get_shared_queue(&qd)?.bind(socket_addr)?;
         // Insert into address to queue descriptor table.
         self.runtime
-            .insert_socket_id_to_qd(SocketId::Passive(socket_addrv4.clone()), qd);
+            .insert_socket_id_to_qd(SocketId::Passive(socket_addrv4), qd);
 
         Ok(())
     }

--- a/src/inetstack/protocols/layer4/tcp/active_open.rs
+++ b/src/inetstack/protocols/layer4/tcp/active_open.rs
@@ -128,7 +128,7 @@ impl SharedActiveOpenSocket {
         tcp_hdr.seq_num = self.local_isn + SeqNumber::from(1);
         debug!("Sending ACK: {:?}", tcp_hdr);
 
-        let dst_ipv4_addr: Ipv4Addr = self.remote.ip().clone();
+        let dst_ipv4_addr: Ipv4Addr = *self.remote.ip();
         let mut pkt: DemiBuffer = DemiBuffer::new_with_headroom(0, MAX_HEADER_SIZE as u16);
         tcp_hdr.serialize_and_attach(
             &mut pkt,
@@ -235,7 +235,7 @@ impl SharedActiveOpenSocket {
             info!("Advertising window scale: {}", self.tcp_config.get_window_scale());
 
             debug!("Sending SYN {:?}", tcp_hdr);
-            let dst_ipv4_addr: Ipv4Addr = self.remote.ip().clone();
+            let dst_ipv4_addr: Ipv4Addr = *self.remote.ip();
             let mut pkt: DemiBuffer = DemiBuffer::new_with_headroom(0, MAX_HEADER_SIZE as u16);
             tcp_hdr.serialize_and_attach(
                 &mut pkt,

--- a/src/inetstack/protocols/layer4/tcp/established/sender.rs
+++ b/src/inetstack/protocols/layer4/tcp/established/sender.rs
@@ -695,7 +695,7 @@ impl Sender {
         // This routine should only ever be called to send TCP segments that contain a valid ACK value.
         debug_assert!(header.ack);
 
-        let remote_ipv4_addr: Ipv4Addr = cb.remote.ip().clone();
+        let remote_ipv4_addr: Ipv4Addr = *cb.remote.ip();
         header.serialize_and_attach(
             &mut pkt,
             cb.local.ip(),

--- a/src/inetstack/protocols/layer4/tcp/passive_open.rs
+++ b/src/inetstack/protocols/layer4/tcp/passive_open.rs
@@ -178,7 +178,7 @@ impl SharedPassiveSocket {
         }
 
         // Send SYN+ACK.
-        let local: SocketAddrV4 = self.local.clone();
+        let local: SocketAddrV4 = self.local;
         let local_isn = self.isn_generator.generate(&local, &remote);
         let remote_isn = tcp_hdr.seq_num;
 
@@ -225,7 +225,7 @@ impl SharedPassiveSocket {
         };
 
         // Create a RST segment.
-        let dst_ipv4_addr: Ipv4Addr = remote.ip().clone();
+        let dst_ipv4_addr: Ipv4Addr = *remote.ip();
         let mut tcp_hdr: TcpHeader = TcpHeader::new(self.local.port(), remote.port());
         tcp_hdr.rst = true;
         tcp_hdr.seq_num = seq_num;
@@ -342,7 +342,7 @@ impl SharedPassiveSocket {
         info!("Advertising window scale: {}", self.tcp_config.get_window_scale());
 
         debug!("Sending SYN+ACK: {:?}", tcp_hdr);
-        let dst_ipv4_addr: Ipv4Addr = remote.ip().clone();
+        let dst_ipv4_addr: Ipv4Addr = *remote.ip();
         let mut pkt: DemiBuffer = DemiBuffer::new_with_headroom(0, MAX_HEADER_SIZE as u16);
         tcp_hdr.serialize_and_attach(
             &mut pkt,

--- a/src/inetstack/protocols/layer4/tcp/peer.rs
+++ b/src/inetstack/protocols/layer4/tcp/peer.rs
@@ -81,7 +81,7 @@ impl SharedTcpPeer {
             self.runtime.clone(),
             self.layer3_endpoint.clone(),
             self.tcp_config.clone(),
-            self.default_socket_options.clone(),
+            self.default_socket_options,
         ))
     }
 
@@ -153,7 +153,7 @@ impl SharedTcpPeer {
         // Should we remove the passive entry for the local address if the socket was previously bound?
         if self
             .addresses
-            .insert(SocketId::Active(local, remote.clone()), socket.clone())
+            .insert(SocketId::Active(local, remote), socket.clone())
             .is_some()
         {
             // We fail here because the ephemeral port allocator should not allocate the same port more than once.
@@ -162,7 +162,7 @@ impl SharedTcpPeer {
         let local_isn: SeqNumber = self.isn_generator.generate(&local, &remote);
         // Wait for connect to complete.
         if let Err(e) = socket.connect(local, remote, local_isn).await {
-            self.addresses.remove(&SocketId::Active(local, remote.clone()));
+            self.addresses.remove(&SocketId::Active(local, remote));
             Err(e)
         } else {
             Ok(())

--- a/src/inetstack/protocols/layer4/tcp/socket.rs
+++ b/src/inetstack/protocols/layer4/tcp/socket.rs
@@ -150,7 +150,7 @@ impl SharedTcpSocket {
             self.runtime.clone(),
             self.layer3_endpoint.clone(),
             self.tcp_config.clone(),
-            self.socket_options.clone(),
+            self.socket_options,
             nonce,
         )?;
         self.state = SocketState::Listening(passive_socket);
@@ -170,7 +170,7 @@ impl SharedTcpSocket {
             self.runtime.clone(),
             self.layer3_endpoint.clone(),
             self.tcp_config.clone(),
-            self.socket_options.clone(),
+            self.socket_options,
         );
         Ok(new_queue)
     }
@@ -189,7 +189,7 @@ impl SharedTcpSocket {
             self.runtime.clone(),
             self.layer3_endpoint.clone(),
             self.tcp_config.clone(),
-            self.socket_options.clone(),
+            self.socket_options,
         )?;
         self.state = SocketState::Connecting(socket.clone());
         let new_socket = socket.connect().await?;

--- a/src/inetstack/protocols/layer4/udp/peer.rs
+++ b/src/inetstack/protocols/layer4/udp/peer.rs
@@ -76,7 +76,7 @@ impl SharedUdpPeer {
         }
 
         socket.bind(addr)?;
-        self.addresses.insert(addr.clone(), socket.clone());
+        self.addresses.insert(addr, socket.clone());
         Ok(())
     }
 

--- a/src/inetstack/protocols/layer4/udp/socket.rs
+++ b/src/inetstack/protocols/layer4/udp/socket.rs
@@ -91,7 +91,7 @@ impl SharedUdpSocket {
         udp_header.serialize_and_attach(&mut buf, &self.local_ipv4_addr, remote.ip(), self.checksum_offload);
         // Send the packet to the lower layer.
         self.layer3_endpoint
-            .transmit_udp_packet_blocking(remote.ip().clone(), buf)
+            .transmit_udp_packet_blocking(*remote.ip(), buf)
             .await
     }
 


### PR DESCRIPTION
The only reason `Copy` types implement `clone` is for generics, not for using the `clone()` method on a concrete type. So removing wherever possible.

We should be cognizant about these decisions going forward and only use `clone` for potentially expensive, explicit duplication of objects.