### PR TITLE
ci: improvements along with a bug fix

### DIFF
--- a/.github/workflows/catnap.yml
+++ b/.github/workflows/catnap.yml
@@ -114,7 +114,8 @@ jobs:
           --server-addr $SERVER_ADDR \
           --client-addr $CLIENT_ADDR
     - name: Archive Logs
-      if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
+      if: always()
+      continue-on-error: true
       uses: actions/upload-artifact@v4
       with:
         name: catnap-release-pipeline-logs

--- a/.github/workflows/catnapw.yml
+++ b/.github/workflows/catnapw.yml
@@ -116,7 +116,8 @@ jobs:
           --server-addr $SERVER_ADDR \
           --client-addr $CLIENT_ADDR
     - name: Archive Logs
-      if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
+      if: always()
+      continue-on-error: true
       uses: actions/upload-artifact@v4
       with:
         name: catnapw-release-pipeline-logs
@@ -215,7 +216,8 @@ jobs:
           --server-addr $SERVER_ADDR \
           --client-addr $CLIENT_ADDR
     - name: Archive Logs
-      if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
+      if: always()
+      continue-on-error: true
       uses: actions/upload-artifact@v4
       with:
         name: catpowder-release-pipeline-logs

--- a/.github/workflows/catnapw.yml
+++ b/.github/workflows/catnapw.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-name: Catnap + Catpowder (Windows Kernel and XDP)
+name: CatnapW + Catpowder (Windows Kernel and XDP)
 
 concurrency:
   group: catnapw
@@ -27,7 +27,7 @@ env:
 jobs:
 
   debug-pipeline:
-    name: Catnap Debug Pipeline (Windows Kernel)
+    name: CatnapW Debug Pipeline (Windows Kernel)
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
@@ -73,7 +73,7 @@ jobs:
           **/*.stderr.txt
 
   release-pipeline:
-    name: Catnap Release Pipeline (Windows Kernel)
+    name: CatnapW Release Pipeline (Windows Kernel)
     needs: debug-pipeline
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/catnip.yml
+++ b/.github/workflows/catnip.yml
@@ -159,7 +159,8 @@ jobs:
           --server-addr $SERVER_ADDR \
           --client-addr $CLIENT_ADDR
     - name: Archive Logs
-      if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
+      if: always()
+      continue-on-error: true
       uses: actions/upload-artifact@v4
       with:
         name: catnip-release-pipeline-logs

--- a/.github/workflows/catpowder.yml
+++ b/.github/workflows/catpowder.yml
@@ -151,7 +151,8 @@ jobs:
           --server-addr $SERVER_ADDR \
           --client-addr $CLIENT_ADDR
     - name: Archive Logs
-      if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
+      if: always()
+      continue-on-error: true
       uses: actions/upload-artifact@v4
       with:
         name: catpowder-release-pipeline-logs

--- a/tools/demikernel_ci.py
+++ b/tools/demikernel_ci.py
@@ -73,8 +73,9 @@ def run_pipeline(
     if test_integration:
         if status["checkout"] and status["compile"]:
             if libos in ["catnap", "catnip", "catpowder"]:
-                status["integration_tests"] = factory.integration_test(test_name="tcp-tests").execute()
-                status["integration_tests"] = factory.integration_test(test_name="udp-tests").execute()
+                status["integration_tests"] = True
+                status["integration_tests"] &= factory.integration_test(test_name="tcp-tests").execute()
+                status["integration_tests"] &= factory.integration_test(test_name="udp-tests").execute()
 
     # STEP 5: Run system tests.
     if test_system and config["platform"]:


### PR DESCRIPTION
```
- ci: continue to upload logs in case of failure

Now that release ci runs are conditional, the log archival must run even
in case of errors.
```
```
- ci: rename Windows catnap workflow to catnapw

This makes it easier to identify what's running in the CI.
```
```
- ci: fix integration test status update

The integration tests results status was getting overriden here. So the
failures for the tcp integration tests were always getting masked by the
udp tests.
```