### PR TITLE
catnap: cleanup type annotations and reduce syntactic clutter, better names

### DIFF
--- a/src/catnap/linux/active_socket.rs
+++ b/src/catnap/linux/active_socket.rs
@@ -12,7 +12,7 @@ use crate::{
     runtime::{fail::Fail, limits, memory::DemiBuffer, DemiRuntime},
 };
 use ::socket2::Socket;
-use ::std::{cmp::min, io, mem::MaybeUninit, net::SocketAddr};
+use ::std::{cmp::min, mem::MaybeUninit, net::SocketAddr, slice};
 
 //======================================================================================================================
 // Structures
@@ -21,7 +21,7 @@ use ::std::{cmp::min, io, mem::MaybeUninit, net::SocketAddr};
 /// This structure represents outgoing packets.
 struct Outgoing {
     addr: Option<SocketAddr>,
-    buf: DemiBuffer,
+    buffer: DemiBuffer,
     result: SharedAsyncValue<Option<Result<(), Fail>>>,
 }
 
@@ -54,43 +54,43 @@ impl ActiveSocketData {
     pub fn poll_send(&mut self) {
         if let Some(Outgoing {
             addr,
-            mut buf,
+            mut buffer,
             mut result,
         }) = self.send_queue.try_pop()
         {
             // A dummy request to detect when the socket has connected.
-            if buf.is_empty() {
+            if buffer.is_empty() {
                 result.set(Some(Ok(())));
                 return;
             }
             // Try to send the buffer.
-            let io_result: Result<usize, io::Error> = match addr {
-                Some(addr) => self.socket.send_to(&buf, &addr.into()),
-                None => self.socket.send(&buf),
+            let io_result = match addr {
+                Some(addr) => self.socket.send_to(&buffer, &addr.into()),
+                None => self.socket.send(&buffer),
             };
             match io_result {
                 // Operation completed.
                 Ok(nbytes) => {
-                    trace!("data pushed ({:?}/{:?} bytes)", nbytes, buf.len());
+                    trace!("data pushed ({:?}/{:?} bytes)", nbytes, buffer.len());
                     expect_ok!(
-                        buf.adjust(nbytes),
+                        buffer.adjust(nbytes),
                         "OS should not have sent more bytes than in the buffer"
                     );
-                    if buf.is_empty() {
+                    if buffer.is_empty() {
                         // Done sending this buffer
                         result.set(Some(Ok(())));
                     } else {
                         // Only sent part of the buffer so try again later.
-                        self.send_queue.push_front(Outgoing { addr, buf, result });
+                        self.send_queue.push_front(Outgoing { addr, buffer, result });
                     }
                 },
                 Err(e) => {
-                    let errno: i32 = get_libc_err(e);
+                    let errno = get_libc_err(e);
                     if DemiRuntime::should_retry(errno) {
                         // Put the buffer back and try again later.
-                        self.send_queue.push_front(Outgoing { addr, buf, result });
+                        self.send_queue.push_front(Outgoing { addr, buffer, result });
                     } else {
-                        let cause: String = format!("failed to send on socket: {:?}", errno);
+                        let cause = format!("failed to send on socket: {:?}", errno);
                         error!("poll_send(): {}", cause);
                         result.set(Some(Err(Fail::new(errno, &cause))));
                     }
@@ -103,30 +103,30 @@ impl ActiveSocketData {
     /// queue.
     /// TODO: Incoming queue should possibly be byte oriented.
     pub fn poll_recv(&mut self) {
-        let mut buf: DemiBuffer = DemiBuffer::new(limits::POP_SIZE_MAX as u16);
+        let mut buffer = DemiBuffer::new(limits::POP_SIZE_MAX as u16);
         if self.closed {
             return;
         }
         match self
             .socket
-            .recv_from(unsafe { std::slice::from_raw_parts_mut(buf.as_mut_ptr() as *mut MaybeUninit<u8>, buf.len()) })
+            .recv_from(unsafe { slice::from_raw_parts_mut(buffer.as_mut_ptr() as *mut MaybeUninit<u8>, buffer.len()) })
         {
             // Operation completed.
-            Ok((nbytes, socketaddr)) => {
-                if let Err(e) = buf.trim(buf.len() - nbytes) {
+            Ok((num_bytes, socketaddr)) => {
+                if let Err(e) = buffer.trim(buffer.len() - num_bytes) {
                     self.recv_queue.push(Err(e));
                 } else {
-                    trace!("data popped ({:?} bytes)", nbytes);
-                    if buf.is_empty() {
+                    trace!("data popped ({:?} bytes)", num_bytes);
+                    if buffer.is_empty() {
                         self.closed = true;
                     }
-                    self.recv_queue.push(Ok((socketaddr.as_socket(), buf)));
+                    self.recv_queue.push(Ok((socketaddr.as_socket(), buffer)));
                 }
             },
             Err(e) => {
-                let errno: i32 = get_libc_err(e);
+                let errno = get_libc_err(e);
                 if !DemiRuntime::should_retry(errno) {
-                    let cause: String = format!("failed to receive on socket: {:?}", errno);
+                    let cause = format!("failed to receive on socket: {:?}", errno);
                     error!("poll_recv(): {}", cause);
                     self.recv_queue.push(Err(Fail::new(errno, &cause)));
                 }
@@ -135,11 +135,11 @@ impl ActiveSocketData {
     }
 
     /// Pushes data to the socket. Blocks until completion.
-    pub async fn push(&mut self, addr: Option<SocketAddr>, buf: DemiBuffer) -> Result<(), Fail> {
-        let mut result: SharedAsyncValue<Option<Result<(), Fail>>> = SharedAsyncValue::new(None);
+    pub async fn push(&mut self, addr: Option<SocketAddr>, buffer: DemiBuffer) -> Result<(), Fail> {
+        let mut result = SharedAsyncValue::new(None);
         self.send_queue.push(Outgoing {
             addr,
-            buf,
+            buffer,
             result: result.clone(),
         });
         loop {
@@ -153,19 +153,18 @@ impl ActiveSocketData {
         }
     }
 
-    /// Pops data from the socket. Blocks until some data is found but does not wait until the buf has reached [size].
+    /// Pops data from the socket. Blocks until some data is found but does not wait until the buffer has reached [size].
     pub async fn pop(&mut self, size: usize) -> Result<(Option<SocketAddr>, DemiBuffer), Fail> {
-        let (addr, mut incoming): (Option<SocketAddr>, DemiBuffer) = self.recv_queue.pop(None).await??;
+        let (addr, mut buffer) = self.recv_queue.pop(None).await??;
         // Figure out how much data we got.
-        let bytes_read: usize = min(incoming.len(), size);
+        let bytes_read = min(buffer.len(), size);
         // Trim the buffer and leave for next read if we got more than expected.
-        if let Ok(remainder) = incoming.split_back(bytes_read) {
+        if let Ok(remainder) = buffer.split_back(bytes_read) {
             if !remainder.is_empty() {
                 self.recv_queue.push_front(Ok((addr, remainder)));
             }
         }
-
-        Ok((addr, incoming))
+        Ok((addr, buffer))
     }
 
     pub fn get_socket(&self) -> &Socket {

--- a/src/catnap/linux/passive_socket.rs
+++ b/src/catnap/linux/passive_socket.rs
@@ -43,14 +43,14 @@ impl PassiveSocketData {
             // Operation completed.
             Ok((new_socket, saddr)) => {
                 trace!("connection accepted ({:?})", new_socket);
-                let addr: SocketAddr = expect_some!(saddr.as_socket(), "not a SocketAddrV4");
+                let addr = expect_some!(saddr.as_socket(), "not a SocketAddrV4");
                 self.accept_queue.push(Ok((new_socket, addr)))
             },
             Err(e) => {
                 // Check the return error code.
-                let errno: i32 = get_libc_err(e);
+                let errno = get_libc_err(e);
                 if !DemiRuntime::should_retry(errno) {
-                    let cause: String = format!("failed to accept on socket: {:?}", errno);
+                    let cause = format!("failed to accept on socket: {:?}", errno);
                     error!("poll_accept(): {}", cause);
                     self.accept_queue.push(Err(Fail::new(errno, &cause)));
                 }

--- a/src/catnap/linux/socket.rs
+++ b/src/catnap/linux/socket.rs
@@ -51,7 +51,7 @@ impl SharedSocketData {
 
     /// Moves an inactive socket to a passive listening socket.
     pub fn move_socket_to_passive(&mut self) {
-        let socket: Socket = match self.deref_mut() {
+        let socket = match self.deref_mut() {
             SocketData::Inactive(socket) => expect_some!(socket.take(), "should have data"),
             SocketData::Active(_) => unreachable!("should not be able to move an active socket to a passive one"),
             SocketData::Passive(_) => return,
@@ -61,7 +61,7 @@ impl SharedSocketData {
 
     /// Moves an inactive socket to an active established socket.
     pub fn move_socket_to_active(&mut self) {
-        let socket: Socket = match self.deref_mut() {
+        let socket = match self.deref_mut() {
             SocketData::Inactive(socket) => expect_some!(socket.take(), "should have data"),
             SocketData::Active(_) => return,
             SocketData::Passive(_) => unreachable!("should not be able to move a passive socket to an active one"),
@@ -71,7 +71,7 @@ impl SharedSocketData {
 
     /// Gets a reference to the actual Socket for reading the socket's metadata (mostly the raw file descriptor).
     pub fn get_socket<'a>(&'a self) -> &'a Socket {
-        let _self: &'a SocketData = self.as_ref();
+        let _self = self.as_ref();
         match _self {
             SocketData::Inactive(Some(socket)) => socket,
             SocketData::Active(data) => data.get_socket(),
@@ -82,7 +82,7 @@ impl SharedSocketData {
 
     /// Gets a mutable reference to the actual Socket for I/O operations.
     pub fn get_mut_socket<'a>(&'a mut self) -> &'a mut Socket {
-        let _self: &'a mut SocketData = self.as_mut();
+        let _self = self.as_mut();
         match _self {
             SocketData::Inactive(Some(socket)) => socket,
             SocketData::Active(data) => data.get_mut_socket(),
@@ -97,10 +97,10 @@ impl SharedSocketData {
     }
 
     /// Push some data to an active established connection.
-    pub async fn push(&mut self, addr: Option<SocketAddr>, buf: DemiBuffer) -> Result<(), Fail> {
+    pub async fn push(&mut self, addr: Option<SocketAddr>, buffer: DemiBuffer) -> Result<(), Fail> {
         match self.deref_mut() {
             SocketData::Inactive(_) => unreachable!("Cannot write to an inactive socket"),
-            SocketData::Active(data) => data.push(addr, buf).await,
+            SocketData::Active(data) => data.push(addr, buffer).await,
             SocketData::Passive(_) => unreachable!("Cannot write to a passive socket"),
         }
     }

--- a/src/catnap/linux/transport.rs
+++ b/src/catnap/linux/transport.rs
@@ -56,7 +56,6 @@ pub struct CatnapTransport {
     options: TcpSocketOptions,
 }
 
-/// Shared network transport across coroutines.
 #[derive(Clone)]
 pub struct SharedCatnapTransport(SharedObject<CatnapTransport>);
 
@@ -68,26 +67,24 @@ type SockDesc = <SharedCatnapTransport as NetworkTransport>::SocketDescriptor;
 //======================================================================================================================
 
 impl SharedCatnapTransport {
-    /// Create a new Linux-based network transport.
     pub fn new(config: &Config, runtime: &mut SharedDemiRuntime) -> Result<Self, Fail> {
-        // Create epoll socket.
-        // Linux ignores the size argument to epoll, it just has to be more than 0.
-        let epoll_fd: RawFd = match unsafe { libc::epoll_create(10) } {
+        // Create epoll socket. Linux ignores the size argument to epoll, it just has to be more than 0.
+        let epoll_fd = match unsafe { libc::epoll_create(10) } {
             fd if fd >= 0 => fd,
             _ => {
-                let errno: libc::c_int = unsafe { *libc::__errno_location() };
+                let errno = unsafe { *libc::__errno_location() };
                 panic!("could not create epoll socket: {:?}", errno);
             },
         };
 
         // Set up background task for polling epoll API.
-        let me: Self = Self(SharedObject::new(CatnapTransport {
+        let me = Self(SharedObject::new(CatnapTransport {
             epoll_fd,
             socket_table: Slab::<SharedSocketData>::new(),
             runtime: runtime.clone(),
             options: TcpSocketOptions::new(config)?,
         }));
-        let mut me2: Self = me.clone();
+        let mut me2 = me.clone();
         runtime.insert_io_polling_coroutine(
             "bgc::catnap::transport::epoll",
             Box::pin(async move { me2.poll().await }.fuse()),
@@ -98,16 +95,16 @@ impl SharedCatnapTransport {
     /// This function registers a handler for incoming and outgoing I/O on the socket. There should only be one of
     /// these per socket.
     fn register_epoll(&mut self, sd: &SockDesc, events: u32) -> Result<(), Fail> {
-        let fd: RawFd = self.raw_fd_from_sd(sd);
-        let mut epoll_event: libc::epoll_event = libc::epoll_event {
+        let fd = self.raw_fd_from_sd(sd);
+        let mut epoll_event = libc::epoll_event {
             events,
             u64: *sd as u64,
         };
         match unsafe { libc::epoll_ctl(self.epoll_fd, libc::EPOLL_CTL_ADD, fd, &mut epoll_event) } {
             0 => Ok(()),
             _ => {
-                let errno: libc::c_int = unsafe { *libc::__errno_location() };
-                let cause: String = format!("failed to register epoll (fd={:?}, errno={:?})", fd, errno);
+                let errno = unsafe { *libc::__errno_location() };
+                let cause = format!("failed to register epoll (fd={:?}, errno={:?})", fd, errno);
                 error!("register_epoll(): {}", cause);
                 Err(Fail::new(errno, &cause))
             },
@@ -116,20 +113,20 @@ impl SharedCatnapTransport {
 
     /// THis function removes the handlers for incoming and outgoing I/O on the socket.
     fn unregister_epoll(&mut self, sd: &SockDesc, events: u32) -> Result<(), Fail> {
-        let fd: RawFd = self.raw_fd_from_sd(sd);
-        let mut epoll_event: libc::epoll_event = libc::epoll_event {
+        let fd = self.raw_fd_from_sd(sd);
+        let mut epoll_event = libc::epoll_event {
             events,
             u64: *sd as u64,
         };
         match unsafe { libc::epoll_ctl(self.epoll_fd, libc::EPOLL_CTL_DEL, fd, &mut epoll_event) } {
             0 => Ok(()),
             _ => {
-                let errno: libc::c_int = unsafe { *libc::__errno_location() };
+                let errno = unsafe { *libc::__errno_location() };
                 if errno == libc::EBADF || errno == libc::ENOENT {
                     warn!("epoll event was already removed or never registered");
                     return Ok(());
                 }
-                let cause: String = format!("failed to remove epoll (fd={:?}, errno={:?})", fd, errno);
+                let cause = format!("failed to remove epoll (fd={:?}, errno={:?})", fd, errno);
                 error!("unregister_epoll(): {}", cause);
                 Err(Fail::new(errno, &cause))
             },
@@ -138,11 +135,11 @@ impl SharedCatnapTransport {
 
     /// Background function for checking for epoll events.
     async fn poll(&mut self) {
-        let mut events: Vec<libc::epoll_event> = Vec::with_capacity(EPOLL_BATCH_SIZE);
+        let mut events = Vec::with_capacity(EPOLL_BATCH_SIZE);
         loop {
             match unsafe { libc::epoll_wait(self.epoll_fd, events.as_mut_ptr(), EPOLL_BATCH_SIZE as i32, 0) } {
                 result if result >= 0 => {
-                    let num_events: usize = result as usize;
+                    let num_events = result as usize;
                     unsafe {
                         events.set_len(num_events);
                     }
@@ -153,14 +150,13 @@ impl SharedCatnapTransport {
                     break;
                 },
                 _ => {
-                    let errno: libc::c_int = unsafe { *libc::__errno_location() };
-                    let cause: String = format!("epoll_wait failed (errno={:?})", errno);
-                    error!("poll(): {}", cause);
+                    let errno = unsafe { *libc::__errno_location() };
+                    error!("poll(): epoll_wait failed (errno={:?})", errno);
                     break;
                 },
             };
             while let Some(event) = events.pop() {
-                let offset: usize = event.u64 as usize;
+                let offset = event.u64 as usize;
                 if event.events & (libc::EPOLLIN as u32) != 0 {
                     // Wake pop.
                     expect_some!(
@@ -246,11 +242,11 @@ impl NetworkTransport for SharedCatnapTransport {
 
     /// Creates a new socket on the underlying network transport. We only support IPv4 and UDP and TCP sockets for now.
     fn socket(&mut self, domain: Domain, typ: Type) -> Result<Self::SocketDescriptor, Fail> {
-        let protocol: Protocol = match typ {
+        let protocol = match typ {
             Type::STREAM => Protocol::TCP,
             Type::DGRAM => Protocol::UDP,
             _ => {
-                let cause: String = format!("socket type not supported: {:?}", typ);
+                let cause = format!("socket type not supported: {:?}", typ);
                 error!("socket(): {}", cause);
                 return Err(Fail::new(libc::ENOTSUP, &cause));
             },
@@ -259,18 +255,17 @@ impl NetworkTransport for SharedCatnapTransport {
         // Attempts to shutdown a socket. If we fail, log a warn message and do not overwrite the original error.
         let attempt_shutdown = |socket: Socket| {
             if let Err(e) = socket.shutdown(Shutdown::Both) {
-                let cause: String = format!("cannot shutdown socket: {:?}", e);
-                warn!("socket(): {}", cause);
+                warn!("socket(): cannot shutdown socket: {:?}", e);
             }
         };
 
         // Create socket.
-        let socket: Socket = match socket2::Socket::new(domain, typ, Some(protocol)) {
+        let socket = match socket2::Socket::new(domain, typ, Some(protocol)) {
             Ok(socket) => {
                 // Set socket options.
                 if let Err(e) = socket.set_reuse_address(true) {
-                    let cause: String = format!("cannot set REUSE_ADDRESS option: {:?}", e);
-                    let errno: i32 = get_libc_err(e);
+                    let cause = format!("cannot set REUSE_ADDRESS option: {:?}", e);
+                    let errno = get_libc_err(e);
                     error!("socket(): {}", cause);
                     attempt_shutdown(socket);
                     return Err(Fail::new(errno, &cause));
@@ -280,8 +275,8 @@ impl NetworkTransport for SharedCatnapTransport {
                 let flags = unsafe { libc::fcntl(socket_fd, libc::F_GETFL) };
                 if flags & libc::O_NONBLOCK == 0 {
                     if let Err(e) = socket.set_nonblocking(true) {
-                        let cause: String = format!("cannot set NONBLOCKING option: {:?}", e);
-                        let errno: i32 = get_libc_err(e);
+                        let cause = format!("cannot set NONBLOCKING option: {:?}", e);
+                        let errno = get_libc_err(e);
                         error!("socket(): {}", cause);
                         attempt_shutdown(socket);
                         return Err(Fail::new(errno, &cause));
@@ -291,8 +286,8 @@ impl NetworkTransport for SharedCatnapTransport {
                 // Set TCP socket options
                 if typ == Type::STREAM {
                     if let Err(e) = socket.set_nodelay(self.options.get_nodelay()) {
-                        let cause: String = format!("cannot set TCP_NODELAY option: {:?}", e);
-                        let errno: i32 = get_libc_err(e);
+                        let cause = format!("cannot set TCP_NODELAY option: {:?}", e);
+                        let errno = get_libc_err(e);
                         error!("socket(): {}", cause);
                         attempt_shutdown(socket);
                         return Err(Fail::new(errno, &cause));
@@ -302,15 +297,15 @@ impl NetworkTransport for SharedCatnapTransport {
                 socket
             },
             Err(e) => {
-                let cause: String = format!("failed to create socket: {:?}", e);
+                let cause = format!("failed to create socket: {:?}", e);
                 error!("{}", cause);
                 return Err(Fail::new(get_libc_err(e), &cause));
             },
         };
-        let sd: Self::SocketDescriptor = match typ {
+        let sd = match typ {
             Type::STREAM => self.socket_table.insert(SharedSocketData::new_inactive(socket)),
             Type::DGRAM => {
-                let new_sd: Self::SocketDescriptor = self.socket_table.insert(SharedSocketData::new_active(socket));
+                let new_sd = self.socket_table.insert(SharedSocketData::new_active(socket));
                 self.register_epoll(&new_sd, (libc::EPOLLIN | libc::EPOLLOUT) as u32)?;
                 new_sd
             },
@@ -322,12 +317,12 @@ impl NetworkTransport for SharedCatnapTransport {
     /// Set an SO_* option on the socket.
     fn set_socket_option(&mut self, sd: &mut Self::SocketDescriptor, option: SocketOption) -> Result<(), Fail> {
         trace!("Set socket option to {:?}", option);
-        let socket: &mut Socket = self.socket_from_sd(sd);
+        let socket = self.socket_from_sd(sd);
         match option {
             SocketOption::Linger(linger) => {
                 if let Err(e) = socket.set_linger(linger) {
-                    let errno: i32 = get_libc_err(e);
-                    let cause: String = format!("SO_LINGER failed: {:?}", errno);
+                    let errno = get_libc_err(e);
+                    let cause = format!("SO_LINGER failed: {:?}", errno);
                     error!("set_socket_option(): {}", cause);
                     Err(Fail::new(errno, &cause))
                 } else {
@@ -336,8 +331,8 @@ impl NetworkTransport for SharedCatnapTransport {
             },
             SocketOption::KeepAlive(alive) => {
                 if let Err(e) = socket.set_keepalive(alive) {
-                    let errno: i32 = get_libc_err(e);
-                    let cause: String = format!("SO_KEEPALIVE failed: {:?}", errno);
+                    let errno = get_libc_err(e);
+                    let cause = format!("SO_KEEPALIVE failed: {:?}", errno);
                     error!("set_socket_option(): {}", cause);
                     Err(Fail::new(errno, &cause))
                 } else {
@@ -346,8 +341,8 @@ impl NetworkTransport for SharedCatnapTransport {
             },
             SocketOption::NoDelay(nagle_off) => {
                 if let Err(e) = socket.set_nodelay(nagle_off) {
-                    let errno: i32 = get_libc_err(e);
-                    let cause: String = format!("SO_TCP_NO_DELAY failed: {:?}", errno);
+                    let errno = get_libc_err(e);
+                    let cause = format!("SO_TCP_NO_DELAY failed: {:?}", errno);
                     error!("set_socket_option(): {}", cause);
                     Err(Fail::new(errno, &cause))
                 } else {
@@ -365,13 +360,13 @@ impl NetworkTransport for SharedCatnapTransport {
         option: SocketOption,
     ) -> Result<SocketOption, Fail> {
         trace!("Set socket option to {:?}", option);
-        let socket: &mut Socket = self.socket_from_sd(sd);
+        let socket = self.socket_from_sd(sd);
         match option {
             SocketOption::Linger(_) => match socket.linger() {
                 Ok(linger) => Ok(SocketOption::Linger(linger)),
                 Err(e) => {
-                    let errno: i32 = get_libc_err(e);
-                    let cause: String = format!("SO_LINGER failed: {:?}", errno);
+                    let errno = get_libc_err(e);
+                    let cause = format!("SO_LINGER failed: {:?}", errno);
                     error!("set_socket_option(): {}", cause);
                     Err(Fail::new(errno, &cause))
                 },
@@ -379,8 +374,8 @@ impl NetworkTransport for SharedCatnapTransport {
             SocketOption::KeepAlive(_) => match socket.keepalive() {
                 Ok(keepalive) => Ok(SocketOption::KeepAlive(keepalive)),
                 Err(e) => {
-                    let errno: i32 = get_libc_err(e);
-                    let cause: String = format!("SO_KEEPALIVE failed: {:?}", errno);
+                    let errno = get_libc_err(e);
+                    let cause = format!("SO_KEEPALIVE failed: {:?}", errno);
                     error!("set_socket_option(): {}", cause);
                     Err(Fail::new(errno, &cause))
                 },
@@ -388,8 +383,8 @@ impl NetworkTransport for SharedCatnapTransport {
             SocketOption::NoDelay(_) => match socket.nodelay() {
                 Ok(nagle_off) => Ok(SocketOption::NoDelay(nagle_off)),
                 Err(e) => {
-                    let errno: i32 = get_libc_err(e);
-                    let cause: String = format!("SO_TCP_NO_DELAY failed: {:?}", errno);
+                    let errno = get_libc_err(e);
+                    let cause = format!("SO_TCP_NO_DELAY failed: {:?}", errno);
                     error!("set_socket_option(): {}", cause);
                     Err(Fail::new(errno, &cause))
                 },
@@ -399,19 +394,19 @@ impl NetworkTransport for SharedCatnapTransport {
 
     // Gets peer name of connected socket.
     fn getpeername(&mut self, sd: &mut Self::SocketDescriptor) -> Result<SocketAddrV4, Fail> {
-        let socket: &mut Socket = self.socket_from_sd(sd);
+        let socket = self.socket_from_sd(sd);
         match socket.peer_addr() {
             Ok(addr) => match addr.as_socket_ipv4() {
                 Some(ipv4_addr) => Ok(ipv4_addr),
                 None => {
-                    let cause: &'static str = "invalid IPv4 address";
+                    let cause = "invalid IPv4 address";
                     error!("getpeername(): {}", cause);
                     Err(Fail::new(libc::EINVAL, cause))
                 },
             },
             Err(e) => {
-                let errno: i32 = get_libc_err(e);
-                let cause: String = format!("failed to get peer name (errno={:?})", errno);
+                let errno = get_libc_err(e);
+                let cause = format!("failed to get peer name (errno={:?})", errno);
                 error!("getpeername(): {}", cause);
                 Err(Fail::new(errno, &cause))
             },
@@ -421,11 +416,11 @@ impl NetworkTransport for SharedCatnapTransport {
     /// Binds a socket to [local] on the underlying network transport.
     fn bind(&mut self, sd: &mut Self::SocketDescriptor, local: SocketAddr) -> Result<(), Fail> {
         trace!("Bind to {:?}", local);
-        let socket: &mut Socket = self.socket_from_sd(sd);
+        let socket = self.socket_from_sd(sd);
 
         // Set SO_REUSE_PORT.
-        let optval: libc::c_int = 1;
-        let optval_len: libc::socklen_t = std::mem::size_of_val(&optval) as libc::socklen_t;
+        let optval = 1;
+        let optval_len = std::mem::size_of_val(&optval) as libc::socklen_t;
         if unsafe {
             libc::setsockopt(
                 socket.as_raw_fd(),
@@ -436,14 +431,14 @@ impl NetworkTransport for SharedCatnapTransport {
             )
         } < 0
         {
-            let e: i32 = get_libc_err(io::Error::last_os_error());
-            let cause: String = format!("failed to bind socket: {:?}", e);
+            let e = get_libc_err(io::Error::last_os_error());
+            let cause = format!("failed to bind socket: {:?}", e);
             error!("bind(): {}", cause);
             return Err(Fail::new(e, &cause));
         }
 
         if let Err(e) = socket.bind(&local.into()) {
-            let cause: String = format!("failed to bind socket: {:?}", e);
+            let cause = format!("failed to bind socket: {:?}", e);
             error!("bind(): {}", cause);
             Err(Fail::new(get_libc_err(e), &cause))
         } else {
@@ -455,7 +450,7 @@ impl NetworkTransport for SharedCatnapTransport {
     /// with epoll.
     fn listen(&mut self, sd: &mut Self::SocketDescriptor, backlog: usize) -> Result<(), Fail> {
         if let Err(e) = self.socket_from_sd(sd).listen(backlog as i32) {
-            let cause: String = format!("failed to listen on socket: {:?}", e);
+            let cause = format!("failed to listen on socket: {:?}", e);
             error!("listen(): {}", cause);
             return Err(Fail::new(get_libc_err(e), &cause));
         }
@@ -473,26 +468,26 @@ impl NetworkTransport for SharedCatnapTransport {
         let (new_socket, addr) = self.data_from_sd(sd).accept().await?;
         // Set socket options.
         if let Err(e) = new_socket.set_reuse_address(true) {
-            let cause: String = format!("cannot set REUSE_ADDRESS option: {:?}", e);
+            let cause = format!("cannot set REUSE_ADDRESS option: {:?}", e);
             new_socket.shutdown(Shutdown::Both)?;
             error!("accept(): {}", cause);
             return Err(Fail::new(get_libc_err(e), &cause));
         }
         if let Err(e) = new_socket.set_nodelay(true) {
-            let cause: String = format!("cannot set TCP_NODELAY option: {:?}", e);
+            let cause = format!("cannot set TCP_NODELAY option: {:?}", e);
             new_socket.shutdown(Shutdown::Both)?;
             error!("accept(): {}", cause);
             return Err(Fail::new(get_libc_err(e), &cause));
         }
         if let Err(e) = new_socket.set_nonblocking(true) {
-            let cause: String = format!("cannot set NONBLOCKING option: {:?}", e);
+            let cause = format!("cannot set NONBLOCKING option: {:?}", e);
             self.socket_from_sd(sd).shutdown(Shutdown::Both)?;
             error!("accept(): {}", cause);
             return Err(Fail::new(get_libc_err(e), &cause));
         }
 
-        let new_data: SharedSocketData = SharedSocketData::new_active(new_socket);
-        let new_sd: usize = self.socket_table.insert(new_data);
+        let new_data = SharedSocketData::new_active(new_socket);
+        let new_sd = self.socket_table.insert(new_data);
         self.register_epoll(&new_sd, (libc::EPOLLIN | libc::EPOLLOUT) as u32)?;
         Ok((new_sd, addr))
     }
@@ -508,11 +503,11 @@ impl NetworkTransport for SharedCatnapTransport {
                 Ok(()) => return Ok(()),
                 Err(e) => {
                     // Check the return error code.
-                    let errno: i32 = get_libc_err(e);
+                    let errno = get_libc_err(e);
                     if DemiRuntime::should_retry(errno) {
                         self.data_from_sd(sd).push(None, DemiBuffer::new(0)).await?;
                     } else {
-                        let cause: String = format!("failed to connect on socket: {:?}", errno);
+                        let cause = format!("failed to connect on socket: {:?}", errno);
                         error!("connect(): {}", cause);
                         return Err(Fail::new(errno, &cause));
                     }
@@ -523,13 +518,13 @@ impl NetworkTransport for SharedCatnapTransport {
 
     /// Close the socket and block until close completes.
     async fn close(&mut self, sd: &mut Self::SocketDescriptor) -> Result<(), Fail> {
-        let data: &mut SharedSocketData = self.data_from_sd(sd);
+        let data = self.data_from_sd(sd);
         loop {
             // Close the socket.
             match data.get_socket().shutdown(Shutdown::Both) {
                 Ok(()) => break,
                 Err(e) => {
-                    let errno: i32 = get_libc_err(e);
+                    let errno = get_libc_err(e);
                     // Close finished, so clean up and exit
                     match errno {
                         libc::ENOTCONN => break,
@@ -553,21 +548,21 @@ impl NetworkTransport for SharedCatnapTransport {
         Ok(())
     }
 
-    /// Push [buf] to the underlying transport. This function blocks until the entire buffer has been written to the
+    /// Push [buffer] to the underlying transport. This function blocks until the entire buffer has been written to the
     /// socket. Returns Ok if successfully sent and an error if not.
     async fn push(
         &mut self,
         sd: &mut Self::SocketDescriptor,
-        buf: &mut DemiBuffer,
+        buffer: &mut DemiBuffer,
         addr: Option<SocketAddr>,
     ) -> Result<(), Fail> {
-        self.data_from_sd(sd).push(addr, buf.clone()).await?;
+        self.data_from_sd(sd).push(addr, buffer.clone()).await?;
         // Clear out the original buffer.
-        expect_ok!(buf.trim(buf.len()), "Should be able to empty the buffer");
+        expect_ok!(buffer.trim(buffer.len()), "Should be able to empty the buffer");
         Ok(())
     }
 
-    /// Pop a [buf] of at most [size] from the underlying transport. This function blocks until the socket has data to
+    /// Pop a [buffer] of at most [size] from the underlying transport. This function blocks until the socket has data to
     /// be read. For connected (i.e., TCP) sockets, this function returns Ok(None). For datagram (i.e., UDP) sockets,
     /// this function returns the remote address that is the source of the incoming data.
     async fn pop(
@@ -580,12 +575,12 @@ impl NetworkTransport for SharedCatnapTransport {
 
     /// Close the socket on the underlying transport. Also unregisters the socket with epoll.
     fn hard_close(&mut self, sd: &mut Self::SocketDescriptor) -> Result<(), Fail> {
-        let data: &mut SharedSocketData = self.data_from_sd(sd);
+        let data = self.data_from_sd(sd);
         // Close the socket.
         match data.get_socket().shutdown(Shutdown::Both) {
             Ok(()) => (),
             Err(e) => {
-                let errno: i32 = get_libc_err(e);
+                let errno = get_libc_err(e);
                 // Close finished, so clean up and exit
                 match errno {
                     libc::ENOTCONN => (),

--- a/src/catnap/win/error.rs
+++ b/src/catnap/win/error.rs
@@ -6,17 +6,14 @@
 //======================================================================================================================
 
 use crate::runtime::fail::Fail;
-use windows::{
-    core::HRESULT,
-    Win32::{
-        Foundation::{
-            RtlNtStatusToDosError, ERROR_ABANDONED_WAIT_0, ERROR_ACCESS_DENIED, ERROR_ALREADY_EXISTS,
-            ERROR_INSUFFICIENT_BUFFER, ERROR_INVALID_HANDLE, ERROR_INVALID_PARAMETER, ERROR_IO_INCOMPLETE,
-            ERROR_IO_PENDING, ERROR_MORE_DATA, ERROR_NOT_ENOUGH_MEMORY, ERROR_OPERATION_ABORTED, ERROR_SUCCESS,
-            NTSTATUS, STATUS_ABANDONED, STATUS_SUCCESS, STATUS_TIMEOUT, WAIT_IO_COMPLETION, WAIT_TIMEOUT, WIN32_ERROR,
-        },
-        Networking::WinSock::{self, WSAGetLastError, WSABASEERR, WSA_ERROR, WSA_IO_PENDING},
+use windows::Win32::{
+    Foundation::{
+        RtlNtStatusToDosError, ERROR_ABANDONED_WAIT_0, ERROR_ACCESS_DENIED, ERROR_ALREADY_EXISTS,
+        ERROR_INSUFFICIENT_BUFFER, ERROR_INVALID_HANDLE, ERROR_INVALID_PARAMETER, ERROR_IO_INCOMPLETE,
+        ERROR_IO_PENDING, ERROR_MORE_DATA, ERROR_NOT_ENOUGH_MEMORY, ERROR_OPERATION_ABORTED, ERROR_SUCCESS, NTSTATUS,
+        STATUS_ABANDONED, STATUS_SUCCESS, STATUS_TIMEOUT, WAIT_IO_COMPLETION, WAIT_TIMEOUT, WIN32_ERROR,
     },
+    Networking::WinSock::{self, WSAGetLastError, WSABASEERR, WSA_ERROR, WSA_IO_PENDING},
 };
 
 //======================================================================================================================
@@ -25,8 +22,8 @@ use windows::{
 
 impl Fail {
     pub fn from_win32_error(error: &windows::core::Error, is_wait_error: bool) -> Fail {
-        let cause: String = format!("{}", error);
-        let errno: libc::errno_t = match WIN32_ERROR::from_error(error) {
+        let cause = format!("{}", error);
+        let errno = match WIN32_ERROR::from_error(error) {
             Some(error) => translate_win32_error(error, is_wait_error),
             None => libc::EFAULT,
         };
@@ -45,7 +42,7 @@ pub fn try_translate_win32_error(err: WIN32_ERROR, is_wait_api: bool) -> Option<
     const ERROR_WAIT_TIMEOUT: WIN32_ERROR = WIN32_ERROR(WAIT_TIMEOUT.0);
     const ERROR_WAIT_IO_COMPLETION: WIN32_ERROR = WIN32_ERROR(WAIT_IO_COMPLETION.0);
 
-    let errno: libc::errno_t = match err {
+    let errno = match err {
         ERROR_ACCESS_DENIED => libc::EACCES,
         ERROR_NOT_ENOUGH_MEMORY => libc::ENOMEM,
         ERROR_ALREADY_EXISTS => libc::EEXIST,
@@ -83,7 +80,7 @@ pub fn try_translate_wsa_error(err: WSA_ERROR) -> Option<libc::errno_t> {
         return None;
     }
 
-    let value: libc::errno_t = match err {
+    let value = match err {
         // Winsock errors with errno equivalents
         WinSock::WSAEINTR => libc::EINTR,
         WinSock::WSAEBADF => libc::EBADF,
@@ -195,18 +192,18 @@ pub fn translate_win32_error(error: WIN32_ERROR, is_wait_api: bool) -> libc::err
 
 /// Translate a win32 error stored as a WSA_ERROR into a windows crate Error type.
 fn wsa_error_to_win_error(err: WSA_ERROR) -> windows::core::Error {
-    let code: HRESULT = WIN32_ERROR(err.0 as u32).into();
+    let code = WIN32_ERROR(err.0 as u32).into();
     windows::core::Error::from_hresult(code)
 }
 
 /// Get the result of the most recent winsock overlapped operation, interpreting WSAGetLastError and handling
 /// IO_PENDING non-errors.
 pub fn last_overlapped_wsa_error() -> Result<(), Fail> {
-    let wsa_error: WSA_ERROR = unsafe { WSAGetLastError() };
+    let wsa_error = unsafe { WSAGetLastError() };
     if wsa_error == WSA_IO_PENDING {
         Ok(())
     } else {
-        let error: windows::core::Error = wsa_error_to_win_error(wsa_error);
+        let error = wsa_error_to_win_error(wsa_error);
         if error.code().is_ok() {
             Ok(())
         } else {
@@ -238,8 +235,8 @@ pub fn expect_last_wsa_error() -> Fail {
 /// Convert from WIN32_ERROR to Fail.
 impl From<WIN32_ERROR> for Fail {
     fn from(value: WIN32_ERROR) -> Self {
-        let code: HRESULT = value.into();
-        let error: windows::core::Error = windows::core::Error::from_hresult(code);
+        let code = value.into();
+        let error = windows::core::Error::from_hresult(code);
         error.into()
     }
 }

--- a/src/catnap/win/overlapped.rs
+++ b/src/catnap/win/overlapped.rs
@@ -81,7 +81,7 @@ impl OverlappedResult {
 
     /// Convert the OverlappedResult into a Result<...> indicating success or failure of the referent operation.
     pub fn ok(&self) -> Result<(), Fail> {
-        let win32_error: WIN32_ERROR = translate_ntstatus(self.result);
+        let win32_error = translate_ntstatus(self.result);
         if win32_error.is_ok() {
             Ok(())
         } else {
@@ -93,7 +93,7 @@ impl OverlappedResult {
 impl<S: Unpin> IoCompletionPort<S> {
     /// Create a new I/O completion port.
     pub fn new() -> Result<IoCompletionPort<S>, Fail> {
-        let iocp: HANDLE = match unsafe { CreateIoCompletionPort(INVALID_HANDLE_VALUE, None, 0, 1) } {
+        let iocp = match unsafe { CreateIoCompletionPort(INVALID_HANDLE_VALUE, None, 0, 1) } {
             Ok(handle) => handle,
             Err(err) => return Err(err.into()),
         };
@@ -150,7 +150,7 @@ impl<S: Unpin> IoCompletionPort<S> {
         for<'a> F2: FnOnce(Pin<&'a mut S>, OverlappedResult) -> Result<R, Fail>,
     {
         // Allocate a new Overlapped completion in the pin slab.
-        let pinslab_index: usize = match self.ops.insert(OverlappedCompletion::new(state)) {
+        let pinslab_index = match self.ops.insert(OverlappedCompletion::new(state)) {
             Some(index) => index,
             None => {
                 return Err(Fail::new(
@@ -160,21 +160,20 @@ impl<S: Unpin> IoCompletionPort<S> {
             },
         };
         // Grab a reference to the new completion in the pin slab.
-        let mut pinned_completion: Pin<&mut OverlappedCompletion<S>> =
-            expect_some!(self.ops.get_pin_mut(pinslab_index), "Just inserted this");
+        let mut pinned_completion = expect_some!(self.ops.get_pin_mut(pinslab_index), "Just inserted this");
 
         // Set the pinslab index so the I/O processor can remove it later if necessary.
         pinned_completion.as_mut().set_pinslab_index(pinslab_index);
 
-        let overlapped: *mut OVERLAPPED = pinned_completion.as_mut().marshal();
-        let result: Result<R, Fail> = match start(pinned_completion.as_mut().get_state(), overlapped) {
+        let overlapped = pinned_completion.as_mut().marshal();
+        let result = match start(pinned_completion.as_mut().get_state(), overlapped) {
             // Operation in progress, pending overlapped completion.
             Ok(()) => {
                 while let Some(mut cv) = pinned_completion.as_ref().get_cv() {
                     cv.wait().await;
                 }
 
-                let overlapped_result: OverlappedResult = OverlappedResult::new(
+                let overlapped_result = OverlappedResult::new(
                     pinned_completion.as_mut().overlapped,
                     pinned_completion.as_mut().completion_key,
                 );
@@ -219,10 +218,10 @@ impl<S: Unpin> IoCompletionPort<S> {
     pub fn process_events(&mut self) -> Result<(), Fail> {
         // Arbitrarily chosen batch size; should be updated after tuning.
         const BATCH_SIZE: usize = 4;
-        let mut entries: [OVERLAPPED_ENTRY; BATCH_SIZE] = [OVERLAPPED_ENTRY::default(); BATCH_SIZE];
+        let mut entries = [OVERLAPPED_ENTRY::default(); BATCH_SIZE];
 
         loop {
-            let mut dequeued: u32 = 0;
+            let mut dequeued = 0;
             match unsafe { GetQueuedCompletionStatusEx(self.iocp, entries.as_mut_slice(), &mut dequeued, 0, FALSE) } {
                 Ok(()) => {
                     for i in 0..dequeued {
@@ -247,7 +246,7 @@ impl<S: Unpin> IoCompletionPort<S> {
 
 impl<S: Unpin> OverlappedCompletion<S> {
     pub fn new(state: S) -> Self {
-        let cv: SharedConditionVariable = SharedConditionVariable::default();
+        let cv = SharedConditionVariable::default();
 
         Self {
             overlapped: OVERLAPPED::default(),
@@ -313,7 +312,7 @@ mod tests {
     use crate::{
         ensure_eq,
         runtime::{conditional_yield_with_timeout, SharedDemiRuntime},
-        OperationResult, QDesc, QToken,
+        OperationResult, QDesc,
     };
     use futures::pin_mut;
     use std::{
@@ -425,7 +424,7 @@ mod tests {
 
     #[test]
     fn test_marshal_unmarshal() -> Result<()> {
-        let mut completion: Pin<Box<OverlappedCompletion<()>>> = Box::pin(OverlappedCompletion::new(()));
+        let mut completion = Box::pin(OverlappedCompletion::new(()));
 
         // Ensure that the marshal returns the address of the overlapped member.
         ensure_eq!(
@@ -445,8 +444,8 @@ mod tests {
             (completion.as_ref().get_ref() as *const OverlappedCompletion<()>) as usize
         );
 
-        let overlapped_ptr: NonNull<OVERLAPPED> = NonNull::new(completion.as_mut().marshal()).unwrap();
-        let unmarshalled: Pin<&mut OverlappedCompletion<()>> = OverlappedCompletion::unmarshal(overlapped_ptr);
+        let overlapped_ptr = NonNull::new(completion.as_mut().marshal()).unwrap();
+        let unmarshalled = OverlappedCompletion::unmarshal(overlapped_ptr);
 
         // Test that unmarshal returns an address which is the same as the OVERLAPPED, which is the same as the original
         // OverlappedCompletionWithState. This implies that OVERLAPPED is at member offset 0 in all structs.
@@ -463,19 +462,19 @@ mod tests {
     fn test_event_processor() -> Result<()> {
         const COMPLETION_KEY: usize = 123;
         let mut iocp: IoCompletionPort<()> = make_iocp()?;
-        let overlapped: OverlappedCompletion<()> = OverlappedCompletion::new(());
-        let mut cv: SharedConditionVariable = overlapped.condition_variable.clone().unwrap();
+        let overlapped = OverlappedCompletion::new(());
+        let mut cv = overlapped.condition_variable.clone().unwrap();
         pin_mut!(overlapped);
 
         // Insert coroutine
-        let mut runtime: SharedDemiRuntime = SharedDemiRuntime::default();
+        let mut runtime = SharedDemiRuntime::default();
         let server = run_as_io_op(async move {
             cv.wait().await;
             Ok(OperationResult::Close)
         })
         .fuse();
 
-        let server_task: QToken = runtime
+        let server_task = runtime
             .insert_nonpolling_coroutine("ioc_server", Box::pin(server))
             .unwrap();
         post_completion(&iocp, overlapped.as_mut().marshal(), COMPLETION_KEY)?;
@@ -503,7 +502,7 @@ mod tests {
         const PIPE_NAME: PCSTR = s!(r"\\.\pipe\demikernel-test-pipe");
         const BUFFER_SIZE: u32 = 128;
         const COMPLETION_KEY: usize = 0xFEEDF00D;
-        let server_pipe: SafeHandle = SafeHandle(unsafe {
+        let server_pipe = SafeHandle(unsafe {
             CreateNamedPipeA(
                 PIPE_NAME,
                 PIPE_ACCESS_DUPLEX | FILE_FLAG_FIRST_PIPE_INSTANCE | FILE_FLAG_OVERLAPPED,
@@ -515,11 +514,11 @@ mod tests {
                 None,
             )
         }?);
-        let server_state: Rc<AtomicU32> = Rc::new(AtomicU32::new(0));
-        let server_state_view: Rc<AtomicU32> = server_state.clone();
-        let mut iocp: UnsafeCell<IoCompletionPort<Rc<Vec<u8>>>> = UnsafeCell::new(make_iocp().map_err(anyhow_fail)?);
+        let server_state = Rc::new(AtomicU32::new(0));
+        let server_state_view = server_state.clone();
+        let mut iocp = UnsafeCell::new(make_iocp().map_err(anyhow_fail)?);
         iocp.get_mut().associate_handle(server_pipe.0, COMPLETION_KEY)?;
-        let iocp_ref: &mut IoCompletionPort<Rc<Vec<u8>>> = unsafe { &mut *iocp.get() };
+        let iocp_ref = unsafe { &mut *iocp.get() };
 
         let server = Box::pin(
             run_as_io_op(async move {
@@ -537,13 +536,12 @@ mod tests {
 
                 server_state.fetch_add(1, Ordering::Relaxed);
 
-                let mut buffer: Rc<Vec<u8>> =
-                    Rc::new(iter::repeat(0u8).take(BUFFER_SIZE as usize).collect::<Vec<u8>>());
+                let mut buffer = Rc::new(iter::repeat(0u8).take(BUFFER_SIZE as usize).collect::<Vec<u8>>());
                 buffer = unsafe {
                     iocp_ref.do_io(
                         buffer,
                         |state: Pin<&mut Rc<Vec<u8>>>, overlapped: *mut OVERLAPPED| -> Result<(), Fail> {
-                            let vec: &mut Vec<u8> = Rc::get_mut(state.get_mut()).unwrap();
+                            let vec = Rc::get_mut(state.get_mut()).unwrap();
                             vec.resize(BUFFER_SIZE as usize, 0u8);
                             is_overlapped_ok(ReadFile(
                                 server_pipe.0,
@@ -572,10 +570,10 @@ mod tests {
                 }
                 .await?;
 
-                let message: &str = std::str::from_utf8(buffer.as_slice())
+                let message = std::str::from_utf8(buffer.as_slice())
                     .map_err(|_| Fail::new(libc::EINVAL, "utf8 conversion failed"))?;
                 if message != MESSAGE {
-                    let err_msg: String = format!("expected \"{}\", got \"{}\"", MESSAGE, message);
+                    let err_msg = format!("expected \"{}\", got \"{}\"", MESSAGE, message);
                     Err(Fail::new(libc::EINVAL, err_msg.as_str()))
                 } else {
                     // Dummy result
@@ -585,8 +583,8 @@ mod tests {
             .fuse(),
         );
 
-        let mut runtime: SharedDemiRuntime = SharedDemiRuntime::default();
-        let server_task: QToken = runtime.insert_nonpolling_coroutine("ioc_server", server).unwrap();
+        let mut runtime = SharedDemiRuntime::default();
+        let server_task = runtime.insert_nonpolling_coroutine("ioc_server", server).unwrap();
 
         let mut wait_for_state = |state| -> Result<(), Fail> {
             while server_state_view.load(Ordering::Relaxed) < state {
@@ -604,7 +602,7 @@ mod tests {
 
         wait_for_state(1)?;
 
-        let client_handle: SafeHandle = SafeHandle(unsafe {
+        let client_handle = SafeHandle(unsafe {
             CreateFileA(
                 PIPE_NAME,
                 GENERIC_WRITE.0,
@@ -618,7 +616,7 @@ mod tests {
 
         wait_for_state(2)?;
 
-        let mut bytes_written: u32 = 0;
+        let mut bytes_written = 0;
         unsafe {
             WriteFile(
                 client_handle.0,
@@ -630,7 +628,7 @@ mod tests {
 
         std::mem::drop(client_handle);
 
-        let result: OperationResult = loop {
+        let result = loop {
             iocp.get_mut().process_events()?;
             if let Ok((_, result)) = runtime.wait(server_task, Duration::ZERO) {
                 break result;
@@ -650,7 +648,7 @@ mod tests {
         const PIPE_NAME: PCSTR = s!(r"\\.\pipe\demikernel-test-cancel-pipe");
         const BUFFER_SIZE: u32 = 128;
         const COMPLETION_KEY: usize = 0xFEEDF00D;
-        let server_pipe: SafeHandle = SafeHandle(unsafe {
+        let server_pipe = SafeHandle(unsafe {
             CreateNamedPipeA(
                 PIPE_NAME,
                 PIPE_ACCESS_DUPLEX | FILE_FLAG_FIRST_PIPE_INSTANCE | FILE_FLAG_OVERLAPPED,
@@ -662,11 +660,11 @@ mod tests {
                 None,
             )
         }?);
-        let server_state: Rc<AtomicU32> = Rc::new(AtomicU32::new(0));
-        let server_state_view: Rc<AtomicU32> = server_state.clone();
-        let mut iocp: UnsafeCell<IoCompletionPort<()>> = UnsafeCell::new(make_iocp().map_err(anyhow_fail)?);
+        let server_state = Rc::new(AtomicU32::new(0));
+        let server_state_view = server_state.clone();
+        let mut iocp = UnsafeCell::new(make_iocp().map_err(anyhow_fail)?);
         iocp.get_mut().associate_handle(server_pipe.0, COMPLETION_KEY)?;
-        let iocp_ref: &mut IoCompletionPort<()> = unsafe { &mut *iocp.get() };
+        let iocp_ref = unsafe { &mut *iocp.get() };
 
         let server = run_as_io_op(async move {
             match conditional_yield_with_timeout(
@@ -690,8 +688,8 @@ mod tests {
         })
         .fuse();
 
-        let mut runtime: SharedDemiRuntime = SharedDemiRuntime::default();
-        let server_task: QToken = runtime
+        let mut runtime = SharedDemiRuntime::default();
+        let server_task = runtime
             .insert_nonpolling_coroutine("ioc_server", Box::pin(server))
             .unwrap();
 
@@ -701,11 +699,11 @@ mod tests {
             "server execution should have started"
         );
 
-        let iocp_ref: &mut IoCompletionPort<()> = unsafe { &mut *iocp.get() };
+        let iocp_ref = unsafe { &mut *iocp.get() };
         iocp_ref.process_events()?;
 
         // Poll the runtime again, which
-        let result: OperationResult = loop {
+        let result = loop {
             // Move time forward, which should time out the operation.
             runtime.advance_clock(Instant::now());
             iocp.get_mut().process_events()?;

--- a/src/catnap/win/socket.rs
+++ b/src/catnap/win/socket.rs
@@ -24,13 +24,13 @@ use std::{
 use windows::{
     core::PSTR,
     Win32::{
-        Foundation::{BOOL, ERROR_NOT_FOUND, FALSE, HANDLE, TRUE},
+        Foundation::{ERROR_NOT_FOUND, FALSE, HANDLE, TRUE},
         Networking::WinSock::{
             bind, closesocket, listen, shutdown, tcp_keepalive, WSAGetLastError, WSARecvFrom, WSASendTo,
             FROM_PROTOCOL_INFO, INVALID_SOCKET, IPPROTO_TCP, LINGER, SD_BOTH, SIO_KEEPALIVE_VALS, SOCKADDR,
             SOCKADDR_IN, SOCKADDR_IN6, SOCKADDR_INET, SOCKADDR_STORAGE, SOCKET, SOCKET_ERROR, SOL_SOCKET, SO_KEEPALIVE,
             SO_LINGER, SO_PROTOCOL_INFOW, SO_UPDATE_ACCEPT_CONTEXT, SO_UPDATE_CONNECT_CONTEXT, TCP_NODELAY, WSABUF,
-            WSAEINVAL, WSAPROTOCOL_INFOW, WSA_FLAG_OVERLAPPED,
+            WSAEINVAL, WSA_FLAG_OVERLAPPED,
         },
         System::IO::{CancelIoEx, OVERLAPPED},
     },
@@ -113,7 +113,7 @@ impl Socket {
         extensions: Rc<SocketExtensions>,
         iocp: &IoCompletionPort<SocketOpState>,
     ) -> Result<Socket, Fail> {
-        let s: Socket = Socket { s, extensions };
+        let s = Socket { s, extensions };
         s.setup_socket(protocol, options)?;
         iocp.associate_socket(s.s, 0)?;
         Ok(s)
@@ -141,7 +141,7 @@ impl Socket {
 
     /// Set linger socket options.
     pub fn set_linger(&self, linger_time: Option<Duration>) -> Result<(), Fail> {
-        let l: LINGER = LINGER {
+        let l = LINGER {
             l_onoff: if linger_time.is_some() { 1 } else { 0 },
             l_linger: linger_time.unwrap_or(Duration::ZERO).as_secs() as u16,
         };
@@ -161,7 +161,7 @@ impl Socket {
 
     /// Get address of peer connected to socket
     pub fn getpeername(&self) -> Result<SocketAddrV4, Fail> {
-        let addr: Result<SocketAddrV4, Fail> = WinsockRuntime::getpeername(self.s);
+        let addr = WinsockRuntime::getpeername(self.s);
         addr
     }
 
@@ -187,7 +187,7 @@ impl Socket {
     /// Enable or disable the use of Nagle's algorithm for TCP.
     pub fn set_nagle(&self, enabled: bool) -> Result<(), Fail> {
         // Note the inverted condition here: TCP_NODELAY is a disabler for Nagle's algorithm.
-        let value: BOOL = if enabled { FALSE } else { TRUE };
+        let value = if enabled { FALSE } else { TRUE };
         unsafe { WinsockRuntime::do_setsockopt(self.s, IPPROTO_TCP.0, TCP_NODELAY, Some(&value)) }?;
         Ok(())
     }
@@ -203,13 +203,11 @@ impl Socket {
     /// Make a new socket like some template socket.
     pub fn new_like(template: &Socket) -> Result<Socket, Fail> {
         // Safety: SO_PROTOCOL_INFOW fills out a WSAPROTOCOL_INFOW structure.
-        let protocol: WSAPROTOCOL_INFOW =
-            unsafe { WinsockRuntime::do_getsockopt(template.s, SOL_SOCKET, SO_PROTOCOL_INFOW) }?;
-
-        let extensions: Rc<SocketExtensions> = template.extensions.clone();
+        let protocol = unsafe { WinsockRuntime::do_getsockopt(template.s, SOL_SOCKET, SO_PROTOCOL_INFOW) }?;
+        let extensions = template.extensions.clone();
 
         // Safety: SOCKET handle is transferred to a Socket instance, which will safely close the handle on drop.
-        let s: SOCKET = unsafe {
+        let s = unsafe {
             WinsockRuntime::raw_socket(
                 FROM_PROTOCOL_INFO,
                 FROM_PROTOCOL_INFO,
@@ -225,8 +223,7 @@ impl Socket {
     /// Begin disconnecting a connection-oriented socket. If called on a non-stream-based socket or an unconnected
     /// stream-based socket, this method will return an `ENOTCONN` failure.
     pub fn start_disconnect(&self, overlapped: *mut OVERLAPPED) -> Result<(), Fail> {
-        let result: bool = unsafe { self.extensions.disconnectex.unwrap()(self.s, overlapped, 0, 0).as_bool() };
-
+        let result = unsafe { self.extensions.disconnectex.unwrap()(self.s, overlapped, 0, 0).as_bool() };
         get_overlapped_api_result(result)
     }
 
@@ -250,7 +247,7 @@ impl Socket {
     /// Call `bind` winsock API on self.
     pub fn bind(&self, local: SocketAddr) -> Result<(), Fail> {
         let sockaddr: socket2::SockAddr = local.into();
-        let result: i32 = unsafe { bind(self.s, sockaddr.as_ptr().cast(), sockaddr.len()) };
+        let result = unsafe { bind(self.s, sockaddr.as_ptr().cast(), sockaddr.len()) };
 
         if result == 0 {
             Ok(())
@@ -261,7 +258,7 @@ impl Socket {
 
     /// Call `listen` winsock API on self.
     pub fn listen(&self, backlog: usize) -> Result<(), Fail> {
-        let backlog: i32 = i32::try_from(backlog).unwrap_or(i32::MAX);
+        let backlog = i32::try_from(backlog).unwrap_or(i32::MAX);
         if unsafe { listen(self.s, backlog) } == 0 {
             Ok(())
         } else {
@@ -286,19 +283,19 @@ impl Socket {
     /// Start an overlapped accept operation; this must be called from inside IoCompletionPort::do_io/do_socket_io.
     /// Once the operation completes, the AcceptState can be given to `finish_accept` to finish the operation.
     pub fn start_accept(&self, state: Pin<&mut SocketOpState>, overlapped: *mut OVERLAPPED) -> Result<(), Fail> {
-        let accept_result: &mut AcceptState = match state.get_mut() {
+        let accept_result = match state.get_mut() {
             SocketOpState::Accept(ref mut accept_result) => accept_result,
             _ => unreachable!("must be an accept operation"),
         };
-        let new_socket: Socket = Socket::new_like(self)?;
+        let new_socket = Socket::new_like(self)?;
 
         // Safety: getting the buffer pointer does not violate pinning invariants.
-        let buf_ptr: *mut u8 = accept_result.buffer.as_mut_ptr();
-        let mut bytes_out: u32 = 0;
+        let buf_ptr = accept_result.buffer.as_mut_ptr();
+        let mut bytes_out = 0;
 
         // Safety: buffer pointers refer to valid, live locations for the duration of the call iff accept_result stays
         // alive until the completion.
-        let success: bool = unsafe {
+        let success = unsafe {
             self.extensions.acceptex.unwrap()(
                 self.s,
                 new_socket.s,
@@ -330,7 +327,7 @@ impl Socket {
     ) -> Result<(Socket, SocketAddr, SocketAddr), Fail> {
         result.ok()?;
 
-        let accept_result: &mut AcceptState = match state.get_mut() {
+        let accept_result = match state.get_mut() {
             SocketOpState::Accept(ref mut accept_result) => accept_result,
             _ => unreachable!("must be an accept operation"),
         };
@@ -356,10 +353,10 @@ impl Socket {
             // crate.
             let mut localsockaddr: MaybeUninit<*mut windows_sys::Win32::Networking::WinSock::SOCKADDR_STORAGE> =
                 MaybeUninit::zeroed();
-            let mut localsockaddrlength: i32 = 0;
+            let mut localsockaddrlength = 0;
             let mut remotesockaddr: MaybeUninit<*mut windows_sys::Win32::Networking::WinSock::SOCKADDR_STORAGE> =
                 MaybeUninit::zeroed();
-            let mut remotesockaddrlength: i32 = 0;
+            let mut remotesockaddrlength = 0;
 
             self.extensions.get_acceptex_sockaddrs.unwrap()(
                 accept_result.buffer.as_ptr().cast(),
@@ -382,11 +379,11 @@ impl Socket {
             )
         };
 
-        let local_addr: SocketAddr = local_addr
+        let local_addr = local_addr
             .as_socket()
             .ok_or_else(|| Fail::new(libc::EAFNOSUPPORT, "bad local socket address from accept"))?;
 
-        let remote_addr: SocketAddr = remote_addr
+        let remote_addr = remote_addr
             .as_socket()
             .ok_or_else(|| Fail::new(libc::EAFNOSUPPORT, "bad remote socket address from accept"))?;
 
@@ -399,10 +396,10 @@ impl Socket {
         const IN6ADDR_ANY: SocketAddrV6 = SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, 0, 0, 0);
         const INADDR_ANY: SocketAddrV4 = SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0);
 
-        let (remote_addr, remote_len): (SOCKADDR_INET, i32) = Self::translate_address(remote);
-        let success: bool = unsafe {
+        let (remote_addr, remote_len) = Self::translate_address(remote);
+        let success = unsafe {
             // NB ConnectEx requires the socket to be explicitly bound.
-            let (localaddr, locallen): (SOCKADDR_INET, i32) = match remote {
+            let (localaddr, locallen) = match remote {
                 SocketAddr::V4(_) => Self::translate_address(INADDR_ANY.into()),
                 SocketAddr::V6(_) => Self::translate_address(IN6ADDR_ANY.into()),
             };
@@ -440,15 +437,15 @@ impl Socket {
     /// immediately, in which case an overlapped completion is not scheduled. To indicate this case, this method will
     /// return EAGAIN and update `buffer` according to the number of bytes received.
     pub fn start_pop(&self, state: Pin<&mut SocketOpState>, overlapped: *mut OVERLAPPED) -> Result<(), Fail> {
-        let pop_state: &mut PopState = match state.get_mut() {
+        let pop_state = match state.get_mut() {
             SocketOpState::Pop(ref mut pop_state) => pop_state,
             _ => unreachable!("must be an accept operation"),
         };
 
-        let mut bytes_transferred: u32 = 0;
-        let mut flags: u32 = 0;
-        let success: bool = unsafe {
-            let wsa_buffer: WSABUF = WSABUF {
+        let mut bytes_transferred = 0;
+        let mut flags = 0;
+        let success = unsafe {
+            let wsa_buffer = WSABUF {
                 len: pop_state.buffer.len() as u32,
                 // Safety: loading the buffer pointer won't violate pinning invariants.
                 buf: PSTR::from_raw(pop_state.buffer.as_mut_ptr()),
@@ -456,7 +453,7 @@ impl Socket {
 
             // NB winsock service providers are required to capture the entire WSABUF array inline with the call, so
             // wsa_buffer and the derivative slice can safely drop after the call.
-            let result: i32 = WSARecvFrom(
+            let result = WSARecvFrom(
                 self.s,
                 std::slice::from_ref(&wsa_buffer),
                 Some(&mut bytes_transferred),
@@ -486,12 +483,12 @@ impl Socket {
         // not useful for this implementation.
         result.ok()?;
 
-        let pop_state: &mut PopState = match state.get_mut() {
+        let pop_state = match state.get_mut() {
             SocketOpState::Pop(ref mut pop_state) => pop_state,
             _ => unreachable!("must be an accept operation"),
         };
 
-        let addr: Option<SocketAddr> = if pop_state.addr_len > 0 {
+        let addr = if pop_state.addr_len > 0 {
             // Safety: since we are done with the overlapped API, pinning is no longer required for pop_state. The
             // returned address and addr_len values come from the OS, so they will be valid to pass to socket2.
             unsafe {
@@ -515,26 +512,26 @@ impl Socket {
         addr: Option<SocketAddr>,
         overlapped: *mut OVERLAPPED,
     ) -> Result<(), Fail> {
-        let buffer: &mut DemiBuffer = match state.get_mut() {
+        let buffer = match state.get_mut() {
             SocketOpState::Push(ref mut buffer) => buffer,
             _ => unreachable!("must be an accept operation"),
         };
 
-        let mut bytes_transferred: u32 = 0;
-        let success: bool = unsafe {
-            let wsa_buffer: WSABUF = WSABUF {
+        let mut bytes_transferred = 0;
+        let success = unsafe {
+            let wsa_buffer = WSABUF {
                 len: buffer.len() as u32,
                 // Safety: loading the buffer pointer won't violate pinning invariants.
                 buf: PSTR::from_raw(buffer.as_mut_ptr()),
             };
 
-            let addr: Option<socket2::SockAddr> = addr.map(socket2::SockAddr::from);
+            let addr = addr.map(socket2::SockAddr::from);
 
             // NB winsock service providers are required to capture the entire WSABUF array inline with the call, so
             // wsa_buffer and the derivative slice can safely drop after the call.
             // Per Windows documentation, WSASendTo ignores the destination address for connection oriented sockets and
             // functions equivalently to WSASend.
-            let result: i32 = WSASendTo(
+            let result = WSASendTo(
                 self.s,
                 std::slice::from_ref(&wsa_buffer),
                 Some(&mut bytes_transferred),

--- a/src/catnap/win/transport.rs
+++ b/src/catnap/win/transport.rs
@@ -34,7 +34,7 @@ use std::{
     pin::Pin,
 };
 use windows::Win32::{
-    Networking::WinSock::{WSAGetLastError, IPPROTO, IPPROTO_TCP, IPPROTO_UDP},
+    Networking::WinSock::{WSAGetLastError, IPPROTO_TCP, IPPROTO_UDP},
     System::IO::OVERLAPPED,
 };
 
@@ -68,7 +68,7 @@ pub struct SharedCatnapTransport(SharedObject<CatnapTransport>);
 impl SharedCatnapTransport {
     /// Create a new transport instance.
     pub fn new(config: &Config, runtime: &mut SharedDemiRuntime) -> Result<Self, Fail> {
-        let me: Self = Self(SharedObject::new(CatnapTransport {
+        let me = Self(SharedObject::new(CatnapTransport {
             winsock: expect_ok!(WinsockRuntime::new(), "failed to initialize WinSock"),
             iocp: expect_ok!(IoCompletionPort::new(), "failed to setup I/O completion port"),
             options: TcpSocketOptions::new(config)?,
@@ -78,7 +78,7 @@ impl SharedCatnapTransport {
         runtime.insert_io_polling_coroutine(
             "bgc::catnap::transport::epoll",
             Box::pin({
-                let mut me: Self = me.clone();
+                let mut me = me.clone();
                 async move { me.run_event_processor().await }.fuse()
             }),
         )?;
@@ -108,11 +108,11 @@ impl NetworkTransport for SharedCatnapTransport {
     /// Create a new socket for the specified domain and type.
     fn socket(&mut self, domain: socket2::Domain, typ: socket2::Type) -> Result<Socket, Fail> {
         // Select protocol.
-        let protocol: IPPROTO = match typ {
+        let protocol = match typ {
             socket2::Type::STREAM => IPPROTO_TCP,
             socket2::Type::DGRAM => IPPROTO_UDP,
             _ => {
-                let cause: String = format!("socket type not supported: {}", libc::c_int::from(typ));
+                let cause = format!("socket type not supported: {}", libc::c_int::from(typ));
                 error!("transport::socket(): {}", &cause);
                 return Err(Fail::new(libc::ENOTSUP, &cause));
             },
@@ -121,7 +121,7 @@ impl NetworkTransport for SharedCatnapTransport {
         let me: &mut CatnapTransport = &mut self.0;
 
         // Create socket.
-        let s: Socket = me
+        let s = me
             .winsock
             .socket(domain.into(), typ.into(), protocol.0, &me.options, &me.iocp)?;
         Ok(s)
@@ -154,11 +154,11 @@ impl NetworkTransport for SharedCatnapTransport {
 
     // Gets address of peer connected to socket
     fn getpeername(&mut self, socket: &mut Self::SocketDescriptor) -> Result<SocketAddrV4, Fail> {
-        let addr: Result<SocketAddrV4, Fail> = socket.getpeername();
+        let addr = socket.getpeername();
         match addr {
             Ok(addr) => Ok(addr),
             Err(_) => {
-                let cause: String = format!("failed to get peer address (errno={:?})", unsafe { WSAGetLastError() });
+                let cause = format!("failed to get peer address (errno={:?})", unsafe { WSAGetLastError() });
                 error!("getpeername(): {:?}", cause);
                 Err(Fail::new(libc::EINVAL, &cause))
             },
@@ -206,7 +206,7 @@ impl NetworkTransport for SharedCatnapTransport {
         let start = |accept_result: Pin<&mut SocketOpState>, overlapped: *mut OVERLAPPED| -> Result<(), Fail> {
             socket.start_accept(accept_result, overlapped)
         };
-        let me_finish: Self = self.clone();
+        let me_finish = self.clone();
         let finish = |accept_result: Pin<&mut SocketOpState>,
                       result: OverlappedResult|
          -> Result<(Socket, SocketAddr, SocketAddr), Fail> {
@@ -245,10 +245,10 @@ impl NetworkTransport for SharedCatnapTransport {
         socket: &mut Self::SocketDescriptor,
         size: usize,
     ) -> Result<(Option<SocketAddr>, DemiBuffer), Fail> {
-        let mut buf: DemiBuffer = DemiBuffer::new(size as u16);
+        let mut buffer = DemiBuffer::new(size as u16);
         unsafe {
             self.0.iocp.do_io(
-                SocketOpState::Pop(PopState::new(buf.clone())),
+                SocketOpState::Pop(PopState::new(buffer.clone())),
                 |state: Pin<&mut SocketOpState>, overlapped: *mut OVERLAPPED| -> Result<(), Fail> {
                     socket.start_pop(state, overlapped)
                 },
@@ -259,13 +259,13 @@ impl NetworkTransport for SharedCatnapTransport {
         }
         .await
         .and_then(|(nbytes, sockaddr)| {
-            buf.trim(buf.len() - nbytes)?;
+            buffer.trim(buffer.len() - nbytes)?;
             if nbytes > 0 {
                 trace!("data received ({:?}/{:?} bytes)", nbytes, size);
             } else {
                 trace!("not data received");
             }
-            Ok((sockaddr, buf))
+            Ok((sockaddr, buffer))
         })
     }
 
@@ -279,7 +279,7 @@ impl NetworkTransport for SharedCatnapTransport {
         addr: Option<SocketAddr>,
     ) -> Result<(), Fail> {
         loop {
-            let result: Result<usize, Fail> = unsafe {
+            let result = unsafe {
                 self.0.iocp.do_io(
                     SocketOpState::Push(buf.clone()),
                     |state: Pin<&mut SocketOpState>, overlapped: *mut OVERLAPPED| -> Result<(), Fail> {
@@ -303,8 +303,8 @@ impl NetworkTransport for SharedCatnapTransport {
 
                 Err(fail) => {
                     if !DemiRuntime::should_retry(fail.errno) {
-                        let message: String = format!("push failed: {}", fail.cause);
-                        return Err(Fail::new(fail.errno, message.as_str()));
+                        let msg = format!("push failed: {}", fail.cause);
+                        return Err(Fail::new(fail.errno, msg.as_str()));
                     }
                 },
             }

--- a/src/catnap/win/winsock.rs
+++ b/src/catnap/win/winsock.rs
@@ -24,10 +24,10 @@ use windows::{
     core::{GUID, PSTR},
     Win32::Networking::WinSock::{
         closesocket, getpeername, getsockopt, setsockopt, WSACleanup, WSAIoctl, WSASocketW, WSAStartup, INVALID_SOCKET,
-        IN_ADDR_0_0, LPFN_ACCEPTEX, LPFN_CONNECTEX, LPFN_DISCONNECTEX, LPFN_GETACCEPTEXSOCKADDRS,
-        RIO_EXTENSION_FUNCTION_TABLE, SIO_GET_EXTENSION_FUNCTION_POINTER, SIO_GET_MULTIPLE_EXTENSION_FUNCTION_POINTER,
-        SOCKADDR, SOCKADDR_IN, SOCKET, SOL_SOCKET, SO_PROTOCOL_INFOW, WSADATA, WSAID_ACCEPTEX, WSAID_CONNECTEX,
-        WSAID_DISCONNECTEX, WSAID_GETACCEPTEXSOCKADDRS, WSAPROTOCOL_INFOW, WSA_FLAG_OVERLAPPED,
+        LPFN_ACCEPTEX, LPFN_CONNECTEX, LPFN_DISCONNECTEX, LPFN_GETACCEPTEXSOCKADDRS, RIO_EXTENSION_FUNCTION_TABLE,
+        SIO_GET_EXTENSION_FUNCTION_POINTER, SIO_GET_MULTIPLE_EXTENSION_FUNCTION_POINTER, SOCKADDR, SOCKADDR_IN, SOCKET,
+        SOL_SOCKET, SO_PROTOCOL_INFOW, WSADATA, WSAID_ACCEPTEX, WSAID_CONNECTEX, WSAID_DISCONNECTEX,
+        WSAID_GETACCEPTEXSOCKADDRS, WSAPROTOCOL_INFOW, WSA_FLAG_OVERLAPPED,
     },
 };
 
@@ -92,7 +92,7 @@ impl SocketExtensions {
 
     /// Resolve the RIO function table, which uses a different I/O control code than individual functions.
     fn resolve_rio_fn_table(s: SOCKET) -> Result<RIO_EXTENSION_FUNCTION_TABLE, Fail> {
-        let mut result: RIO_EXTENSION_FUNCTION_TABLE = RIO_EXTENSION_FUNCTION_TABLE::default();
+        let mut result = RIO_EXTENSION_FUNCTION_TABLE::default();
         result.cbSize = std::mem::size_of::<RIO_EXTENSION_FUNCTION_TABLE>() as u32;
 
         // Safety: SIO_GET_MULTIPLE_EXTENSION_FUNCTION_POINTER expects input of type GUID and output of type
@@ -119,14 +119,14 @@ impl SocketExtensions {
     /// Lookup a single function pointer using SIO_GET_EXTENSION_FUNCTION_POINTER ioctl. To be sound, T must be a `fn`
     /// type.
     fn lookup_single_fn<T>(s: SOCKET, guid: &GUID) -> Result<Option<T>, Fail> {
-        let mut fn_ptr: Option<T> = None;
+        let mut fn_ptr = None;
 
         // Safety: SIO_GET_EXTENSION_FUNCTION_POINTER expects type GUID for input. Option<fn()> is compatible with C
         // output type for this ioctl.
         unsafe {
             WinsockRuntime::do_ioctl(s, SIO_GET_EXTENSION_FUNCTION_POINTER, Some(guid), Some(&mut fn_ptr)).map_err(
                 |err| {
-                    let msg: String = format!("{} for function lookup {:?}", err.cause, guid);
+                    let msg = format!("{} for function lookup {:?}", err.cause, guid);
                     Fail::new(err.errno, msg.as_str())
                 },
             )?;
@@ -144,7 +144,7 @@ impl WinsockRuntime {
     /// Start up the Winsock runtime, creating a new instance of WinsockRuntime. While it is not functionally useful,
     /// it is valid to instantiate multiple instances of this struct.
     pub fn new() -> Result<Self, Fail> {
-        let mut data: WSADATA = WSADATA::default();
+        let mut data = WSADATA::default();
         if unsafe { WSAStartup(0x202u16, &mut data as *mut WSADATA) } != 0 {
             return Err(expect_last_wsa_error());
         }
@@ -161,11 +161,11 @@ impl WinsockRuntime {
         input: Option<&T>,
         output: Option<&mut U>,
     ) -> Result<(), Fail> {
-        let input: Option<*const libc::c_void> = input.map(|t: &T| -> *const libc::c_void { (t as *const T).cast() });
-        let input_size: usize = input.map(|_| std::mem::size_of::<T>()).unwrap_or(0);
+        let input = input.map(|t: &T| -> *const libc::c_void { (t as *const T).cast() });
+        let input_size = input.map(|_| std::mem::size_of::<T>()).unwrap_or(0);
 
-        let output: Option<*mut libc::c_void> = output.map(|u: &mut U| -> *mut libc::c_void { (u as *mut U).cast() });
-        let output_size: usize = output.map(|_| std::mem::size_of::<U>()).unwrap_or(0);
+        let output = output.map(|u: &mut U| -> *mut libc::c_void { (u as *mut U).cast() });
+        let output_size = output.map(|_| std::mem::size_of::<U>()).unwrap_or(0);
 
         if input_size > u32::MAX as usize {
             return Err(Fail::new(
@@ -180,8 +180,8 @@ impl WinsockRuntime {
             ));
         }
 
-        let mut bytes_returned: u32 = 0;
-        let ret: i32 = unsafe {
+        let mut bytes_returned = 0;
+        let ret = unsafe {
             WSAIoctl(
                 s,
                 control_code,
@@ -199,7 +199,7 @@ impl WinsockRuntime {
             if bytes_returned == output_size as u32 {
                 Ok(())
             } else {
-                let s: String = format!("WSAIoctl returned {} bytes; expected {}", bytes_returned, output_size);
+                let s = format!("WSAIoctl returned {} bytes; expected {}", bytes_returned, output_size);
                 Err(Fail::new(libc::EFAULT, s.as_str()))
             }
         } else {
@@ -223,7 +223,7 @@ impl WinsockRuntime {
 
     /// Implementation of setsockopt.
     pub(super) unsafe fn do_setsockopt<'a, T>(s: SOCKET, level: i32, opt: i32, val: Option<&'a T>) -> Result<(), Fail> {
-        let val: Option<&'a [u8]> =
+        let val =
             val.map(|val| unsafe { std::slice::from_raw_parts((val as *const T).cast(), std::mem::size_of::<T>()) });
 
         if unsafe { setsockopt(s, level, opt, val) } == 0 {
@@ -242,8 +242,8 @@ impl WinsockRuntime {
 
     pub(super) unsafe fn do_getsockopt<T>(s: SOCKET, level: i32, optname: i32) -> Result<T, Fail> {
         let mut out: MaybeUninit<T> = MaybeUninit::zeroed();
-        let optval: PSTR = PSTR::from_raw(out.as_mut_ptr().cast());
-        let mut optlen: i32 =
+        let optval = PSTR::from_raw(out.as_mut_ptr().cast());
+        let mut optlen =
             i32::try_from(std::mem::size_of::<T>()).map_err(|_| Fail::new(libc::E2BIG, "option type too large"))?;
         if unsafe { getsockopt(s, level, optname, optval, &mut optlen) } == 0 {
             Ok(unsafe { out.assume_init() })
@@ -260,16 +260,15 @@ impl WinsockRuntime {
 
     /// Gets ip and port from SOCKADDR_IN and converts to SocketAddrV4
     pub fn getpeername(s: SOCKET) -> Result<SocketAddrV4, Fail> {
-        let mut sockaddr_in: SOCKADDR_IN = SOCKADDR_IN::default();
-        let sockaddr_ptr: &mut SOCKADDR = &mut unsafe { mem::transmute::<SOCKADDR_IN, SOCKADDR>(sockaddr_in) };
-        let mut namelen: i32 = std::mem::size_of::<SOCKADDR>() as i32;
+        let mut sockaddr_in = SOCKADDR_IN::default();
+        let sockaddr_ptr = &mut unsafe { mem::transmute::<SOCKADDR_IN, SOCKADDR>(sockaddr_in) };
+        let mut namelen = std::mem::size_of::<SOCKADDR>() as i32;
 
         if unsafe { getpeername(s, sockaddr_ptr, &mut namelen) } == 0 {
             sockaddr_in = unsafe { mem::transmute::<SOCKADDR, SOCKADDR_IN>(*sockaddr_ptr) };
-            let port: u16 = sockaddr_in.sin_port;
-            let addr: IN_ADDR_0_0 = unsafe { sockaddr_in.sin_addr.S_un.S_un_b };
-            let addrv4: SocketAddrV4 =
-                SocketAddrV4::new(Ipv4Addr::new(addr.s_b1, addr.s_b2, addr.s_b3, addr.s_b4), port);
+            let port = sockaddr_in.sin_port;
+            let addr = unsafe { sockaddr_in.sin_addr.S_un.S_un_b };
+            let addrv4 = SocketAddrV4::new(Ipv4Addr::new(addr.s_b1, addr.s_b2, addr.s_b3, addr.s_b4), port);
             Ok(addrv4)
         } else {
             Err(expect_last_wsa_error())
@@ -280,14 +279,13 @@ impl WinsockRuntime {
     /// which may be shared by multiple sockets.
     fn get_or_init_extensions(&mut self, s: SOCKET) -> Result<Rc<SocketExtensions>, Fail> {
         let protocol: WSAPROTOCOL_INFOW = unsafe { self.getsockopt(s, SOL_SOCKET, SO_PROTOCOL_INFOW) }?;
+        let extensions = self.extensions_by_provider.entry(protocol.ProviderId).or_default();
 
-        let extensions: &mut Weak<SocketExtensions> =
-            self.extensions_by_provider.entry(protocol.ProviderId).or_default();
         if let Some(extensions) = extensions.upgrade() {
             return Ok(extensions);
         }
 
-        let new_extensions: Rc<SocketExtensions> = SocketExtensions::new(s)?;
+        let new_extensions = SocketExtensions::new(s)?;
         *extensions = Rc::downgrade(&new_extensions);
 
         Ok(new_extensions)
@@ -300,7 +298,7 @@ impl WinsockRuntime {
         protocol_info: Option<&WSAPROTOCOL_INFOW>,
         flags: u32,
     ) -> Result<SOCKET, Fail> {
-        let protocol_info: Option<*const WSAPROTOCOL_INFOW> = protocol_info.map(|i| i as *const WSAPROTOCOL_INFOW);
+        let protocol_info = protocol_info.map(|i| i as *const WSAPROTOCOL_INFOW);
         match unsafe { WSASocketW(domain, typ, protocol, protocol_info, 0, flags) } {
             INVALID_SOCKET => Err(expect_last_wsa_error()),
             socket => Ok(socket),
@@ -318,7 +316,7 @@ impl WinsockRuntime {
     ) -> Result<Socket, Fail> {
         // Safety: SOCKET is a loose handle; it must be closed with `closesocket` to clean up resources. Socket struct
         // will take ownership by end of method; failures after this call need to be cause a `closesocket` call.
-        let s: SOCKET = unsafe { Self::raw_socket(domain, typ, protocol, None, WSA_FLAG_OVERLAPPED) }?;
+        let s = unsafe { Self::raw_socket(domain, typ, protocol, None, WSA_FLAG_OVERLAPPED) }?;
 
         self.get_or_init_extensions(s)
             .and_then(|extensions: Rc<SocketExtensions>| Socket::new(s, protocol, options, extensions, iocp))

--- a/src/inetstack/protocols/layer1/mod.rs
+++ b/src/inetstack/protocols/layer1/mod.rs
@@ -19,7 +19,7 @@ use super::layer4::ephemeral::EphemeralPorts;
 /// API for the Physical Layer for any underlying hardware that implements a raw NIC interface (e.g., DPDK, raw
 /// sockets). It must implement [DemiMemoryAllocator] to specify how to allocate DemiBuffers for the physical layer.
 pub trait PhysicalLayer: 'static + DemiMemoryAllocator {
-    /// Transmits a single [PacketBuf].
+    /// Transmits a single [Demibuffer].
     fn transmit(&mut self, pkt: DemiBuffer) -> Result<(), Fail>;
 
     /// Receives a batch of [DemiBuffer].


### PR DESCRIPTION
Reducing syntactic clutter has enhanced the readability of the codebase. Also, it allows for better names because there is now more space. The semantics pop out better than before without loss of any meaningful information.