### PR TITLE
inetstack: layer4: cleanup to enhance focus on semantics over syntax

### DIFF
--- a/src/inetstack/protocols/layer4/tcp/established/congestion_control/cubic.rs
+++ b/src/inetstack/protocols/layer4/tcp/established/congestion_control/cubic.rs
@@ -64,16 +64,16 @@ pub struct Cubic {
 
 impl CongestionControl for Cubic {
     fn new(mss: usize, seq_no: SeqNumber, options: Option<Options>) -> Box<dyn CongestionControl> {
-        let mss: u32 = mss.try_into().unwrap();
+        let mss = mss.try_into().unwrap();
         // The initial value of cwnd is set according to RFC5681, section 3.1, page 7.
-        let initial_cwnd: u32 = match mss {
+        let initial_cwnd = match mss {
             0..=1095 => 4 * mss,
             1096..=2190 => 3 * mss,
             _ => 2 * mss,
         };
 
-        let options: Options = options.unwrap_or_default();
-        let fast_convergence: bool = options.get_bool("fast_convergence").unwrap_or(true);
+        let options = options.unwrap_or_default();
+        let fast_convergence = options.get_bool("fast_convergence").unwrap_or(true);
 
         Box::new(Self {
             mss,
@@ -113,7 +113,7 @@ impl Cubic {
     fn fast_convergence(&self) {
         // The fast convergence algorithm assumes that w_max and cwnd are stored in units of mss, so we do this
         // integer division to prevent it being applied too often.
-        let cwnd: u32 = self.cwnd.get();
+        let cwnd = self.cwnd.get();
 
         if (cwnd / self.mss) < self.w_max.get() / self.mss {
             self.w_max.set((cwnd as f32 * (1. + Self::BETA_CUBIC) / 2.) as u32);
@@ -123,7 +123,7 @@ impl Cubic {
     }
 
     fn increment_dup_ack_count(&mut self) -> u32 {
-        let duplicate_ack_count: u32 = self.duplicate_ack_count.get() + 1;
+        let duplicate_ack_count = self.duplicate_ack_count.get() + 1;
         self.duplicate_ack_count.set(duplicate_ack_count);
         if duplicate_ack_count < Self::DUP_ACK_THRESHOLD {
             self.limited_transmit_cwnd_increase.modify(|ltci| ltci + self.mss);
@@ -133,13 +133,13 @@ impl Cubic {
 
     fn on_dup_ack_received(&mut self, send_next: SeqNumber, ack_seq_no: SeqNumber) {
         // Get and increment the duplicate ACK count, and store the updated value.
-        let duplicate_ack_count: u32 = self.increment_dup_ack_count();
+        let duplicate_ack_count = self.increment_dup_ack_count();
 
-        let prev_ack_seq_no: SeqNumber = self.prev_ack_seq_no.get();
+        let prev_ack_seq_no = self.prev_ack_seq_no.get();
         let ack_seq_no_diff: u32 = (ack_seq_no - prev_ack_seq_no).into();
-        let cwnd: u32 = self.cwnd.get();
-        let ack_covers_recover: bool = ack_seq_no - SeqNumber::from(1) > self.recover.get();
-        let retransmitted_packet_dropped_heuristic: bool = cwnd > self.mss && ack_seq_no_diff <= 4 * self.mss;
+        let cwnd = self.cwnd.get();
+        let ack_covers_recover = ack_seq_no - SeqNumber::from(1) > self.recover.get();
+        let retransmitted_packet_dropped_heuristic = cwnd > self.mss && ack_seq_no_diff <= 4 * self.mss;
 
         if duplicate_ack_count == Self::DUP_ACK_THRESHOLD
             && (ack_covers_recover || retransmitted_packet_dropped_heuristic)
@@ -147,7 +147,7 @@ impl Cubic {
             // Check against recover specified in RFC6582.
             self.in_fast_recovery.set(true);
             self.recover.set(send_next);
-            let reduced_cwnd: u32 = (cwnd as f32 * Self::BETA_CUBIC) as u32;
+            let reduced_cwnd = (cwnd as f32 * Self::BETA_CUBIC) as u32;
 
             if self.fast_convergence {
                 self.fast_convergence();
@@ -167,7 +167,7 @@ impl Cubic {
     fn on_ack_received_fast_recovery(&mut self, send_unacked: SeqNumber, send_next: SeqNumber, ack_seq_no: SeqNumber) {
         let bytes_outstanding: u32 = (send_next - send_unacked).into();
         let bytes_acknowledged: u32 = (ack_seq_no - send_unacked).into();
-        let mss: u32 = self.mss;
+        let mss = self.mss;
 
         if ack_seq_no > self.recover.get() {
             // Full acknowledgement.
@@ -210,35 +210,35 @@ impl Cubic {
     fn w_est(&self, w_max: f32, t: f32, rtt: f32) -> f32 {
         // While we store w_max in terms of bytes, we have pre-normalised it to units of MSS
         // for compatibility with RFC8312.
-        let bc: f32 = Self::BETA_CUBIC;
+        let bc = Self::BETA_CUBIC;
         w_max * bc + ((3. * (1. - bc) / (1. + bc)) * t / rtt)
     }
 
     fn on_ack_received_ss_ca(&mut self, rto: Duration, send_unacked: SeqNumber, ack_seq_no: SeqNumber) {
-        let bytes_acknowledged: u32 = (ack_seq_no - send_unacked).into();
-        let mss: u32 = self.mss;
-        let cwnd: u32 = self.cwnd.get();
-        let ssthresh: u32 = self.ssthresh.get();
+        let bytes_acknowledged = (ack_seq_no - send_unacked).into();
+        let mss = self.mss;
+        let cwnd = self.cwnd.get();
+        let ssthresh = self.ssthresh.get();
 
         if cwnd < ssthresh {
             // Slow start.
             self.cwnd.modify(|c| c + min(bytes_acknowledged, mss));
         } else {
             // Congestion avoidance.
-            let t: f32 = self.ca_start.get().elapsed().as_secs_f32();
-            let rtt: f32 = rto.as_secs_f32();
-            let mss_f32: f32 = mss as f32;
-            let normalised_w_max: f32 = self.w_max.get() as f32 / mss_f32;
-            let k: f32 = self.k(normalised_w_max);
-            let w_est: f32 = self.w_est(normalised_w_max, t, rtt);
+            let t = self.ca_start.get().elapsed().as_secs_f32();
+            let rtt = rto.as_secs_f32();
+            let mss_f32 = mss as f32;
+            let normalised_w_max = self.w_max.get() as f32 / mss_f32;
+            let k = self.k(normalised_w_max);
+            let w_est = self.w_est(normalised_w_max, t, rtt);
             if self.w_cubic(normalised_w_max, t, k) < w_est {
                 // w_est return units of MSS which we multiply back up to get bytes.
                 self.cwnd.set((w_est * mss_f32) as u32);
             } else {
-                let cwnd_f32: f32 = cwnd as f32;
+                let cwnd_f32 = cwnd as f32;
                 // Again, do everything in terms of units of MSS.
-                let normalised_cwnd: f32 = cwnd_f32 / mss_f32;
-                let cwnd_inc: f32 =
+                let normalised_cwnd = cwnd_f32 / mss_f32;
+                let cwnd_inc =
                     ((self.w_cubic(normalised_w_max, t + rtt, k) - normalised_cwnd) / normalised_cwnd) * mss_f32;
                 self.cwnd.modify(|c| c + cwnd_inc as u32);
             }
@@ -246,7 +246,7 @@ impl Cubic {
     }
 
     fn on_rto_ss_ca(&mut self) {
-        let cwnd: u32 = self.cwnd.get();
+        let cwnd = self.cwnd.get();
 
         if self.fast_convergence {
             self.fast_convergence();
@@ -255,7 +255,7 @@ impl Cubic {
         }
         self.cwnd.set(self.mss);
 
-        let rpif: u32 = self.retransmitted_packets_in_flight.get();
+        let rpif = self.retransmitted_packets_in_flight.get();
         if rpif == 0 {
             // If we lost a retransmitted packet, we don't shrink ssthresh.
             // So we have to check if a retransmitted packet was in flight before we shrink it.
@@ -288,10 +288,10 @@ impl SlowStartCongestionAvoidance for Cubic {
     }
 
     fn on_cwnd_check_before_send(&mut self) {
-        let long_time_since_send: bool =
+        let long_time_since_send =
             Instant::now().duration_since(self.last_send_time.get()) > self.rtt_at_last_send.get();
         if long_time_since_send {
-            let restart_window: u32 = min(self.initial_cwnd, self.cwnd.get());
+            let restart_window = min(self.initial_cwnd, self.cwnd.get());
             self.cwnd.set(restart_window);
             self.limited_transmit_cwnd_increase.set_without_notify(0);
         }
@@ -300,7 +300,7 @@ impl SlowStartCongestionAvoidance for Cubic {
     fn on_send(&mut self, rto: Duration, num_bytes_sent: u32) {
         self.last_send_time.set(Instant::now());
         self.rtt_at_last_send.set(rto);
-        let new_value: u32 = self.limited_transmit_cwnd_increase.get().saturating_sub(num_bytes_sent);
+        let new_value = self.limited_transmit_cwnd_increase.get().saturating_sub(num_bytes_sent);
         self.limited_transmit_cwnd_increase.set_without_notify(new_value);
     }
 

--- a/src/inetstack/protocols/layer4/tcp/established/mod.rs
+++ b/src/inetstack/protocols/layer4/tcp/established/mod.rs
@@ -40,7 +40,7 @@ use ::std::{
     net::SocketAddrV4,
     ops::{Deref, DerefMut},
     pin::pin,
-    time::{Duration, Instant},
+    time::Duration,
 };
 
 //======================================================================================================================
@@ -132,14 +132,14 @@ impl SharedEstablishedSocket {
             _ => (),
         };
 
-        let sender: Sender = Sender::new(
+        let sender = Sender::new(
             sender_seq_no,
             receiver_seq_no,
             sender_window_size_bytes,
             sender_window_scale_bits,
             sender_mss,
         );
-        let receiver: Receiver = Receiver::new(
+        let receiver = Receiver::new(
             receiver_seq_no,
             receiver_seq_no,
             ack_delay_timeout_secs,
@@ -157,7 +157,7 @@ impl SharedEstablishedSocket {
             receiver,
             congestion_control_algorithm,
         );
-        let mut me: Self = Self(SharedObject::new(EstablishedSocket {
+        let mut me = Self(SharedObject::new(EstablishedSocket {
             control_block: cb,
             runtime: runtime.clone(),
             layer3_endpoint,
@@ -167,7 +167,7 @@ impl SharedEstablishedSocket {
         if let Some((header, data)) = data_from_ack {
             me.receive(header, data);
         }
-        let me2: Self = me.clone();
+        let me2 = me.clone();
         runtime.insert_nonpolling_coroutine(
             "bgc::inetstack::tcp::established::background",
             Box::pin(async move { me2.background().await }.fuse()),
@@ -183,8 +183,8 @@ impl SharedEstablishedSocket {
             tcp_hdr,
         );
 
-        let now: Instant = self.runtime.get_now();
-        let mut layer3_endpoint: SharedLayer3Endpoint = self.layer3_endpoint.clone();
+        let now = self.runtime.get_now();
+        let mut layer3_endpoint = self.layer3_endpoint.clone();
         Receiver::receive(&mut self.control_block, &mut layer3_endpoint, tcp_hdr, buf, now);
     }
 
@@ -195,7 +195,7 @@ impl SharedEstablishedSocket {
             State::Established => self.local_close().await,
             State::CloseWait => self.remote_already_closed().await,
             _ => {
-                let cause: &'static str = "socket is already closing";
+                let cause = "socket is already closing";
                 error!("close(): {}", cause);
                 Err(Fail::new(libc::EBADF, cause))
             },
@@ -207,11 +207,11 @@ impl SharedEstablishedSocket {
         self.control_block.state = State::FinWait1;
 
         // 2. Wait for FIN and FIN ack.
-        let mut me2: SharedEstablishedSocket = self.clone();
-        let mut me3: SharedEstablishedSocket = self.clone();
+        let mut me2 = self.clone();
+        let mut me3 = self.clone();
         let wait_for_fin = pin!(me3.control_block.receiver.wait_for_fin().fuse());
-        let mut runtime: SharedDemiRuntime = self.runtime.clone();
-        let mut layer3_endpoint: SharedLayer3Endpoint = self.layer3_endpoint.clone();
+        let mut runtime = self.runtime.clone();
+        let mut layer3_endpoint = self.layer3_endpoint.clone();
         let push_fin_and_wait_for_ack =
             pin!(Sender::push(&mut me2.control_block, &mut layer3_endpoint, &mut runtime, None).fuse());
         let (result1, result2) = join!(wait_for_fin, push_fin_and_wait_for_ack);
@@ -221,7 +221,7 @@ impl SharedEstablishedSocket {
         // 3. TIMED_WAIT
         debug_assert_eq!(self.control_block.state, State::TimeWait);
         trace!("socket options: {:?}", self.control_block.socket_options.get_linger());
-        let timeout: Duration = self.control_block.socket_options.get_linger().unwrap_or(MSL * 2);
+        let timeout = self.control_block.socket_options.get_linger().unwrap_or(MSL * 2);
         yield_with_timeout(timeout).await;
         self.control_block.state = State::Closed;
         Ok(())
@@ -231,8 +231,8 @@ impl SharedEstablishedSocket {
         // 0. Move state forward
         self.control_block.state = State::LastAck;
         // 1. Send FIN and wait for ack before closing.
-        let mut runtime: SharedDemiRuntime = self.runtime.clone();
-        let mut layer3_endpoint: SharedLayer3Endpoint = self.layer3_endpoint.clone();
+        let mut runtime = self.runtime.clone();
+        let mut layer3_endpoint = self.layer3_endpoint.clone();
         Sender::push(&mut self.control_block, &mut layer3_endpoint, &mut runtime, None).await?;
         debug_assert_eq!(self.control_block.state, State::Closed);
 
@@ -240,8 +240,8 @@ impl SharedEstablishedSocket {
     }
 
     pub async fn push(&mut self, buf: DemiBuffer) -> Result<(), Fail> {
-        let mut runtime: SharedDemiRuntime = self.runtime.clone();
-        let mut layer3_endpoint: SharedLayer3Endpoint = self.layer3_endpoint.clone();
+        let mut runtime = self.runtime.clone();
+        let mut layer3_endpoint = self.layer3_endpoint.clone();
         Sender::push(&mut self.control_block, &mut layer3_endpoint, &mut runtime, Some(buf)).await
     }
 
@@ -254,27 +254,27 @@ impl SharedEstablishedSocket {
     }
 
     async fn background(self) {
-        let mut me: Self = self.clone();
+        let mut me = self.clone();
         let acknowledger = async_timer!("tcp::established::background::acknowledger", async {
-            let mut layer3_endpoint: SharedLayer3Endpoint = me.layer3_endpoint.clone();
+            let mut layer3_endpoint = me.layer3_endpoint.clone();
             Receiver::acknowledger(&mut me.control_block, &mut layer3_endpoint).await
         })
         .fuse();
         pin_mut!(acknowledger);
 
-        let mut me2: Self = self.clone();
+        let mut me2 = self.clone();
         let retransmitter = async_timer!("tcp::established::background::retransmitter", async {
-            let mut layer3_endpoint: SharedLayer3Endpoint = me2.layer3_endpoint.clone();
-            let mut runtime: SharedDemiRuntime = me2.runtime.clone();
+            let mut layer3_endpoint = me2.layer3_endpoint.clone();
+            let mut runtime = me2.runtime.clone();
             Sender::background_retransmitter(&mut me2.control_block, &mut layer3_endpoint, &mut runtime).await
         })
         .fuse();
         pin_mut!(retransmitter);
 
-        let mut me3: Self = self.clone();
+        let mut me3 = self.clone();
         let sender = async_timer!("tcp::established::background::sender", async {
-            let mut layer3_endpoint: SharedLayer3Endpoint = me3.layer3_endpoint.clone();
-            let mut runtime: SharedDemiRuntime = me3.runtime.clone();
+            let mut layer3_endpoint = me3.layer3_endpoint.clone();
+            let mut runtime = me3.runtime.clone();
             Sender::background_sender(&mut me3.control_block, &mut layer3_endpoint, &mut runtime).await
         })
         .fuse();

--- a/src/inetstack/protocols/layer4/tcp/established/mod.rs
+++ b/src/inetstack/protocols/layer4/tcp/established/mod.rs
@@ -58,7 +58,7 @@ const MAX_WINDOW_SIZE_WITH_SCALING: u32 = 1073741824;
 
 pub struct EstablishedSocket {
     // All shared state for this established TCP connection.
-    cb: ControlBlock,
+    control_block: ControlBlock,
     runtime: SharedDemiRuntime,
     layer3_endpoint: SharedLayer3Endpoint,
 }
@@ -158,7 +158,7 @@ impl SharedEstablishedSocket {
             congestion_control_algorithm,
         );
         let mut me: Self = Self(SharedObject::new(EstablishedSocket {
-            cb,
+            control_block: cb,
             runtime: runtime.clone(),
             layer3_endpoint,
         }));
@@ -178,20 +178,20 @@ impl SharedEstablishedSocket {
     pub fn receive(&mut self, tcp_hdr: TcpHeader, buf: DemiBuffer) {
         debug!(
             "{:?} Connection Receiving {} bytes + {:?}",
-            self.cb.state,
+            self.control_block.state,
             buf.len(),
             tcp_hdr,
         );
 
         let now: Instant = self.runtime.get_now();
         let mut layer3_endpoint: SharedLayer3Endpoint = self.layer3_endpoint.clone();
-        Receiver::receive(&mut self.cb, &mut layer3_endpoint, tcp_hdr, buf, now);
+        Receiver::receive(&mut self.control_block, &mut layer3_endpoint, tcp_hdr, buf, now);
     }
 
     // This coroutine runs the close protocol.
     pub async fn close(&mut self) -> Result<(), Fail> {
         // Assert we are in a valid state and move to new state.
-        match self.cb.state {
+        match self.control_block.state {
             State::Established => self.local_close().await,
             State::CloseWait => self.remote_already_closed().await,
             _ => {
@@ -204,37 +204,37 @@ impl SharedEstablishedSocket {
 
     async fn local_close(&mut self) -> Result<(), Fail> {
         // 1. Start close protocol by setting state and sending FIN.
-        self.cb.state = State::FinWait1;
+        self.control_block.state = State::FinWait1;
 
         // 2. Wait for FIN and FIN ack.
         let mut me2: SharedEstablishedSocket = self.clone();
         let mut me3: SharedEstablishedSocket = self.clone();
-        let wait_for_fin = pin!(me3.cb.receiver.wait_for_fin().fuse());
+        let wait_for_fin = pin!(me3.control_block.receiver.wait_for_fin().fuse());
         let mut runtime: SharedDemiRuntime = self.runtime.clone();
         let mut layer3_endpoint: SharedLayer3Endpoint = self.layer3_endpoint.clone();
         let push_fin_and_wait_for_ack =
-            pin!(Sender::push(&mut me2.cb, &mut layer3_endpoint, &mut runtime, None).fuse());
+            pin!(Sender::push(&mut me2.control_block, &mut layer3_endpoint, &mut runtime, None).fuse());
         let (result1, result2) = join!(wait_for_fin, push_fin_and_wait_for_ack);
         result1?;
         result2?;
 
         // 3. TIMED_WAIT
-        debug_assert_eq!(self.cb.state, State::TimeWait);
-        trace!("socket options: {:?}", self.cb.socket_options.get_linger());
-        let timeout: Duration = self.cb.socket_options.get_linger().unwrap_or(MSL * 2);
+        debug_assert_eq!(self.control_block.state, State::TimeWait);
+        trace!("socket options: {:?}", self.control_block.socket_options.get_linger());
+        let timeout: Duration = self.control_block.socket_options.get_linger().unwrap_or(MSL * 2);
         yield_with_timeout(timeout).await;
-        self.cb.state = State::Closed;
+        self.control_block.state = State::Closed;
         Ok(())
     }
 
     async fn remote_already_closed(&mut self) -> Result<(), Fail> {
         // 0. Move state forward
-        self.cb.state = State::LastAck;
+        self.control_block.state = State::LastAck;
         // 1. Send FIN and wait for ack before closing.
         let mut runtime: SharedDemiRuntime = self.runtime.clone();
         let mut layer3_endpoint: SharedLayer3Endpoint = self.layer3_endpoint.clone();
-        Sender::push(&mut self.cb, &mut layer3_endpoint, &mut runtime, None).await?;
-        debug_assert_eq!(self.cb.state, State::Closed);
+        Sender::push(&mut self.control_block, &mut layer3_endpoint, &mut runtime, None).await?;
+        debug_assert_eq!(self.control_block.state, State::Closed);
 
         Ok(())
     }
@@ -242,22 +242,22 @@ impl SharedEstablishedSocket {
     pub async fn push(&mut self, buf: DemiBuffer) -> Result<(), Fail> {
         let mut runtime: SharedDemiRuntime = self.runtime.clone();
         let mut layer3_endpoint: SharedLayer3Endpoint = self.layer3_endpoint.clone();
-        Sender::push(&mut self.cb, &mut layer3_endpoint, &mut runtime, Some(buf)).await
+        Sender::push(&mut self.control_block, &mut layer3_endpoint, &mut runtime, Some(buf)).await
     }
 
     pub async fn pop(&mut self, size: Option<usize>) -> Result<DemiBuffer, Fail> {
-        self.cb.receiver.pop(size).await
+        self.control_block.receiver.pop(size).await
     }
 
     pub fn endpoints(&self) -> (SocketAddrV4, SocketAddrV4) {
-        (self.cb.local, self.cb.remote)
+        (self.control_block.local, self.control_block.remote)
     }
 
     async fn background(self) {
         let mut me: Self = self.clone();
         let acknowledger = async_timer!("tcp::established::background::acknowledger", async {
             let mut layer3_endpoint: SharedLayer3Endpoint = me.layer3_endpoint.clone();
-            Receiver::acknowledger(&mut me.cb, &mut layer3_endpoint).await
+            Receiver::acknowledger(&mut me.control_block, &mut layer3_endpoint).await
         })
         .fuse();
         pin_mut!(acknowledger);
@@ -266,7 +266,7 @@ impl SharedEstablishedSocket {
         let retransmitter = async_timer!("tcp::established::background::retransmitter", async {
             let mut layer3_endpoint: SharedLayer3Endpoint = me2.layer3_endpoint.clone();
             let mut runtime: SharedDemiRuntime = me2.runtime.clone();
-            Sender::background_retransmitter(&mut me2.cb, &mut layer3_endpoint, &mut runtime).await
+            Sender::background_retransmitter(&mut me2.control_block, &mut layer3_endpoint, &mut runtime).await
         })
         .fuse();
         pin_mut!(retransmitter);
@@ -275,7 +275,7 @@ impl SharedEstablishedSocket {
         let sender = async_timer!("tcp::established::background::sender", async {
             let mut layer3_endpoint: SharedLayer3Endpoint = me3.layer3_endpoint.clone();
             let mut runtime: SharedDemiRuntime = me3.runtime.clone();
-            Sender::background_sender(&mut me3.cb, &mut layer3_endpoint, &mut runtime).await
+            Sender::background_sender(&mut me3.control_block, &mut layer3_endpoint, &mut runtime).await
         })
         .fuse();
         pin_mut!(sender);

--- a/src/inetstack/protocols/layer4/tcp/established/receiver.rs
+++ b/src/inetstack/protocols/layer4/tcp/established/receiver.rs
@@ -114,21 +114,21 @@ impl Receiver {
     // Block until some data is received, up to an optional size.
     pub async fn pop(&mut self, size: Option<usize>) -> Result<DemiBuffer, Fail> {
         debug!("waiting on pop {:?}", size);
-        let buf: DemiBuffer = if let Some(size) = size {
-            let mut buf: DemiBuffer = self.pop_queue.pop(None).await?;
+        let buffer = if let Some(size) = size {
+            let mut buffer = self.pop_queue.pop(None).await?;
             // Split the buffer if it's too big.
-            if buf.len() > size {
-                buf.split_front(size)?
+            if buffer.len() > size {
+                buffer.split_front(size)?
             } else {
-                buf
+                buffer
             }
         } else {
             self.pop_queue.pop(None).await?
         };
 
-        match buf.len() {
+        match buffer.len() {
             len if len > 0 => {
-                self.reader_next_seq_no = self.reader_next_seq_no + SeqNumber::from(buf.len() as u32);
+                self.reader_next_seq_no = self.reader_next_seq_no + SeqNumber::from(buffer.len() as u32);
             },
             _ => {
                 debug!("found FIN");
@@ -136,18 +136,18 @@ impl Receiver {
             },
         }
 
-        Ok(buf)
+        Ok(buffer)
     }
 
     // Receive a single incoming packet from layer3.
     pub fn receive(
-        cb: &mut ControlBlock,
+        control_block: &mut ControlBlock,
         layer3_endpoint: &mut SharedLayer3Endpoint,
         tcp_hdr: TcpHeader,
         buf: DemiBuffer,
         now: Instant,
     ) {
-        match Self::process_packet(cb, layer3_endpoint, tcp_hdr, buf, now) {
+        match Self::process_packet(control_block, layer3_endpoint, tcp_hdr, buf, now) {
             Ok(()) => (),
             Err(e) => debug!("Dropped packet: {:?}", e),
         }
@@ -157,19 +157,19 @@ impl Receiver {
     /// active. Each step in this function return Ok if there is further processing to be done and EBADMSG if the
     /// packet should be dropped after the step.
     fn process_packet(
-        cb: &mut ControlBlock,
+        control_block: &mut ControlBlock,
         layer3_endpoint: &mut SharedLayer3Endpoint,
         mut header: TcpHeader,
         mut data: DemiBuffer,
         now: Instant,
     ) -> Result<(), Fail> {
-        let mut seg_start: SeqNumber = header.seq_num;
-        let mut seg_end: SeqNumber = seg_start;
-        let mut seg_len: u32 = data.len() as u32;
+        let mut seg_start = header.seq_num;
+        let mut seg_end = seg_start;
+        let mut seg_len = data.len() as u32;
 
         // Check if the segment is in the receive window and trim off everything else.
         Self::check_segment_in_window(
-            cb,
+            control_block,
             layer3_endpoint,
             &mut header,
             &mut data,
@@ -177,9 +177,9 @@ impl Receiver {
             &mut seg_end,
             &mut seg_len,
         )?;
-        Self::check_and_process_rst(cb, &header)?;
+        Self::check_and_process_rst(control_block, &header)?;
         Self::check_syn(&header)?;
-        Self::check_and_process_ack(cb, &header, now)?;
+        Self::check_and_process_ack(control_block, &header, now)?;
 
         // TODO: Check the URG bit.  If we decide to support this, how should we do it?
         if header.urg {
@@ -187,24 +187,24 @@ impl Receiver {
         }
 
         // Store whether the packet has data here because processing it will consume the DemiBuffer.
-        let has_data: bool = !data.is_empty();
+        let has_data = !data.is_empty();
         if has_data {
-            Self::process_data(cb, layer3_endpoint, data, seg_start, seg_end, seg_len)?;
+            Self::process_data(control_block, layer3_endpoint, data, seg_start, seg_end, seg_len)?;
         }
         // Deal with FIN flag, saving the FIN for later if it is out of order.
-        Self::check_and_process_fin(cb, &header, seg_end, layer3_endpoint)?;
+        Self::check_and_process_fin(control_block, &header, seg_end, layer3_endpoint)?;
 
         // We should ACK this segment, preferably via piggybacking on a response.
-        if cb.receiver.ack_deadline_time_secs.get().is_none() {
+        if control_block.receiver.ack_deadline_time_secs.get().is_none() {
             // Start the delayed ACK timer to ensure an ACK gets sent soon even if no piggyback opportunity occurs.
-            let timeout: Duration = cb.receiver.ack_delay_timeout_secs;
+            let timeout = control_block.receiver.ack_delay_timeout_secs;
             // Getting the current time is extremely cheap as it is just a variable lookup.
-            cb.receiver.ack_deadline_time_secs.set(Some(now + timeout));
+            control_block.receiver.ack_deadline_time_secs.set(Some(now + timeout));
         } else if has_data {
             // We already owe our peer an ACK (the timer was already running), so cancel the timer and ACK now.
-            cb.receiver.ack_deadline_time_secs.set(None);
+            control_block.receiver.ack_deadline_time_secs.set(None);
             trace!("process_packet(): sending ack before deadline because another packet arrived");
-            Sender::send_ack(cb, layer3_endpoint);
+            Sender::send_ack(control_block, layer3_endpoint);
         }
 
         Ok(())
@@ -280,8 +280,8 @@ impl Receiver {
     }
 
     pub fn hdr_window_size(&self) -> u16 {
-        let window_size: u32 = self.get_receive_window_size();
-        let hdr_window_size: u16 = expect_ok!(
+        let window_size = self.get_receive_window_size();
+        let hdr_window_size = expect_ok!(
             (window_size >> self.window_scale_shift_bits).try_into(),
             "Window size overflow"
         );
@@ -328,7 +328,7 @@ impl Receiver {
 
     // Block until the remote sends a FIN (plus all previous data has arrived).
     pub async fn wait_for_fin(&mut self) -> Result<(), Fail> {
-        let mut fin_seq_no: Option<SeqNumber> = self.fin_seq_no.get();
+        let mut fin_seq_no = self.fin_seq_no.get();
         loop {
             match fin_seq_no {
                 Some(fin_seq_no) if self.receive_next_seq_no >= fin_seq_no => return Ok(()),
@@ -381,9 +381,9 @@ impl Receiver {
             *seg_end = *seg_start + SeqNumber::from(*seg_len - 1);
         }
 
-        let receive_next: SeqNumber = cb.receiver.receive_next_seq_no;
+        let receive_next = cb.receiver.receive_next_seq_no;
 
-        let after_receive_window: SeqNumber = receive_next + SeqNumber::from(cb.receiver.get_receive_window_size());
+        let after_receive_window = receive_next + SeqNumber::from(cb.receiver.get_receive_window_size());
 
         // Check if this segment fits in our receive window.
         // In the optimal case it starts at RCV.NXT, so we check for that first.
@@ -398,13 +398,13 @@ impl Receiver {
                         trace!("check_segment_in_window(): send ack on duplicate segment");
                         Sender::send_ack(cb, layer3_endpoint);
                     }
-                    let cause: &'static str = "duplicate packet";
+                    let cause = "duplicate packet";
                     error!("check_segment_in_window(): {}", cause);
                     return Err(Fail::new(libc::EBADMSG, cause));
                 } else {
                     // Some of this segment's data is new.  Cut the duplicate data off of the front.
                     // If there is a SYN at the start of this segment, remove it too.
-                    let mut duplicate: u32 = u32::from(receive_next - *seg_start);
+                    let mut duplicate = u32::from(receive_next - *seg_start);
                     *seg_start = *seg_start + SeqNumber::from(duplicate);
                     *seg_len -= duplicate;
                     if header.syn {
@@ -425,7 +425,7 @@ impl Receiver {
                         trace!("check_segment_in_window(): send ack on out-of-window segment");
                         Sender::send_ack(cb, layer3_endpoint);
                     }
-                    let cause: &'static str = "packet outside of receive window";
+                    let cause = "packet outside of receive window";
                     error!("check_segment_in_window(): {}", cause);
                     return Err(Fail::new(libc::EBADMSG, cause));
                 }
@@ -437,7 +437,7 @@ impl Receiver {
         // The start of the segment is in the window.
         // Check that the end of the segment is in the window, and trim it down if it is not.
         if *seg_len > 0 && *seg_end >= after_receive_window {
-            let mut excess: u32 = u32::from(*seg_end - after_receive_window);
+            let mut excess = u32::from(*seg_end - after_receive_window);
             excess += 1;
             // TODO: If we end up (after receive handling rewrite is complete) not needing seg_end and seg_len after
             // this, remove these two lines adjusting them as they're being computed needlessly.
@@ -496,7 +496,7 @@ impl Receiver {
             // TODO: RFC 5961 "Blind Reset Attack Using the SYN Bit" prevention would have us always ACK and drop here.
 
             // Receiving a SYN here is an error.
-            let cause: &'static str = "Received in-window SYN on established connection.";
+            let cause = "Received in-window SYN on established connection.";
             error!("{}", cause);
             // TODO: Send Reset.
             // TODO: Return all outstanding Receive and Send requests with "reset" responses.
@@ -512,7 +512,7 @@ impl Receiver {
     fn check_and_process_ack(cb: &mut ControlBlock, header: &TcpHeader, now: Instant) -> Result<(), Fail> {
         if !header.ack {
             // All segments on established connections should be ACKs.  Drop this segment.
-            let cause: &'static str = "Received non-ACK segment on established connection";
+            let cause = "Received non-ACK segment on established connection";
             error!("{}", cause);
             return Err(Fail::new(libc::EBADMSG, cause));
         }
@@ -570,8 +570,8 @@ impl Receiver {
     // Note: Since this is not the "fast path", this is written for clarity over efficiency.
     //
     fn store_out_of_order_segment(&mut self, mut new_start: SeqNumber, mut new_end: SeqNumber, mut buf: DemiBuffer) {
-        let mut action_index: usize = self.out_of_order_frames.len();
-        let mut another_pass_neeeded: bool = true;
+        let mut action_index = self.out_of_order_frames.len();
+        let mut another_pass_neeeded = true;
 
         while another_pass_neeeded {
             another_pass_neeeded = false;
@@ -580,13 +580,13 @@ impl Receiver {
             // The out-of-order store is sorted by starting sequence number, and contains no duplicate data.
             action_index = self.out_of_order_frames.len();
             for index in 0..self.out_of_order_frames.len() {
-                let stored_segment: &(SeqNumber, DemiBuffer) = &self.out_of_order_frames[index];
+                let stored_segment = &self.out_of_order_frames[index];
 
                 // Properties of the segment stored at this index.
-                let stored_start: SeqNumber = stored_segment.0;
-                let stored_len: u32 = stored_segment.1.len() as u32;
+                let stored_start = stored_segment.0;
+                let stored_len = stored_segment.1.len() as u32;
                 debug_assert_ne!(stored_len, 0);
-                let stored_end: SeqNumber = stored_start + SeqNumber::from(stored_len - 1);
+                let stored_end = stored_start + SeqNumber::from(stored_len - 1);
 
                 //
                 // The new data segment has six possibilites when compared to an existing out-of-order segment:
@@ -618,7 +618,7 @@ impl Receiver {
                     }
                     // We have some data overlap between the new segment and the front of the out-of-order segment.
                     // Trim the end of the new segment and stop checking for out-of-order overlap.
-                    let excess: u32 = u32::from(new_end - stored_start) + 1;
+                    let excess = u32::from(new_end - stored_start) + 1;
                     new_end = new_end - SeqNumber::from(excess);
                     expect_ok!(
                         buf.trim(excess as usize),
@@ -641,7 +641,7 @@ impl Receiver {
                     }
                     // We have some data overlap between the new segment and the end of the out-of-order segment.
                     // Adjust the beginning of the new segment and continue on to check the next out-of-order segment.
-                    let duplicate: u32 = u32::from(stored_end - new_start);
+                    let duplicate = u32::from(stored_end - new_start);
                     new_start = new_start + SeqNumber::from(duplicate);
                     expect_ok!(
                         buf.adjust(duplicate as usize),
@@ -672,8 +672,8 @@ impl Receiver {
         cb: &mut ControlBlock,
         layer3_endpoint: &mut SharedLayer3Endpoint,
     ) -> Result<Never, Fail> {
-        let mut ack_deadline: SharedAsyncValue<Option<Instant>> = cb.receiver.ack_deadline_time_secs.clone();
-        let mut deadline: Option<Instant> = ack_deadline.get();
+        let mut ack_deadline = cb.receiver.ack_deadline_time_secs.clone();
+        let mut deadline = ack_deadline.get();
 
         loop {
             // TODO: Implement TCP delayed ACKs, subject to restrictions from RFC 1122

--- a/src/inetstack/protocols/layer4/tcp/established/rto.rs
+++ b/src/inetstack/protocols/layer4/tcp/established/rto.rs
@@ -45,7 +45,7 @@ impl RtoCalculator {
         // Clock granularity in seconds.
         const GRANULARITY: f64 = 0.001f64;
 
-        let rtt: f64 = rtt.as_secs_f64();
+        let rtt = rtt.as_secs_f64();
 
         if !self.received_sample {
             // Initial sample formula from RFC 6298 Section 2.2:
@@ -59,7 +59,7 @@ impl RtoCalculator {
         }
 
         // The new RTO value is the smoothed RTT plus the maximum of the clock granularity and 4 times the RTT variance.
-        let rto: f64 = self.srtt + GRANULARITY.max(4.0 * self.rttvar);
+        let rto = self.srtt + GRANULARITY.max(4.0 * self.rttvar);
 
         // Store the updated RTT value.
         self.update_rto(rto);

--- a/src/inetstack/protocols/layer4/tcp/established/sender.rs
+++ b/src/inetstack/protocols/layer4/tcp/established/sender.rs
@@ -23,7 +23,6 @@ use crate::{
 use ::futures::{never::Never, pin_mut, select_biased, FutureExt};
 use ::std::{
     cmp, fmt,
-    net::Ipv4Addr,
     time::{Duration, Instant},
 };
 
@@ -173,7 +172,7 @@ impl Sender {
             self.rto_calculator.add_sample(now - initial_tx);
         }
 
-        let mut data: DemiBuffer = segment
+        let mut data = segment
             .bytes
             .take()
             .expect("there should be data because this is not a FIN.");
@@ -269,8 +268,8 @@ impl Sender {
         }
 
         // Wait until the sequnce number of the pushed buffer is acknowledged.
-        let mut send_unacked_watched: SharedAsyncValue<SeqNumber> = cb.sender.send_unacked.clone();
-        let ack_seq_no: SeqNumber = cb.sender.unsent_next_seq_no;
+        let mut send_unacked_watched = cb.sender.send_unacked.clone();
+        let ack_seq_no = cb.sender.unsent_next_seq_no;
         debug_assert!(send_unacked_watched.get() < ack_seq_no);
         while send_unacked_watched.get() < ack_seq_no {
             send_unacked_watched.wait_for_change(None).await?;
@@ -285,15 +284,15 @@ impl Sender {
     ) -> Result<Never, Fail> {
         loop {
             // Get next bit of unsent data.
-            let buf: DemiBuffer = cb.sender.unsent_queue.pop(None).await?;
-            Self::send_buffer(cb, layer3_endpoint, runtime.get_now(), buf).await?;
+            let buffer = cb.sender.unsent_queue.pop(None).await?;
+            Self::send_buffer(cb, layer3_endpoint, runtime.get_now(), buffer).await?;
         }
     }
 
     fn send_fin(cb: &mut ControlBlock, layer3_endpoint: &mut SharedLayer3Endpoint, now: Instant) -> Result<(), Fail> {
         debug_assert!(cb.sender.fin_seq_no.is_some());
 
-        let mut header: TcpHeader = Self::tcp_header(cb, cb.sender.fin_seq_no);
+        let mut header = Self::tcp_header(cb, cb.sender.fin_seq_no);
         header.fin = true;
         Self::emit(cb, layer3_endpoint, header, None);
         // Update SND.NXT.
@@ -307,7 +306,7 @@ impl Sender {
         cb.sender.unacked_queue.push(unacked_segment);
         // Set the retransmit timer.
         if cb.sender.retransmit_deadline_time_secs.get().is_none() {
-            let rto: Duration = cb.sender.rto_calculator.rto();
+            let rto = cb.sender.rto_calculator.rto();
             cb.sender.retransmit_deadline_time_secs.set(Some(now + rto));
         }
         Ok(())
@@ -319,13 +318,12 @@ impl Sender {
         now: Instant,
         mut buffer: DemiBuffer,
     ) -> Result<(), Fail> {
-        let mut send_unacked_watched: SharedAsyncValue<SeqNumber> = cb.sender.send_unacked.clone();
-        let mut cwnd_watched: SharedAsyncValue<u32> = cb.congestion_control_algorithm.get_cwnd();
+        let mut send_unacked_watched = cb.sender.send_unacked.clone();
+        let mut cwnd_watched = cb.congestion_control_algorithm.get_cwnd();
 
         // The limited transmit algorithm may increase the effective size of cwnd by up to 2 * mss.
-        let mut ltci_watched: SharedAsyncValue<u32> =
-            cb.congestion_control_algorithm.get_limited_transmit_cwnd_increase();
-        let mut win_sz_watched: SharedAsyncValue<u32> = cb.sender.send_window.clone();
+        let mut ltci_watched = cb.congestion_control_algorithm.get_limited_transmit_cwnd_increase();
+        let mut win_sz_watched = cb.sender.send_window.clone();
 
         // Try in a loop until we send this segment.
         loop {
@@ -339,7 +337,7 @@ impl Sender {
                 // TODO: Silly window syndrome - See RFC 1122's discussion of the SWS avoidance algorithm.
 
                 // We have some window, try to send some or all of the segment.
-                let _: usize = Self::send_segment(cb, layer3_endpoint, now, &mut buffer);
+                let _ = Self::send_segment(cb, layer3_endpoint, now, &mut buffer);
                 // If the buffer is now empty, then we sent all of it.
                 if buffer.is_empty() {
                     return Ok(());
@@ -375,11 +373,11 @@ impl Sender {
 
         // Note that we loop here *forever*, exponentially backing off.
         // TODO: Use the correct PERSIST mode timer here.
-        let mut timeout: Duration = Duration::from_secs(1);
-        let mut win_sz_watched: SharedAsyncValue<u32> = cb.sender.send_window.clone();
+        let mut timeout = Duration::from_secs(1);
+        let mut win_sz_watched = cb.sender.send_window.clone();
         loop {
             // Create packet.
-            let header: TcpHeader = Self::tcp_header(cb, None);
+            let header = Self::tcp_header(cb, None);
             Self::emit(cb, layer3_endpoint, header, Some(probe.clone()));
 
             match win_sz_watched.wait_for_change(Some(timeout)).await {
@@ -402,39 +400,39 @@ impl Sender {
         now: Instant,
         segment: &mut DemiBuffer,
     ) -> usize {
-        let buf_len: usize = segment.len();
-        debug_assert_ne!(buf_len, 0);
+        let buffer_length = segment.len();
+        debug_assert_ne!(buffer_length, 0);
 
-        let max_frame_size_bytes: usize = Self::get_open_window_size_bytes(cb);
+        let max_frame_size_bytes = Self::get_open_window_size_bytes(cb);
         if max_frame_size_bytes == 0 {
             return 0;
         }
 
         // Split the packet if necessary.
         // TODO: Use a scatter/gather array to coalesce multiple buffers into a single segment.
-        let (frame_size_bytes, do_push): (usize, bool) = {
-            if buf_len > max_frame_size_bytes {
+        let (frame_size_bytes, do_push) = {
+            if buffer_length > max_frame_size_bytes {
                 // Suppress PSH flag for partial buffers.
                 (max_frame_size_bytes, false)
             } else {
                 // We can just send the whole packet. Clone it so we can attach headers/retransmit it later.
-                (buf_len, true)
+                (buffer_length, true)
             }
         };
-        let segment_data: DemiBuffer = segment
+        let segment_data = segment
             .split_front(frame_size_bytes)
             .expect("Should be able to split within the length of the buffer");
 
-        let segment_data_len: u32 = segment_data.len() as u32;
+        let segment_data_len = segment_data.len() as u32;
 
-        let rto: Duration = cb.sender.rto_calculator.rto();
+        let rto = cb.sender.rto_calculator.rto();
         cb.congestion_control_algorithm.on_send(
             rto,
             (cb.sender.send_next_seq_no.get() - cb.sender.send_unacked.get()).into(),
         );
 
         // Prepare the segment and send it.
-        let mut header: TcpHeader = Self::tcp_header(cb, None);
+        let mut header = Self::tcp_header(cb, None);
         if do_push {
             header.psh = true;
         }
@@ -462,7 +460,7 @@ impl Sender {
 
         // Set the retransmit timer.
         if cb.sender.retransmit_deadline_time_secs.get().is_none() {
-            let rto: Duration = cb.sender.rto_calculator.rto();
+            let rto = cb.sender.rto_calculator.rto();
             cb.sender.retransmit_deadline_time_secs.set(Some(now + rto));
         }
         segment_data_len as usize
@@ -472,7 +470,7 @@ impl Sender {
     /// If a sequence number is provided, use it otherwise, use the current unsent sequence number.
     /// The only time that the unsent sequence number is not used is when we are retransmitting.
     pub fn tcp_header(cb: &mut ControlBlock, seq_num: Option<SeqNumber>) -> TcpHeader {
-        let mut header: TcpHeader = TcpHeader::new(cb.local.port(), cb.remote.port());
+        let mut header = TcpHeader::new(cb.local.port(), cb.remote.port());
         header.window_size = cb.receiver.hdr_window_size();
 
         // Note that once we reach a synchronized state we always include a valid acknowledgement number.
@@ -480,27 +478,26 @@ impl Sender {
         header.ack_num = cb.receiver.receive_next_seq_no;
         header.seq_num = seq_num.unwrap_or(cb.sender.send_next_seq_no.get());
 
-        // Return this header.
         header
     }
 
     fn get_open_window_size_bytes(cb: &mut ControlBlock) -> usize {
         // Calculate amount of data in flight (SND.NXT - SND.UNA).
-        let send_unacknowledged: SeqNumber = cb.sender.send_unacked.get();
-        let send_next: SeqNumber = cb.sender.send_next_seq_no.get();
-        let sent_data: u32 = (send_next - send_unacknowledged).into();
+        let send_unacknowledged = cb.sender.send_unacked.get();
+        let send_next = cb.sender.send_next_seq_no.get();
+        let sent_data = (send_next - send_unacknowledged).into();
 
         // Before we get cwnd for the check, we prompt it to shrink it if the connection has been idle.
         cb.congestion_control_algorithm.on_cwnd_check_before_send();
-        let cwnd: SharedAsyncValue<u32> = cb.congestion_control_algorithm.get_cwnd();
+        let cwnd = cb.congestion_control_algorithm.get_cwnd();
 
         // The limited transmit algorithm can increase the effective size of cwnd by up to 2MSS.
-        let effective_cwnd: u32 = cwnd.get()
+        let effective_cwnd = cwnd.get()
             + cb.congestion_control_algorithm
                 .get_limited_transmit_cwnd_increase()
                 .get();
 
-        let win_sz: u32 = cb.sender.send_window.get();
+        let win_sz = cb.sender.send_window.get();
 
         if Self::has_open_window(win_sz, sent_data, effective_cwnd) {
             Self::calculate_open_window_bytes(win_sz, sent_data, cb.sender.mss, effective_cwnd)
@@ -526,14 +523,12 @@ impl Sender {
         runtime: &mut SharedDemiRuntime,
     ) -> Result<Never, Fail> {
         // Watch the retransmission deadline.
-        let mut rtx_deadline_watched: SharedAsyncValue<Option<Instant>> =
-            cb.sender.retransmit_deadline_time_secs.clone();
+        let mut rtx_deadline_watched = cb.sender.retransmit_deadline_time_secs.clone();
         // Watch the fast retransmit flag.
-        let mut rtx_fast_retransmit_watched: SharedAsyncValue<bool> =
-            cb.congestion_control_algorithm.get_retransmit_now_flag();
+        let mut rtx_fast_retransmit_watched = cb.congestion_control_algorithm.get_retransmit_now_flag();
         loop {
-            let rtx_deadline: Option<Instant> = rtx_deadline_watched.get();
-            let rtx_fast_retransmit: bool = rtx_fast_retransmit_watched.get();
+            let rtx_deadline = rtx_deadline_watched.get();
+            let rtx_fast_retransmit = rtx_fast_retransmit_watched.get();
             if rtx_fast_retransmit {
                 // Notify congestion control about fast retransmit.
                 cb.congestion_control_algorithm.on_fast_retransmit();
@@ -570,7 +565,7 @@ impl Sender {
                     cb.sender.rto_calculator.back_off();
 
                     // RFC 6298 Section 5.6: Restart the retransmission timer with the new RTO.
-                    let deadline: Instant = runtime.get_now() + cb.sender.rto_calculator.rto();
+                    let deadline = runtime.get_now() + cb.sender.rto_calculator.rto();
                     cb.sender.retransmit_deadline_time_secs.set(Some(deadline));
                 },
                 Err(_) => {
@@ -590,11 +585,11 @@ impl Sender {
             segment.initial_tx.take();
 
             // Clone the segment data here for retransmission.
-            let data: Option<DemiBuffer> = segment.bytes.clone();
+            let data = segment.bytes.clone();
 
             // TODO: Issue #198 Repacketization - we should send a full MSS (and set the FIN flag if applicable).
 
-            let mut header: TcpHeader = Self::tcp_header(cb, Some(cb.sender.send_unacked.get()));
+            let mut header = Self::tcp_header(cb, Some(cb.sender.send_unacked.get()));
 
             if data.is_some() {
                 // Regular packet, so set the PSH flag.
@@ -610,7 +605,7 @@ impl Sender {
 
     pub fn process_ack(cb: &mut ControlBlock, header: &TcpHeader, now: Instant) {
         // Start by checking that the ACK acknowledges something new.
-        let send_unacknowledged: SeqNumber = cb.sender.send_unacked.get();
+        let send_unacknowledged = cb.sender.send_unacked.get();
         // Check and update send window if necessary.
         cb.sender.update_send_window(header);
 
@@ -621,7 +616,7 @@ impl Sender {
             // Convert the difference in sequence numbers into a u32.
             let bytes_acknowledged: u32 = (header.ack_num - cb.sender.send_unacked.get()).into();
             // Convert that into a usize for counting bytes to remove from the unacked queue.
-            let mut bytes_remaining: usize = bytes_acknowledged as usize;
+            let mut bytes_remaining = bytes_acknowledged as usize;
             // Remove bytes from the unacked queue.
             while bytes_remaining != 0 {
                 bytes_remaining = match cb.sender.unacked_queue.try_pop() {
@@ -640,7 +635,7 @@ impl Sender {
 
             // Reset the retransmit timer if necessary. If there is more data that hasn't been acked, then set to the
             // next segment deadline, otherwise, do not set.
-            let retransmit_deadline_time_secs: Option<Instant> = cb.sender.update_retransmit_deadline(now);
+            let retransmit_deadline_time_secs = cb.sender.update_retransmit_deadline(now);
             #[cfg(debug_assertions)]
             if retransmit_deadline_time_secs.is_none() {
                 debug_assert_eq!(cb.sender.send_next_seq_no.get(), header.ack_num);
@@ -661,7 +656,7 @@ impl Sender {
 
     /// Send an ACK to our peer, reflecting our current state.
     pub fn send_ack(cb: &mut ControlBlock, layer3_endpoint: &mut SharedLayer3Endpoint) {
-        let header: TcpHeader = Self::tcp_header(cb, None);
+        let header = Self::tcp_header(cb, None);
         Self::emit(cb, layer3_endpoint, header, None);
     }
 
@@ -692,7 +687,7 @@ impl Sender {
         // This routine should only ever be called to send TCP segments that contain a valid ACK value.
         debug_assert!(header.ack);
 
-        let remote_ipv4_addr: Ipv4Addr = *cb.remote.ip();
+        let remote_ipv4_addr = *cb.remote.ip();
         header.serialize_and_attach(
             &mut pkt,
             cb.local.ip(),


### PR DESCRIPTION
Removing visual and mental clutter allows for better naming of variables (especially the long-lived ones) and clear focus on semantics instead of the syntax.