### PR TITLE
ci: workflows: conditional release build to speed up PR merge loop

### DIFF
--- a/.github/workflows/catnap.yml
+++ b/.github/workflows/catnap.yml
@@ -22,6 +22,7 @@ env:
   CLIENT: ${{ secrets.CATNAP_HOSTNAME_B }}
   SERVER_ADDR: 10.3.1.10
   CLIENT_ADDR: 10.3.1.11
+  SHOULD_RUN_RELEASE: ${{ github.ref_name == 'main' || github.ref_name == 'unstable' || github.ref_name == 'dev' || contains(github.head_ref, 'do-release') }}
 
 jobs:
 
@@ -75,11 +76,16 @@ jobs:
     needs: debug-pipeline
     runs-on: ubuntu-latest
     steps:
+    - name: Print if release pipeline should not run
+      if: ${{ env.SHOULD_RUN_RELEASE == 'false' }}
+      run: echo "Release pipeline skipped because branch is not main, unstable, dev, or does not contain 'do-release'."
     - name: Checkout
+      if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Setup SSH
+      if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
       shell: bash
       run: |
         mkdir -p $HOME/.ssh/
@@ -93,6 +99,7 @@ jobs:
         echo -e "\tUser ${{ secrets.USERNAME }}" >> $HOME/.ssh/config
         echo -e "\tPort ${{ secrets.PORTNUM }}" >> $HOME/.ssh/config
     - name: Run
+      if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
       run: |
         branch_name=${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}
         python3 tools/demikernel_ci.py \
@@ -107,7 +114,7 @@ jobs:
           --server-addr $SERVER_ADDR \
           --client-addr $CLIENT_ADDR
     - name: Archive Logs
-      if: always()
+      if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
       uses: actions/upload-artifact@v4
       with:
         name: catnap-release-pipeline-logs
@@ -127,19 +134,26 @@ jobs:
       pull-requests: write
       security-events: write
     steps:
+    - name: Print if release pipeline should not run
+      if: ${{ env.SHOULD_RUN_RELEASE == 'false' }}
+      run: echo "Release pipeline skipped because branch is not main, unstable, dev, or does not contain 'do-release'."
     - name: Checkout
+      if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Download Release Pipeline Logs
+      if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
       uses: actions/download-artifact@v4
       with:
         name: catnap-release-pipeline-logs
         path: ./catnap_release_pipeline_logs
     - name: Setup FlameGraph Repository
+      if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
       run: |
         git clone https://github.com/brendangregg/FlameGraph.git /tmp/FlameGraph
     - name: Parse Statistics
+      if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
       id: parse-stats
       run: |
         branch_name=${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}
@@ -149,6 +163,7 @@ jobs:
           --libos $LIBOS \
           --log-dir ./catnap_release_pipeline_logs)
     - name: Archive Performance Data
+      if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
       uses: actions/upload-artifact@v4
       with:
         name: performance-data

--- a/.github/workflows/catnapw.yml
+++ b/.github/workflows/catnapw.yml
@@ -22,6 +22,7 @@ env:
   CLIENT: ${{ secrets.CATNAPW_HOSTNAME_B }}
   SERVER_ADDR: 10.3.1.60
   CLIENT_ADDR: 10.3.1.61
+  SHOULD_RUN_RELEASE: ${{ github.ref_name == 'main' || github.ref_name == 'unstable' || github.ref_name == 'dev' || contains(github.head_ref, 'do-release') }}
 
 jobs:
 
@@ -76,11 +77,16 @@ jobs:
     needs: debug-pipeline
     runs-on: ubuntu-latest
     steps:
+    - name: Print if release pipeline should not run
+      if: ${{ env.SHOULD_RUN_RELEASE == 'false' }}
+      run: echo "Release pipeline skipped because branch is not main, unstable, dev, or does not contain 'do-release'."
     - name: Checkout
+      if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Setup SSH
+      if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
       shell: bash
       run: |
         mkdir -p $HOME/.ssh/
@@ -94,6 +100,7 @@ jobs:
         echo -e "\tUser ${{ secrets.USERNAME }}" >> $HOME/.ssh/config
         echo -e "\tPort ${{ secrets.PORTNUM }}" >> $HOME/.ssh/config
     - name: Run
