### PR TITLE
ci: workflows: ignore missing files when release build is skipped

### DIFF
--- a/.github/workflows/catnap.yml
+++ b/.github/workflows/catnap.yml
@@ -115,7 +115,7 @@ jobs:
           --client-addr $CLIENT_ADDR
     - name: Archive Logs
       if: always()
-      continue-on-error: true
+      if-no-files-found: ignore
       uses: actions/upload-artifact@v4
       with:
         name: catnap-release-pipeline-logs

--- a/.github/workflows/catnapw.yml
+++ b/.github/workflows/catnapw.yml
@@ -117,7 +117,7 @@ jobs:
           --client-addr $CLIENT_ADDR
     - name: Archive Logs
       if: always()
-      continue-on-error: true
+      if-no-files-found: ignore
       uses: actions/upload-artifact@v4
       with:
         name: catnapw-release-pipeline-logs
@@ -217,7 +217,7 @@ jobs:
           --client-addr $CLIENT_ADDR
     - name: Archive Logs
       if: always()
-      continue-on-error: true
+      if-no-files-found: ignore
       uses: actions/upload-artifact@v4
       with:
         name: catpowder-release-pipeline-logs

--- a/.github/workflows/catnip.yml
+++ b/.github/workflows/catnip.yml
@@ -160,7 +160,7 @@ jobs:
           --client-addr $CLIENT_ADDR
     - name: Archive Logs
       if: always()
-      continue-on-error: true
+      if-no-files-found: ignore
       uses: actions/upload-artifact@v4
       with:
         name: catnip-release-pipeline-logs

--- a/.github/workflows/catpowder.yml
+++ b/.github/workflows/catpowder.yml
@@ -152,7 +152,7 @@ jobs:
           --client-addr $CLIENT_ADDR
     - name: Archive Logs
       if: always()
-      continue-on-error: true
+      if-no-files-found: ignore
       uses: actions/upload-artifact@v4
       with:
         name: catpowder-release-pipeline-logs


### PR DESCRIPTION
Now that release builds are optional, there is no need to see the warning when the upload artifact step does not find files to upload becuase the previous step (i.e. the release build) was skipped.