### PR TITLE
Fix typo in demi_close.md

### DIFF
--- a/man/demi_close.md
+++ b/man/demi_close.md
@@ -14,7 +14,7 @@ int demi_close(int qd);
 
 ## Description
 
-`demi_close()` closes an I/O queue descriptor, so that it no longers refers to an I/O queue.
+`demi_close()` closes an I/O queue descriptor, so that it no longer refers to an I/O queue.
 
 The `qd` parameter is the I/O queue descriptor that is associated with the target I/O queue.
 


### PR DESCRIPTION
Changes "it no longers" to "it no longer" in `man/demi_close.md`

https://github.com/microsoft/demikernel/blob/5914e02fbd6bbb10b17fba965eeb8269f014787f/man/demi_close.md?plain=1#L17