+      if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
       run: |
         branch_name=${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}
         python3 tools/demikernel_ci.py \
@@ -109,7 +116,7 @@ jobs:
           --server-addr $SERVER_ADDR \
           --client-addr $CLIENT_ADDR
     - name: Archive Logs
-      if: always()
+      if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
       uses: actions/upload-artifact@v4
       with:
         name: catnapw-release-pipeline-logs
@@ -169,11 +176,16 @@ jobs:
     needs: catpowder-debug-pipeline
     runs-on: ubuntu-latest
     steps:
+    - name: Print if release pipeline should not run
+      if: ${{ env.SHOULD_RUN_RELEASE == 'false' }}
+      run: echo "Release pipeline skipped because branch is not main, unstable, dev, or does not contain 'do-release'."
     - name: Checkout
+      if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Setup SSH
+      if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
       shell: bash
       run: |
         mkdir -p $HOME/.ssh/
@@ -187,6 +199,7 @@ jobs:
         echo -e "\tUser ${{ secrets.USERNAME }}" >> $HOME/.ssh/config
         echo -e "\tPort ${{ secrets.PORTNUM }}" >> $HOME/.ssh/config
     - name: Run
+      if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
       run: |
         branch_name=${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}
         python3 tools/demikernel_ci.py \
@@ -202,7 +215,7 @@ jobs:
           --server-addr $SERVER_ADDR \
           --client-addr $CLIENT_ADDR
     - name: Archive Logs
-      if: always()
+      if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
       uses: actions/upload-artifact@v4
       with:
         name: catpowder-release-pipeline-logs

--- a/.github/workflows/catnip.yml
+++ b/.github/workflows/catnip.yml
@@ -22,6 +22,7 @@ env:
   CLIENT: ${{ secrets.CATNIP_HOSTNAME_B }}
   SERVER_ADDR: 10.3.1.50
   CLIENT_ADDR: 10.3.1.51
+  SHOULD_RUN_RELEASE: ${{ github.ref_name == 'main' || github.ref_name == 'unstable' || github.ref_name == 'dev' || contains(github.head_ref, 'do-release') }}
 
 jobs:
 
@@ -97,11 +98,16 @@ jobs:
     needs: debug-pipeline
     runs-on: ubuntu-latest
     steps:
+    - name: Print if release pipeline should not run
+      if: ${{ env.SHOULD_RUN_RELEASE == 'false' }}
+      run: echo "Release pipeline skipped because branch is not main, unstable, dev, or does not contain 'do-release'."
     - name: Checkout
+      if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Setup SSH
+      if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
       shell: bash
       run: |
         mkdir -p $HOME/.ssh/
@@ -115,6 +121,7 @@ jobs:
         echo -e "\tUser ${{ secrets.USERNAME }}" >> $HOME/.ssh/config
         echo -e "\tPort ${{ secrets.PORTNUM }}" >> $HOME/.ssh/config
     - name: Bootstrap VMs
+      if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
       shell: bash
       run: |
         echo "Running azure-init-mlx.sh on SERVER"
@@ -137,6 +144,7 @@ jobs:
         ssh $CLIENT "sudo ip -br addr show dev eth1 | grep -q ' UP ' && \
                      sudo ip addr flush dev eth1"
     - name: Run
+      if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
       run: |
         branch_name=${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}
         python3 tools/demikernel_ci.py \
@@ -151,7 +159,7 @@ jobs:
           --server-addr $SERVER_ADDR \
           --client-addr $CLIENT_ADDR
     - name: Archive Logs
-      if: always()
+      if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
       uses: actions/upload-artifact@v4
       with:
         name: catnip-release-pipeline-logs
@@ -171,19 +179,26 @@ jobs:
       pull-requests: write
       security-events: write
     steps:
+    - name: Print if release pipeline should not run
+      if: ${{ env.SHOULD_RUN_RELEASE == 'false' }}
+      run: echo "Release pipeline skipped because branch is not main, unstable, dev, or does not contain 'do-release'."
     - name: Checkout
+      if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Download Release Pipeline Logs
+      if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
       uses: actions/download-artifact@v4
       with:
         name: catnip-release-pipeline-logs
         path: ./catnip_release_pipeline_logs
     - name: Setup FlameGraph Repository
