### PR TITLE
profiler: fixing scoping issue with async profiling

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,7 +203,7 @@ macro_rules! expect_ok {
 macro_rules! timer {
     ($name:expr) => {
         #[cfg(feature = "profiler")]
-        let _guard = $crate::perftools::profiler::PROFILER.with(|p| p.clone().sync_scope($name));
+        let _guard = $crate::perftools::profiler::PROFILER.with(|p| p.clone().create_and_enter_sync_scope($name));
     };
 }
 
@@ -213,7 +213,7 @@ macro_rules! async_timer {
     ($name:expr, $future:expr) => {
         async {
             std::pin::pin!($crate::perftools::profiler::AsyncScope::new(
-                $crate::perftools::profiler::PROFILER.with(|p| p.clone().get_or_create_scope($name)),
+                $name,
                 std::pin::pin!($future).as_mut()
             ))
             .await
@@ -233,7 +233,7 @@ macro_rules! async_timer {
 #[macro_export]
 macro_rules! coroutine_timer {
     ($name:expr, $future:expr) => {
-        Box::pin($crate::perftools::profiler::SharedProfiler::coroutine_scope($name, $future).fuse())
+        Box::pin($crate::perftools::profiler::coroutine_scope($name, $future).fuse())
     };
 }
 

--- a/src/perftools/profiler/mod.rs
+++ b/src/perftools/profiler/mod.rs
@@ -1,7 +1,11 @@
 // Copyright(c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-//! This module provides a small performance profiler for the Demikernel libOSes.
+//! This module provides a small performance profiler for the Demikernel libOSes. It supports two kinds of profilers:
+//! ones for synchronous blocks of code and ones for asynchronous blocks of code. For synchronous blocks, we use a
+//! [SyncScopeGuard] to automatically scope the timer. The profiler creates the [SyncScopeGuard] when the timer starts
+//! and the timer stops when the [SyncScopeGuard] goes out of scope. For asynchronous blocks, we simply create a
+//! [SharedScope] and time the number of cycles for each poll. We do not use a guard for scoping asynchronous blocks.
 
 //======================================================================================================================
 // Exports
@@ -17,7 +21,7 @@ mod tests;
 //======================================================================================================================
 
 use crate::{
-    perftools::profiler::scope::{Guard, SharedScope},
+    perftools::profiler::scope::{SharedScope, SyncScopeGuard},
     runtime::{types::demi_callback_t, SharedObject},
 };
 use ::futures::future::FusedFuture;
@@ -34,7 +38,7 @@ use ::std::{
 //======================================================================================================================
 
 thread_local!(
-    pub static PROFILER: SharedProfiler = SharedProfiler::new()
+    pub static PROFILER: SharedProfiler = SharedProfiler::default();
 );
 
 /// A `Profiler` stores the scope tree and keeps track of the currently active scope. Note that there is a global
@@ -42,7 +46,8 @@ thread_local!(
 /// create an instance of `Profiler`.
 pub struct Profiler {
     root_scopes: Vec<SharedScope>,
-    current_scope: Option<SharedScope>,
+    current_sync_scope: Option<SharedScope>,
+    current_async_scope: Option<SharedScope>,
     perf_callback: Option<demi_callback_t>,
 }
 
@@ -53,13 +58,6 @@ pub struct SharedProfiler(SharedObject<Profiler>);
 // Associated Functions
 //======================================================================================================================
 
-/// Print profiling scope tree. Percentages represent the amount of time taken relative to the parent node. Frequencies
-/// are computed with respect to the total amount of time spent in root nodes. Thus, if you have multiple root nodes
-/// and they do not cover all code that runs in your program, the printed frequencies will be overestimated.
-pub fn write<W: io::Write>(out: &mut W) -> io::Result<()> {
-    PROFILER.with(|p| p.write(out))
-}
-
 pub fn reset() {
     PROFILER.with(|p| p.clone().reset());
 }
@@ -68,97 +66,13 @@ pub fn set_callback(perf_callback: demi_callback_t) {
     PROFILER.with(|p| p.clone().set_callback(perf_callback));
 }
 
-impl SharedProfiler {
-    pub fn new() -> SharedProfiler {
-        Self(SharedObject::new(Profiler::new()))
-    }
-
-    /// Create a special async scopes that is rooted because it does not run under other scopes.
-    #[inline]
-    pub async fn coroutine_scope<F: FusedFuture>(name: &'static str, mut coroutine: Pin<Box<F>>) -> F::Output {
-        AsyncScope::new(
-            PROFILER.with(|p| p.clone().get_or_create_root_scope(name)),
-            coroutine.as_mut(),
-        )
-        .await
-    }
+/// Create a special async scopes that is rooted because it does not run under other scopes.
+#[inline]
+pub async fn coroutine_scope<F: FusedFuture>(name: &'static str, mut coroutine: Pin<Box<F>>) -> F::Output {
+    AsyncScope::new(name, coroutine.as_mut()).await
 }
 
 impl Profiler {
-    fn new() -> Profiler {
-        Self {
-            root_scopes: Vec::new(),
-            current_scope: None,
-            perf_callback: None,
-        }
-    }
-
-    pub fn set_callback(&mut self, perf_callback: demi_callback_t) {
-        self.perf_callback = Some(perf_callback)
-    }
-
-    /// Create and enter a syncronous scope. Returns a [`Guard`](struct.Guard.html) that should be dropped upon
-    /// leaving the scope. Usually, this method will be called by the [`profile`](macro.profile.html) macro,
-    /// so it does not need to be used directly.
-    #[inline]
-    pub fn sync_scope(&mut self, name: &'static str) -> Guard {
-        let scope = self.get_or_create_scope(name);
-        self.enter_scope(&scope)
-    }
-
-    fn get_or_create_root_scope(&mut self, name: &'static str) -> SharedScope {
-        let existing_root_scope = self.root_scopes.iter().find(|s| s.name == name).cloned();
-
-        existing_root_scope.unwrap_or_else(|| {
-            let new_scope: SharedScope = SharedScope::new(name, None, self.perf_callback);
-            self.root_scopes.push(new_scope.clone());
-            new_scope
-        })
-    }
-
-    pub fn get_or_create_scope(&mut self, name: &'static str) -> SharedScope {
-        match self.current_scope.as_ref() {
-            Some(current_scope) => {
-                let existing_scope: Option<SharedScope> =
-                    current_scope.children_scopes.iter().find(|s| s.name == name).cloned();
-
-                existing_scope.unwrap_or_else(|| {
-                    let new_scope: SharedScope =
-                        SharedScope::new(name, Some(current_scope.clone()), self.perf_callback);
-                    current_scope.clone().add_child_scope(new_scope.clone());
-                    new_scope
-                })
-            },
-            None => self.get_or_create_root_scope(name),
-        }
-    }
-
-    fn enter_scope(&mut self, scope: &SharedScope) -> Guard {
-        let guard = scope.enter();
-        self.current_scope = Some(scope.clone());
-        guard
-    }
-
-    fn reset(&mut self) {
-        self.root_scopes.clear();
-
-        // Note that we could now still be anywhere in the previous profiling
-        // tree, so we can not simply reset `self.current`. However, as the
-        // frame comes to an end we will eventually leave a root node, at which
-        // point `self.current` will be set to `None`.
-    }
-
-    #[inline]
-    fn leave_scope(&mut self, duration: u64) {
-        self.current_scope = if let Some(current_scope) = self.current_scope.as_ref() {
-            current_scope.clone().leave(duration);
-            current_scope.parent_scope.as_ref().cloned()
-        } else {
-            // This should not happen with proper usage.
-            unreachable!("Called perftools::profiler::leave() while not in any scope");
-        };
-    }
-
     fn write<W: io::Write>(&self, out: &mut W) -> io::Result<()> {
         let thread_id = thread::current().id();
         let ns_per_cycle = Self::measure_ns_per_cycle();
@@ -169,21 +83,11 @@ impl Profiler {
             "call_depth,thread_id,function_name,num_calls,cycles_per_call,nanoseconds_per_call,total_duration,total_duration_exclusive"
         )?;
 
-        self.write_root_scopes(out, thread_id, ns_per_cycle)?;
-
-        out.flush()
-    }
-
-    fn write_root_scopes<W: io::Write>(
-        &self,
-        out: &mut W,
-        thread_id: thread::ThreadId,
-        ns_per_cycle: f64,
-    ) -> Result<(), io::Error> {
         for s in self.root_scopes.iter() {
             s.write_recursive(out, thread_id, 0, ns_per_cycle)?;
         }
-        Ok(())
+
+        out.flush()
     }
 
     fn measure_ns_per_cycle() -> f64 {
@@ -197,6 +101,84 @@ impl Profiler {
         let in_ns: u64 = since_the_epoch.as_secs() * 1_000_000_000 + since_the_epoch.subsec_nanos() as u64;
 
         in_ns as f64 / (end_cycle - start_cycle) as f64
+    }
+}
+
+impl SharedProfiler {
+    pub fn set_callback(&mut self, perf_callback: demi_callback_t) {
+        self.perf_callback = Some(perf_callback)
+    }
+
+    fn find_or_create_new_scope(
+        scopes: &mut Vec<SharedScope>,
+        name: &'static str,
+        parent_scope: Option<SharedScope>,
+        perf_callback: Option<demi_callback_t>,
+    ) -> SharedScope {
+        match scopes.iter().find(|s| s.name == name) {
+            Some(existing_scope) => existing_scope.clone(),
+            None => {
+                let new_scope: SharedScope = SharedScope::new(name, parent_scope, perf_callback);
+                scopes.push(new_scope.clone());
+                new_scope
+            },
+        }
+    }
+
+    /// Create and enter a syncronous scope. Returns a [`Guard`](struct.Guard.html) that should be dropped upon
+    /// leaving the scope. Usually, this method will be called by the [`profile`](macro.profile.html) macro,
+    /// so it does not need to be used directly.
+    fn create_scope(&mut self, current_scope: &mut Option<SharedScope>, name: &'static str) -> SharedScope {
+        let perf_callback: Option<demi_callback_t> = self.perf_callback;
+        match current_scope {
+            Some(current_scope) => {
+                let parent_scope: Option<SharedScope> = Some(current_scope.clone());
+                Self::find_or_create_new_scope(&mut current_scope.children_scopes, name, parent_scope, perf_callback)
+            },
+            None => Self::find_or_create_new_scope(&mut self.root_scopes, name, None, perf_callback),
+        }
+    }
+
+    pub fn create_and_enter_sync_scope(&mut self, name: &'static str) -> SyncScopeGuard {
+        let mut current_scope: Option<SharedScope> = self.current_sync_scope.clone();
+        let scope = self.create_scope(&mut current_scope, name);
+        self.current_sync_scope = Some(scope.clone());
+        scope.enter_sync_scope()
+    }
+
+    #[inline]
+    fn leave_sync_scope(&mut self, duration: u64) {
+        // Note that we could now still be anywhere in the previous profiling
+        // tree, so we can not simply reset `self.current`. However, as the
+        // frame comes to an end we will eventually leave a root node, at which
+        // point `self.current` will be set to `None`.
+        self.current_sync_scope = if let Some(mut current_scope) = self.current_sync_scope.take() {
+            current_scope.add_duration(duration);
+            current_scope.parent_scope.as_ref().cloned()
+        } else {
+            // This should not happen with proper usage.
+            unreachable!("Called perftools::profiler::leave() while not in any scope");
+        };
+    }
+
+    pub fn create_and_enter_async_scope(&mut self, name: &'static str) {
+        let mut current_scope: Option<SharedScope> = self.current_async_scope.clone();
+        let scope = self.create_scope(&mut current_scope, name);
+        self.current_async_scope = Some(scope.clone());
+    }
+
+    #[inline]
+    fn leave_async_scope(&mut self, duration: u64) {
+        self.current_async_scope = if let Some(mut current_scope) = self.current_async_scope.take() {
+            current_scope.add_duration(duration);
+            current_scope.parent_scope.as_ref().cloned()
+        } else {
+            // This should not happen with proper usage.
+            unreachable!("Called perftools::profiler::leave() while not in any scope");
+        };
+    }
+    fn reset(&mut self) {
+        self.root_scopes.clear();
     }
 }
 
@@ -215,6 +197,17 @@ impl Deref for SharedProfiler {
 impl DerefMut for SharedProfiler {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
+    }
+}
+
+impl Default for SharedProfiler {
+    fn default() -> Self {
+        Self(SharedObject::new(Profiler {
+            root_scopes: Vec::new(),
+            current_sync_scope: None,
+            current_async_scope: None,
+            perf_callback: None,
+        }))
     }
 }
 

--- a/src/perftools/profiler/scope.rs
+++ b/src/perftools/profiler/scope.rs
@@ -42,13 +42,13 @@ pub struct Scope {
 pub struct SharedScope(SharedObject<Scope>);
 
 /// A guard that is created when entering a scope and dropped when leaving it.
-pub struct Guard {
+pub struct SyncScopeGuard {
     enter_time: u64,
 }
 
 /// A scope over an async block that may yield and re-enter several times.
 pub struct AsyncScope<'a, F: Future> {
-    scope: SharedScope,
+    name: &'static str,
     future: Pin<&'a mut F>,
 }
 
@@ -62,40 +62,25 @@ impl SharedScope {
         parent_scope: Option<SharedScope>,
         perf_callback: Option<demi_callback_t>,
     ) -> SharedScope {
-        Self(SharedObject::new(Scope::new(name, parent_scope, perf_callback)))
-    }
-}
-
-impl Scope {
-    pub fn new(name: &'static str, parent_scope: Option<SharedScope>, perf_callback: Option<demi_callback_t>) -> Scope {
-        Self {
+        Self(SharedObject::new(Scope {
             name,
             parent_scope,
             children_scopes: Vec::new(),
             num_calls: 0,
             duration_sum: 0,
             perf_callback,
-        }
-    }
-
-    pub fn add_child_scope(&mut self, child_scope: SharedScope) {
-        self.children_scopes.push(child_scope.clone())
-    }
-
-    #[cfg(test)]
-    pub fn get_num_calls(&self) -> usize {
-        self.num_calls
+        }))
     }
 
     /// Enter this scope. Returns a `Guard` instance that should be dropped when leaving the scope.
     #[inline]
-    pub fn enter(&self) -> Guard {
-        Guard::enter()
+    pub fn enter_sync_scope(&self) -> SyncScopeGuard {
+        SyncScopeGuard::enter()
     }
 
     /// Leave this scope. Called automatically by the `Guard` instance.
     #[inline]
-    pub fn leave(&mut self, duration: u64) {
+    pub fn add_duration(&mut self, duration: u64) {
         if let Some(callback_fn) = self.perf_callback {
             callback_fn(self.name.as_ptr() as *const i8, self.name.len() as u32, duration);
         } else {
@@ -150,12 +135,12 @@ impl Scope {
 }
 
 impl<'a, F: Future> AsyncScope<'a, F> {
-    pub fn new(scope: SharedScope, future: Pin<&'a mut F>) -> Self {
-        Self { scope, future }
+    pub fn new(name: &'static str, future: Pin<&'a mut F>) -> Self {
+        Self { name, future }
     }
 }
 
-impl Guard {
+impl SyncScopeGuard {
     #[inline]
     pub fn enter() -> Self {
         let now: u64 = unsafe { x86::time::rdtscp().0 };
@@ -193,17 +178,22 @@ impl<'a, F: Future> Future for AsyncScope<'a, F> {
     fn poll(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Self::Output> {
         let self_: &mut Self = self.get_mut();
 
-        let _guard = PROFILER.with(|p| p.clone().enter_scope(&self_.scope));
-        Future::poll(self_.future.as_mut(), ctx)
+        PROFILER.with(|p| p.clone().create_and_enter_async_scope(self_.name));
+        let start: u64 = unsafe { x86::time::rdtscp().0 };
+        let result = Future::poll(self_.future.as_mut(), ctx);
+        let end: u64 = unsafe { x86::time::rdtscp().0 };
+        let duration: u64 = end - start;
+        PROFILER.with(|p| p.clone().leave_async_scope(duration));
+        result
     }
 }
 
-impl Drop for Guard {
+impl Drop for SyncScopeGuard {
     #[inline]
     fn drop(&mut self) {
         let now: u64 = unsafe { x86::time::rdtscp().0 };
         let duration: u64 = now - self.enter_time;
 
-        PROFILER.with(|p| p.clone().leave_scope(duration));
+        PROFILER.with(|p| p.clone().leave_sync_scope(duration));
     }
 }

--- a/src/perftools/profiler/tests.rs
+++ b/src/perftools/profiler/tests.rs
@@ -85,7 +85,7 @@ fn test_reset_during_frame() -> Result<()> {
                 profiler::reset();
             }
 
-            crate::ensure_eq!(profiler::PROFILER.with(|p| p.current_scope.is_some()), true);
+            crate::ensure_eq!(profiler::PROFILER.with(|p| p.current_sync_scope.is_some()), true);
 
             timer!("d");
         }
@@ -93,7 +93,7 @@ fn test_reset_during_frame() -> Result<()> {
 
     profiler::PROFILER.with(|p| -> Result<()> {
         crate::ensure_eq!(p.root_scopes.is_empty(), true);
-        crate::ensure_eq!(p.current_scope.is_none(), true);
+        crate::ensure_eq!(p.current_sync_scope.is_none(), true);
         Ok(())
     })
 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -168,7 +168,7 @@ impl SharedDemiRuntime {
         #[cfg(feature = "profiler")]
         let coroutine = coroutine_timer!(task_name, coroutine);
         let task: TaskWithResult<F::Output> = TaskWithResult::<F::Output>::new(task_name, coroutine);
-        match self.scheduler.insert_task(group_id, task) {
+        match self.scheduler.insert_and_poll_task(group_id, task) {
             Some(InsertResult::Inserted(task_id)) => {
                 let qt: QToken = self.qtoken_to_scheduler_id.insert_with_new_id(task_id).unwrap();
                 self.scheduler

--- a/src/runtime/scheduler/group.rs
+++ b/src/runtime/scheduler/group.rs
@@ -74,7 +74,7 @@ impl TaskGroup {
     }
 
     /// Insert a new task into our scheduler returning a handle corresponding to it.
-    pub fn insert(&mut self, task: Box<dyn Task>) -> Option<InsertResult> {
+    pub fn insert_and_poll_task(&mut self, task: Box<dyn Task>) -> Option<InsertResult> {
         let task_name: &'static str = task.get_name();
         // The pin slab index can be reverse-computed in a page index and an offset within the page.
         let pin_slab_index: usize = self.tasks.insert(task)?;

--- a/src/runtime/scheduler/scheduler.rs
+++ b/src/runtime/scheduler/scheduler.rs
@@ -60,9 +60,9 @@ impl Scheduler {
     }
 
     /// The parent id can either be the id of the group or another task in the same group.
-    pub fn insert_task<T: Task>(&mut self, group_id: SchedulerId, task: T) -> Option<InsertResult> {
+    pub fn insert_and_poll_task<T: Task>(&mut self, group_id: SchedulerId, task: T) -> Option<InsertResult> {
         let group: &mut TaskGroup = self.get_mut_group(group_id)?;
-        group.insert(Box::new(task))
+        group.insert_and_poll_task(Box::new(task))
     }
 
     pub fn get_mut_task(&mut self, group_id: SchedulerId, task_id: SchedulerId) -> Option<Pin<&mut Box<dyn Task>>> {
@@ -189,7 +189,7 @@ mod tests {
 
         // Insert a single future in the scheduler. This future shall complete with a single poll operation.
         let task: DummyTask = DummyTask::new("testing", Box::pin(DummyCoroutine::new(1).fuse()));
-        let Some(InsertResult::Inserted(_)) = scheduler.insert_task(group_id, task) else {
+        let Some(InsertResult::Inserted(_)) = scheduler.insert_and_poll_task(group_id, task) else {
             anyhow::bail!("insert() failed")
         };
 
@@ -210,7 +210,7 @@ mod tests {
         // Insert a single future in the scheduler. This future shall complete
         // with two poll operations.
         let task: DummyTask = DummyTask::new("testing", Box::pin(DummyCoroutine::new(2).fuse()));
-        let Some(InsertResult::Inserted(_)) = scheduler.insert_task(group_id, task) else {
+        let Some(InsertResult::Inserted(_)) = scheduler.insert_and_poll_task(group_id, task) else {
             anyhow::bail!("insert() failed")
         };
 
@@ -234,7 +234,7 @@ mod tests {
 
         // Insert a single future in the scheduler. This future shall complete with a single poll operation.
         let task: DummyTask = DummyTask::new("testing", Box::pin(DummyCoroutine::new(1).fuse()));
-        let Some(InsertResult::Inserted(_)) = scheduler.insert_task(group_id, task) else {
+        let Some(InsertResult::Inserted(_)) = scheduler.insert_and_poll_task(group_id, task) else {
             anyhow::bail!("insert() failed")
         };
 
@@ -254,7 +254,7 @@ mod tests {
 
         b.iter(|| {
             let task: DummyTask = DummyTask::new("testing", Box::pin(black_box(DummyCoroutine::new(1).fuse())));
-            let Some(InsertResult::Inserted(task_id)) = scheduler.insert_task(group_id, task) else {
+            let Some(InsertResult::Inserted(task_id)) = scheduler.insert_and_poll_task(group_id, task) else {
                 panic!("couldn't insert future in scheduler");
             };
             black_box(task_id);
@@ -271,7 +271,7 @@ mod tests {
 
         for val in 1..NUM_TASKS {
             let task: DummyTask = DummyTask::new("testing", Box::pin(DummyCoroutine::new(val).fuse()));
-            match scheduler.insert_task(group_id, task) {
+            match scheduler.insert_and_poll_task(group_id, task) {
                 Some(InsertResult::Completed(_)) => panic!("task should not have completed"),
                 Some(InsertResult::Inserted(task_id)) => task_ids.push(task_id),
                 None => panic!("insert() failed"),
@@ -293,7 +293,7 @@ mod tests {
 
         for val in 1..NUM_TASKS {
             let task: DummyTask = DummyTask::new("testing", Box::pin(DummyCoroutine::new(val).fuse()));
-            match scheduler.insert_task(group_id, task) {
+            match scheduler.insert_and_poll_task(group_id, task) {
                 Some(InsertResult::Completed(_)) => panic!("task should not have completed"),
                 Some(InsertResult::Inserted(task_id)) => task_ids.push(task_id),
                 None => panic!("insert() failed"),

--- a/tests/rust/tcp-tests/wait/mod.rs
+++ b/tests/rust/tcp-tests/wait/mod.rs
@@ -8,7 +8,7 @@
 use crate::check_for_network_error;
 use ::anyhow::Result;
 use ::demikernel::{runtime::types::demi_opcode_t, LibOS, QDesc, QToken};
-use ::std::net::SocketAddr;
+use ::std::{net::SocketAddr, time::Duration};
 
 //======================================================================================================================
 // Constants
@@ -182,7 +182,7 @@ fn wait_after_async_close_connecting_socket(libos: &mut LibOS, remote: &SocketAd
 // Attempt to wait on an invalid queue token.
 fn wait_on_invalid_queue_token_returns_einval(libos: &mut LibOS) -> Result<()> {
     // Wait on an invalid queue token made from u64 MAX value.
-    match libos.wait(QToken::from(u64::MAX), None) {
+    match libos.wait(QToken::from(u64::MAX), Some(Duration::ZERO)) {
         Ok(_) => anyhow::bail!("wait() should not succeed on invalid token"),
         // If we are using direct mapping, this will time out because we do not have a data structure to track valid and
         // invalid qtokens. Instead, we will never find a completed qtoken.
@@ -194,7 +194,7 @@ fn wait_on_invalid_queue_token_returns_einval(libos: &mut LibOS) -> Result<()> {
     }
 
     // Wait on an invalid queue token made from 0 value.
-    match libos.wait(QToken::from(0), None) {
+    match libos.wait(QToken::from(0), Some(Duration::ZERO)) {
         Ok(_) => anyhow::bail!("wait() should not succeed on invalid token"),
         // If we are using direct mapping, this will time out because we do not have a data structure to track valid and
         // invalid qtokens. Instead, we will never find a completed qtoken.


### PR DESCRIPTION
Fixes #1593. Previously we were not properly tracking the current running profiler scope and replacing it if we run an asynchronous block. Originally this was not an issue because we only ran async blocks in wait_* calls but now that we run them on insert, that is no longer true.