### PR TITLE
inetstack: protocols: use for loop instead of complex while loops

### DIFF
--- a/src/inetstack/protocols/layer4/tcp/header.rs
+++ b/src/inetstack/protocols/layer4/tcp/header.rs
@@ -490,7 +490,7 @@ fn tcp_checksum(src_ipv4_addr: &Ipv4Addr, dst_ipv4_addr: &Ipv4Addr, header: &[u8
 
     // Finally, checksum the data itself.
     let mut chunks_iter: ChunksExact<u8> = data.chunks_exact(2);
-    while let Some(chunk) = chunks_iter.next() {
+    for chunk in chunks_iter.by_ref() {
         state += u16::from_be_bytes([chunk[0], chunk[1]]) as u32;
     }
     // Since the data may have an odd number of bytes, pad the last byte with zero if necessary.

--- a/src/inetstack/protocols/layer4/udp/header.rs
+++ b/src/inetstack/protocols/layer4/udp/header.rs
@@ -173,7 +173,7 @@ impl UdpHeader {
 
         // Payload.
         let mut chunks_iter: ChunksExact<u8> = data.chunks_exact(2);
-        while let Some(chunk) = chunks_iter.next() {
+        for chunk in chunks_iter.by_ref() {
             state += u16::from_be_bytes([chunk[0], chunk[1]]) as u32;
         }
         // Pad with zeros with payload has an odd number of bytes.

--- a/src/inetstack/protocols/mod.rs
+++ b/src/inetstack/protocols/mod.rs
@@ -44,7 +44,7 @@ pub fn compute_generic_checksum(buf: &[u8], start: Option<u32>) -> u32 {
     };
 
     let mut chunks_iter: ChunksExact<u8> = buf.chunks_exact(2);
-    while let Some(chunk) = chunks_iter.next() {
+    for chunk in chunks_iter.by_ref() {
         state += u16::from_be_bytes([chunk[0], chunk[1]]) as u32;
     }
 


### PR DESCRIPTION
A simple for loop is faster to read, and conveys the intent better.