### PR TITLE
temp: ci: continue to upload logs in case of failure

### DIFF
--- a/.github/workflows/catnap.yml
+++ b/.github/workflows/catnap.yml
@@ -114,7 +114,8 @@ jobs:
           --server-addr $SERVER_ADDR \
           --client-addr $CLIENT_ADDR
     - name: Archive Logs
-      if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
+      if: always()
+      continue-on-error: true
       uses: actions/upload-artifact@v4
       with:
         name: catnap-release-pipeline-logs

--- a/.github/workflows/catnapw.yml
+++ b/.github/workflows/catnapw.yml
@@ -116,7 +116,8 @@ jobs:
           --server-addr $SERVER_ADDR \
           --client-addr $CLIENT_ADDR
     - name: Archive Logs
-      if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
+      if: always()
+      continue-on-error: true
       uses: actions/upload-artifact@v4
       with:
         name: catnapw-release-pipeline-logs
@@ -215,7 +216,8 @@ jobs:
           --server-addr $SERVER_ADDR \
           --client-addr $CLIENT_ADDR
     - name: Archive Logs
-      if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
+      if: always()
+      continue-on-error: true
       uses: actions/upload-artifact@v4
       with:
         name: catpowder-release-pipeline-logs

--- a/.github/workflows/catnip.yml
+++ b/.github/workflows/catnip.yml
@@ -159,7 +159,8 @@ jobs:
           --server-addr $SERVER_ADDR \
           --client-addr $CLIENT_ADDR
     - name: Archive Logs
-      if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
+      if: always()
+      continue-on-error: true
       uses: actions/upload-artifact@v4
       with:
         name: catnip-release-pipeline-logs

--- a/.github/workflows/catpowder.yml
+++ b/.github/workflows/catpowder.yml
@@ -151,7 +151,8 @@ jobs:
           --server-addr $SERVER_ADDR \
           --client-addr $CLIENT_ADDR
     - name: Archive Logs
-      if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
+      if: always()
+      continue-on-error: true
       uses: actions/upload-artifact@v4
       with:
         name: catpowder-release-pipeline-logs


### PR DESCRIPTION
Now that release ci runs are conditional, the log archival must run even in case of errors.