### PR TITLE
catnapw: cleanup: patch series for code improvements

### DIFF
--- a/src/catnap/win/socket.rs
+++ b/src/catnap/win/socket.rs
@@ -243,7 +243,7 @@ impl Socket {
         if unsafe { shutdown(self.s, SD_BOTH) } == 0 {
             Ok(())
         } else {
-            Err(expect_last_wsa_error().into())
+            Err(expect_last_wsa_error())
         }
     }
 
@@ -255,7 +255,7 @@ impl Socket {
         if result == 0 {
             Ok(())
         } else {
-            Err(expect_last_wsa_error().into())
+            Err(expect_last_wsa_error())
         }
     }
 
@@ -265,7 +265,7 @@ impl Socket {
         if unsafe { listen(self.s, backlog) } == 0 {
             Ok(())
         } else {
-            Err(expect_last_wsa_error().into())
+            Err(expect_last_wsa_error())
         }
     }
 

--- a/src/catnap/win/socket.rs
+++ b/src/catnap/win/socket.rs
@@ -328,9 +328,7 @@ impl Socket {
         iocp: &IoCompletionPort<SocketOpState>,
         result: OverlappedResult,
     ) -> Result<(Socket, SocketAddr, SocketAddr), Fail> {
-        if let Err(err) = result.ok() {
-            return Err(err);
-        }
+        result.ok()?;
 
         let accept_result: &mut AcceptState = match state.get_mut() {
             SocketOpState::Accept(ref mut accept_result) => accept_result,
@@ -432,9 +430,7 @@ impl Socket {
 
     /// Finish a connect operation started by start_connect.
     pub fn finish_connect(&self, result: OverlappedResult) -> Result<(), Fail> {
-        if let Err(err) = result.ok() {
-            return Err(err);
-        }
+        result.ok()?;
 
         // Required to update user mode attributes of the socket after ConnectEx completes.
         unsafe { WinsockRuntime::do_setsockopt::<()>(self.s, SOL_SOCKET, SO_UPDATE_CONNECT_CONTEXT, None) }
@@ -488,9 +484,7 @@ impl Socket {
         // flags seem (determined experimentally) to be derived from the NTSTATUS of the resulting overlapped. The
         // WSA/GetOverlappedResult API should be avoided, as it seems to incur some synchronization overhead which is
         // not useful for this implementation.
-        if let Err(err) = result.ok() {
-            return Err(err);
-        }
+        result.ok()?;
 
         let pop_state: &mut PopState = match state.get_mut() {
             SocketOpState::Pop(ref mut pop_state) => pop_state,

--- a/src/catnap/win/socket.rs
+++ b/src/catnap/win/socket.rs
@@ -312,10 +312,10 @@ impl Socket {
         }
         .as_bool();
 
-        get_overlapped_api_result(success).and_then(|_| {
+        get_overlapped_api_result(success).map(|_| {
             // Safety: the socket does not require structural pinning.
             accept_result.new_socket = Some(new_socket);
-            Ok(())
+            ()
         })
     }
 

--- a/src/catnap/win/socket.rs
+++ b/src/catnap/win/socket.rs
@@ -172,7 +172,7 @@ impl Socket {
         if keepalive_params.onoff != 0 {
             // Safety: SIO_KEEPALIVE_VALS uses tcp_keepalive structure as ABI.
             unsafe {
-                WinsockRuntime::do_ioctl::<tcp_keepalive, ()>(self.s, SIO_KEEPALIVE_VALS, Some(&keepalive_params), None)
+                WinsockRuntime::do_ioctl::<tcp_keepalive, ()>(self.s, SIO_KEEPALIVE_VALS, Some(keepalive_params), None)
             }?;
         }
 

--- a/src/catnap/win/winsock.rs
+++ b/src/catnap/win/winsock.rs
@@ -223,12 +223,8 @@ impl WinsockRuntime {
 
     /// Implementation of setsockopt.
     pub(super) unsafe fn do_setsockopt<'a, T>(s: SOCKET, level: i32, opt: i32, val: Option<&'a T>) -> Result<(), Fail> {
-        let val: Option<&'a [u8]> = match val {
-            Some(val) => {
-                Some(unsafe { std::slice::from_raw_parts((val as *const T).cast(), std::mem::size_of::<T>()) })
-            },
-            None => None,
-        };
+        let val: Option<&'a [u8]> =
+            val.map(|val| unsafe { std::slice::from_raw_parts((val as *const T).cast(), std::mem::size_of::<T>()) });
 
         if unsafe { setsockopt(s, level, opt, val) } == 0 {
             Ok(())
@@ -330,9 +326,9 @@ impl WinsockRuntime {
 
         self.get_or_init_extensions(s)
             .and_then(|extensions: Rc<SocketExtensions>| Socket::new(s, protocol, options, extensions, iocp))
-            .or_else(|err: Fail| {
+            .map_err(|err: Fail| {
                 unsafe { closesocket(s) };
-                Err(err)
+                err
             })
     }
 }

--- a/src/catnap/win/winsock.rs
+++ b/src/catnap/win/winsock.rs
@@ -236,11 +236,10 @@ impl WinsockRuntime {
     /// Set a socket option (via setsockopt) from a structured value `val`.
     /// Safety: the requested socket option must agree with the ABI of T.
     #[allow(unused)]
-    pub unsafe fn setsockopt<'a, T>(&self, s: SOCKET, level: i32, opt: i32, val: Option<&'a T>) -> Result<(), Fail> {
+    pub unsafe fn setsockopt<T>(&self, s: SOCKET, level: i32, opt: i32, val: Option<&T>) -> Result<(), Fail> {
         Self::do_setsockopt(s, level, opt, val)
     }
 
-    /// Implementation of getsockopt.
     pub(super) unsafe fn do_getsockopt<T>(s: SOCKET, level: i32, optname: i32) -> Result<T, Fail> {
         let mut out: MaybeUninit<T> = MaybeUninit::zeroed();
         let optval: PSTR = PSTR::from_raw(out.as_mut_ptr().cast());

--- a/src/catnap/win/winsock.rs
+++ b/src/catnap/win/winsock.rs
@@ -281,10 +281,8 @@ impl WinsockRuntime {
     fn get_or_init_extensions(&mut self, s: SOCKET) -> Result<Rc<SocketExtensions>, Fail> {
         let protocol: WSAPROTOCOL_INFOW = unsafe { self.getsockopt(s, SOL_SOCKET, SO_PROTOCOL_INFOW) }?;
 
-        let extensions: &mut Weak<SocketExtensions> = self
-            .extensions_by_provider
-            .entry(protocol.ProviderId)
-            .or_insert(Weak::default());
+        let extensions: &mut Weak<SocketExtensions> =
+            self.extensions_by_provider.entry(protocol.ProviderId).or_default();
         if let Some(extensions) = extensions.upgrade() {
             return Ok(extensions);
         }
@@ -295,7 +293,6 @@ impl WinsockRuntime {
         Ok(new_extensions)
     }
 
-    /// Create a raw Winsock socket.
     pub(super) unsafe fn raw_socket(
         domain: libc::c_int,
         typ: libc::c_int,


### PR DESCRIPTION
This is a series of patches with serveral code improvements targeting CatnapW. It will be easier to walk through the list of commits because each commit is self-contained, groups similar changes together and has reasoning behind the changes.