### PR TITLE
runtime: memory: use is_null instead of comparing with ptr::null_mut

### DIFF
--- a/src/runtime/memory/mod.rs
+++ b/src/runtime/memory/mod.rs
@@ -14,10 +14,7 @@ use crate::runtime::{
     types::{demi_sgarray_t, demi_sgaseg_t},
 };
 use ::libc::c_void;
-use ::std::{
-    mem,
-    ptr::{self, NonNull},
-};
+use ::std::{mem, ptr::NonNull};
 
 //======================================================================================================================
 // Exports
@@ -84,7 +81,7 @@ pub fn sgafree(sga: demi_sgarray_t) -> Result<(), Fail> {
         return Err(Fail::new(libc::EINVAL, "demi_sgarray_t has invalid segment count"));
     }
 
-    if sga.sga_buf == ptr::null_mut() {
+    if sga.sga_buf.is_null() {
         return Err(Fail::new(libc::EINVAL, "demi_sgarray_t has invalid DemiBuffer token"));
     }
 
@@ -107,7 +104,7 @@ pub fn clone_sgarray(sga: &demi_sgarray_t) -> Result<DemiBuffer, Fail> {
         return Err(Fail::new(libc::EINVAL, "demi_sgarray_t has invalid segment count"));
     }
 
-    if sga.sga_buf == ptr::null_mut() {
+    if sga.sga_buf.is_null() {
         return Err(Fail::new(libc::EINVAL, "demi_sgarray_t has invalid DemiBuffer token"));
     }
 

--- a/tools/demikernel_ci.py
+++ b/tools/demikernel_ci.py
@@ -73,8 +73,9 @@ def run_pipeline(
     if test_integration:
         if status["checkout"] and status["compile"]:
             if libos in ["catnap", "catnip", "catpowder"]:
-                status["integration_tests"] = factory.integration_test(test_name="tcp-tests").execute()
-                status["integration_tests"] = factory.integration_test(test_name="udp-tests").execute()
+                status["integration_tests"] = True
+                status["integration_tests"] &= factory.integration_test(test_name="tcp-tests").execute()
+                status["integration_tests"] &= factory.integration_test(test_name="udp-tests").execute()
 
     # STEP 5: Run system tests.
     if test_system and config["platform"]:


### PR DESCRIPTION
This shorter convention is more readable and terse.