### PR TITLE
catnapw: use familiar `map` instead of alternatives wherever possible

### DIFF
--- a/src/catnap/win/socket.rs
+++ b/src/catnap/win/socket.rs
@@ -312,10 +312,10 @@ impl Socket {
         }
         .as_bool();
 
-        get_overlapped_api_result(success).and_then(|_| {
+        get_overlapped_api_result(success).map(|_| {
             // Safety: the socket does not require structural pinning.
             accept_result.new_socket = Some(new_socket);
-            Ok(())
+            ()
         })
     }
 

--- a/src/catnap/win/winsock.rs
+++ b/src/catnap/win/winsock.rs
@@ -223,12 +223,8 @@ impl WinsockRuntime {
 
     /// Implementation of setsockopt.
     pub(super) unsafe fn do_setsockopt<'a, T>(s: SOCKET, level: i32, opt: i32, val: Option<&'a T>) -> Result<(), Fail> {
-        let val: Option<&'a [u8]> = match val {
-            Some(val) => {
-                Some(unsafe { std::slice::from_raw_parts((val as *const T).cast(), std::mem::size_of::<T>()) })
-            },
-            None => None,
-        };
+        let val: Option<&'a [u8]> =
+            val.map(|val| unsafe { std::slice::from_raw_parts((val as *const T).cast(), std::mem::size_of::<T>()) });
 
         if unsafe { setsockopt(s, level, opt, val) } == 0 {
             Ok(())
@@ -326,9 +322,9 @@ impl WinsockRuntime {
 
         self.get_or_init_extensions(s)
             .and_then(|extensions: Rc<SocketExtensions>| Socket::new(s, protocol, options, extensions, iocp))
-            .or_else(|err: Fail| {
+            .map_err(|err: Fail| {
                 unsafe { closesocket(s) };
-                Err(err)
+                err
             })
     }
 }


### PR DESCRIPTION
Other mechanisms that achieve the same functionality increase variation in code and causes slow downs for the reader. So using `map` wherever possible.