+      if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
       run: |
         git clone https://github.com/brendangregg/FlameGraph.git /tmp/FlameGraph
     - name: Parse Statistics
+      if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
       id: parse-stats
       run: |
         branch_name=${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}
@@ -193,6 +208,7 @@ jobs:
           --libos $LIBOS \
           --log-dir ./catnip_release_pipeline_logs)
     - name: Archive Performance Data
+      if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
       uses: actions/upload-artifact@v4
       with:
         name: performance-data

--- a/.github/workflows/catpowder.yml
+++ b/.github/workflows/catpowder.yml
@@ -22,6 +22,7 @@ env:
   CLIENT: ${{ secrets.CATPOWDER_HOSTNAME_B }}
   SERVER_ADDR: 10.3.1.20
   CLIENT_ADDR: 10.3.1.21
+  SHOULD_RUN_RELEASE: ${{ github.ref_name == 'main' || github.ref_name == 'unstable' || github.ref_name == 'dev' || contains(github.head_ref, 'do-release') }}
 
 jobs:
 
@@ -93,11 +94,16 @@ jobs:
     needs: debug-pipeline
     runs-on: ubuntu-latest
     steps:
+    - name: Print if release pipeline should not run
+      if: ${{ env.SHOULD_RUN_RELEASE == 'false' }}
+      run: echo "Release pipeline skipped because branch is not main, unstable, dev, or does not contain 'do-release'."
     - name: Checkout
+      if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Setup SSH
+      if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
       shell: bash
       run: |
         mkdir -p $HOME/.ssh/
@@ -111,6 +117,7 @@ jobs:
         echo -e "\tUser ${{ secrets.USERNAME }}" >> $HOME/.ssh/config
         echo -e "\tPort ${{ secrets.PORTNUM }}" >> $HOME/.ssh/config
     - name: Bootstrap VMs
+      if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
       shell: bash
       run: |
         echo "Running iptables rule on SERVER"
@@ -129,6 +136,7 @@ jobs:
         ssh $CLIENT "sudo ip -br addr show dev eth1 | grep -q ' UP ' && \
                      sudo ip addr flush dev eth1"
     - name: Run
+      if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
       run: |
         branch_name=${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}
         python3 tools/demikernel_ci.py \
@@ -143,7 +151,7 @@ jobs:
           --server-addr $SERVER_ADDR \
           --client-addr $CLIENT_ADDR
     - name: Archive Logs
-      if: always()
+      if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
       uses: actions/upload-artifact@v4
       with:
         name: catpowder-release-pipeline-logs
@@ -163,19 +171,26 @@ jobs:
       pull-requests: write
       security-events: write
     steps:
+    - name: Print if release pipeline should not run
+      if: ${{ env.SHOULD_RUN_RELEASE == 'false' }}
+      run: echo "Release pipeline skipped because branch is not main, unstable, dev, or does not contain 'do-release'."
     - name: Checkout
+      if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Download Release Pipeline Logs
+      if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
       uses: actions/download-artifact@v4
       with:
         name: catpowder-release-pipeline-logs
         path: ./catpowder_release_pipeline_logs
     - name: Setup FlameGraph Repository
+      if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
       run: |
         git clone https://github.com/brendangregg/FlameGraph.git /tmp/FlameGraph
     - name: Parse Statistics
+      if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
       id: parse-stats
       run: |
         branch_name=${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}
@@ -185,6 +200,7 @@ jobs:
           --libos $LIBOS \
           --log-dir ./catpowder_release_pipeline_logs)
     - name: Archive Performance Data
+      if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
       uses: actions/upload-artifact@v4
       with:
         name: performance-data


### PR DESCRIPTION
We decided to run only the debug build for pull request branches. The debug + release build will run when we merge pull requests into the dev branch. This will save a lot of PR loop time!

The debug + release build will run when changes are pushed to the 'unstable' and 'main' branches as well.

Given that we have hardly ever encountered issues just in the release-specific builds, it's unlikely that once the PR branch succeeds dev CI runs may fail. Of course, it may still happen, but quite low possibility.

Finally, there is a way to run the release build for PR branches as well by ending the PR branch name with "do-release" text.