### PR TITLE
runtime: reduce visual clutter by removing type annotations

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,18 +141,18 @@ macro_rules! collect_test {
 #[macro_export]
 macro_rules! dump_test {
     ($vec:ident) => {{
-        let mut nfailed: usize = 0;
+        let mut num_failed = 0;
         // Dump results.
         for (test_name, test_status, test_result) in $vec {
             std::println!("[{}] {}", test_status, test_name);
             if let Err(e) = test_result {
-                nfailed += 1;
+                num_failed += 1;
                 std::println!("{}", e);
             }
         }
 
-        if nfailed > 0 {
-            anyhow::bail!("{} tests failed", nfailed);
+        if num_failed > 0 {
+            anyhow::bail!("{} tests failed", num_failed);
         } else {
             std::println!("all tests passed");
             Ok(())

--- a/src/runtime/condition_variable.rs
+++ b/src/runtime/condition_variable.rs
@@ -47,11 +47,9 @@ pub struct ConditionVariable {
 pub struct SharedConditionVariable(SharedObject<ConditionVariable>);
 
 struct YieldPoint {
-    /// Unique identifier.
     id: YieldPointId,
-    /// Reference to the condition variable that issued this future.
-    cond_var: SharedConditionVariable,
-    /// State of the yield.
+    /// Condition variable that issued this future.
+    condition_variable: SharedConditionVariable,
     state: YieldState,
 }
 
@@ -88,7 +86,7 @@ impl SharedConditionVariable {
         self.last_id += 1;
         YieldPoint {
             id: YieldPointId(self.last_id),
-            cond_var: self.clone(),
+            condition_variable: self.clone(),
             state: YieldState::Running,
         }
         .await
@@ -137,17 +135,17 @@ impl Future for YieldPoint {
     /// The first time that this future is polled, it is not ready but the next time must be a signal so then it is
     /// ready.
     fn poll(self: Pin<&mut Self>, context: &mut Context) -> Poll<Self::Output> {
-        let state: YieldState = self.state;
-        let num_ready: usize = self.cond_var.num_ready;
-        let self_: &mut Self = self.get_mut();
+        let state = self.state;
+        let num_ready = self.condition_variable.num_ready;
+        let self_ = self.get_mut();
         match state {
             YieldState::Running => {
-                self_.cond_var.add_waiter(self_.id, context.waker().clone());
+                self_.condition_variable.add_waiter(self_.id, context.waker().clone());
                 self_.state = YieldState::Yielded;
                 Poll::Pending
             },
             YieldState::Yielded if num_ready > 0 => {
-                self_.cond_var.num_ready -= 1;
+                self_.condition_variable.num_ready -= 1;
                 self_.state = YieldState::Running;
                 Poll::Ready(())
             },
@@ -158,7 +156,7 @@ impl Future for YieldPoint {
 
 impl Drop for YieldPoint {
     fn drop(&mut self) {
-        self.cond_var.remove_waiter(self.id)
+        self.condition_variable.remove_waiter(self.id)
     }
 }
 

--- a/src/runtime/fail.rs
+++ b/src/runtime/fail.rs
@@ -12,12 +12,9 @@ use ::std::{error, fmt, io};
 // Structures
 //======================================================================================================================
 
-/// Failure
 #[derive(Clone)]
 pub struct Fail {
-    /// Error code.
     pub errno: c_int,
-    /// Cause.
     pub cause: String,
 }
 
@@ -25,9 +22,7 @@ pub struct Fail {
 // Associate Functions
 //======================================================================================================================
 
-/// Associate Functions for Failures
 impl Fail {
-    /// Creates a new Failure
     pub fn new(errno: i32, cause: &str) -> Self {
         Self {
             errno,
@@ -40,24 +35,20 @@ impl Fail {
 // Trait Implementations
 //======================================================================================================================
 
-/// Display Trait Implementation for Failures
 impl fmt::Display for Fail {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Error {:?}: {:?}", self.errno, self.cause)
     }
 }
 
-/// Debug trait Implementation for Failures
 impl fmt::Debug for Fail {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Error {:?}: {:?}", self.errno, self.cause)
     }
 }
 
-/// Error Trait Implementation for Failures
 impl error::Error for Fail {}
 
-/// Conversion Trait Implementation for Fail
 impl From<io::Error> for Fail {
     fn from(_: io::Error) -> Self {
         Self {

--- a/src/runtime/logging.rs
+++ b/src/runtime/logging.rs
@@ -29,7 +29,6 @@ pub struct CallbackLogWriter {
 // Associated Functions
 //=====================================================================================================================
 impl CallbackLogWriter {
-    /// Creates a new `CallbackLogWriter` instance.
     pub fn new(callback: demi_log_callback_t) -> Self {
         Self { callback }
     }
@@ -40,9 +39,9 @@ impl CallbackLogWriter {
 //======================================================================================================================
 impl LogWriter for CallbackLogWriter {
     fn write(&self, _now: &mut flexi_logger::DeferredNow, record: &log::Record) -> std::io::Result<()> {
-        let module: &str = record.module_path().unwrap_or("{unnamed}");
-        let file: &str = record.file().unwrap_or("{unknown file}");
-        let message: String = record.args().to_string();
+        let module = record.module_path().unwrap_or("{unnamed}");
+        let file = record.file().unwrap_or("{unknown file}");
+        let message = record.args().to_string();
         ((self.callback)(
             record.level() as i32,
             module.as_ptr() as *const std::ffi::c_char,
@@ -66,7 +65,6 @@ impl LogWriter for CallbackLogWriter {
 // Standalone Functions
 //======================================================================================================================
 
-/// Initializes logging features.
 pub fn initialize() {
     let _ = LOG_HANDLE.get_or_init(|| Logger::try_with_env().unwrap().format(with_thread).start().unwrap());
 }
@@ -77,7 +75,7 @@ pub fn initialize() {
 #[allow(unused)]
 pub fn custom_initialize<F: FnOnce() -> Logger>(f: F) {
     let _ = LOG_HANDLE.get_or_init(|| {
-        let logger: Logger = f();
+        let logger = f();
         logger.start().unwrap()
     });
 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -115,9 +115,9 @@ impl SharedDemiRuntime {
     #[cfg(test)]
     pub fn new(now: Instant) -> Self {
         timer::global_set_time(now);
-        let mut scheduler: SharedScheduler = SharedScheduler::default();
-        let foreground_group_id: SchedulerId = scheduler.create_group();
-        let background_group_id: SchedulerId = scheduler.create_group();
+        let mut scheduler = SharedScheduler::default();
+        let foreground_group_id = scheduler.create_group();
+        let background_group_id = scheduler.create_group();
         Self(SharedObject::<DemiRuntime>::new(DemiRuntime {
             qtable: IoQueueTable::default(),
             qtoken_to_scheduler_id: Id64Map::default(),
@@ -167,10 +167,10 @@ impl SharedDemiRuntime {
         trace!("Inserting coroutine: {:?}", task_name);
         #[cfg(feature = "profiler")]
         let coroutine = coroutine_timer!(task_name, coroutine);
-        let task: TaskWithResult<F::Output> = TaskWithResult::<F::Output>::new(task_name, coroutine);
+        let task = TaskWithResult::<F::Output>::new(task_name, coroutine);
         match self.scheduler.insert_and_poll_task(group_id, task) {
             Some(InsertResult::Inserted(task_id)) => {
-                let qt: QToken = self.qtoken_to_scheduler_id.insert_with_new_id(task_id).unwrap();
+                let qt = self.qtoken_to_scheduler_id.insert_with_new_id(task_id).unwrap();
                 self.scheduler
                     .get_mut_task(group_id, task_id)
                     .unwrap()
@@ -181,11 +181,11 @@ impl SharedDemiRuntime {
             Some(InsertResult::Completed(mut boxed_task)) => {
                 trace!("Completed while inserting coroutine: {:?}", boxed_task.get_name());
                 // Place into id map so that the application can retrive the result later.
-                let qt: QToken = self.qtoken_to_scheduler_id.insert_with_new_id(0_u64.into()).unwrap();
+                let qt = self.qtoken_to_scheduler_id.insert_with_new_id(0_u64.into()).unwrap();
                 boxed_task.set_id(qt.into());
 
                 // OperationTasks return a value to the application, so we must stash these for later.
-                let mut task: OperationTask =
+                let mut task =
                     OperationTask::try_from(boxed_task.as_any()).expect("should be able to unbox what we just boxed");
                 self.completed_results.insert(
                     qt,
@@ -194,7 +194,7 @@ impl SharedDemiRuntime {
                 Ok(qt)
             },
             None => {
-                let cause: String = format!("cannot schedule coroutine (task_name={:?})", &task_name);
+                let cause = format!("cannot schedule coroutine (task_name={:?})", &task_name);
                 error!("insert_nonpolling_coroutine(): {}", cause);
                 Err(Fail::new(libc::EAGAIN, &cause))
             },
@@ -210,7 +210,7 @@ impl SharedDemiRuntime {
             self.completed_tasks.len()
         );
         // Put the QToken into a single element array.
-        let qt_array: [QToken; 1] = [qt];
+        let qt_array = [qt];
 
         // Call wait_any() to do the real work.
         let (offset, returned_qt, qd, result) = self.wait_any(&qt_array, timeout)?;
@@ -235,10 +235,10 @@ impl SharedDemiRuntime {
             }
         }
 
-        let mut result: Option<(usize, QToken, QDesc, OperationResult)> = None;
-        let mut unused_results: Vec<(QToken, QDesc, OperationResult)> = vec![];
+        let mut result = None;
+        let mut unused_results = vec![];
         // Wait until one of the qts is ready.
-        let return_value: Result<(), Fail> = self.wait_next_n(
+        let return_value = self.wait_next_n(
             |completed_qt, completed_qd, completed_result| match qts
                 .iter()
                 .enumerate()
@@ -276,14 +276,14 @@ impl SharedDemiRuntime {
         mut acceptor: Acceptor,
         timeout: Duration,
     ) -> Result<(), Fail> {
-        let deadline_time: Instant = self.get_now() + timeout;
+        let deadline_time = self.get_now() + timeout;
         loop {
             if self.completed_tasks.is_empty() {
                 self.run_scheduler();
             }
             while let Some(mut task) = self.completed_tasks.pop_front() {
-                let qt: QToken = expect_some!(task.get_id(), "should have been set on insert").into();
-                let (qd, result): (QDesc, OperationResult) = expect_some!(task.get_result(), "coroutine not finished");
+                let qt = expect_some!(task.get_id(), "should have been set on insert").into();
+                let (qd, result) = expect_some!(task.get_result(), "coroutine not finished");
                 self.qtoken_to_scheduler_id.remove(&qt);
 
                 if !acceptor(qt, qd, result) {
@@ -307,7 +307,7 @@ impl SharedDemiRuntime {
         // 1. Run each of the background tasks once.
         self.poll_background_tasks();
         // 2. Run all foreground tasks until none are ready.
-        let completed_tasks: Vec<OperationTask> = self.poll_foreground_tasks();
+        let completed_tasks = self.poll_foreground_tasks();
 
         // 3. Update the list of previously completed tasks.
         self.completed_tasks = VecDeque::from(completed_tasks);
@@ -315,7 +315,7 @@ impl SharedDemiRuntime {
 
     /// Allocates a queue of type `T` and returns the associated queue descriptor.
     pub fn alloc_queue<T: IoQueue>(&mut self, queue: T) -> QDesc {
-        let qd: QDesc = self.qtable.alloc::<T>(queue);
+        let qd = self.qtable.alloc::<T>(queue);
         trace!("Allocating new queue: qd={:?}", qd);
         qd
     }
@@ -409,14 +409,14 @@ impl SharedDemiRuntime {
     }
 
     pub fn poll_background_tasks(&mut self) {
-        let background_group_id: SchedulerId = self.background_group_id;
+        let background_group_id = self.background_group_id;
         // Ignore any results from tasks that completed because background tasks do not return anything.
         self.scheduler
             .poll_group_once(background_group_id, Some(TIMER_RESOLUTION));
     }
 
     pub fn poll_foreground_tasks(&mut self) -> Vec<OperationTask> {
-        let foreground_group_id: SchedulerId = self.foreground_group_id;
+        let foreground_group_id = self.foreground_group_id;
 
         let completed_tasks = self
             .scheduler
@@ -483,7 +483,7 @@ pub async fn conditional_yield_until<F: Future>(condition: F, expiry: Option<Ins
 
 /// Yield for one quanta.
 pub async fn poll_yield() {
-    let poll: PollFuture = PollFuture::default();
+    let poll = PollFuture::default();
     poll.await;
 }
 
@@ -494,9 +494,9 @@ pub async fn poll_yield() {
 impl Default for SharedDemiRuntime {
     fn default() -> Self {
         timer::global_set_time(Instant::now());
-        let mut scheduler: SharedScheduler = SharedScheduler::default();
-        let foreground_group_id: SchedulerId = scheduler.create_group();
-        let background_group_id: SchedulerId = scheduler.create_group();
+        let mut scheduler = SharedScheduler::default();
+        let foreground_group_id = scheduler.create_group();
+        let background_group_id = scheduler.create_group();
         Self(SharedObject::<DemiRuntime>::new(DemiRuntime {
             qtable: IoQueueTable::default(),
             qtoken_to_scheduler_id: Id64Map::default(),
@@ -529,7 +529,7 @@ impl<T> Deref for SharedObject<T> {
 /// coroutine yields.
 impl<T> DerefMut for SharedObject<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        let ptr: *mut T = Rc::as_ptr(&self.0) as *mut T;
+        let ptr = Rc::as_ptr(&self.0) as *mut T;
         unsafe { &mut *ptr }
     }
 }
@@ -547,7 +547,7 @@ impl<T> AsRef<T> for SharedObject<T> {
 /// at a time.
 impl<T> AsMut<T> for SharedObject<T> {
     fn as_mut(&mut self) -> &mut T {
-        let ptr: *mut T = Rc::as_ptr(&self.0) as *mut T;
+        let ptr = Rc::as_ptr(&self.0) as *mut T;
         unsafe { &mut *ptr }
     }
 }
@@ -628,13 +628,13 @@ mod tests {
 
     #[test]
     fn poll_and_wait_for_first_task() -> Result<()> {
-        let mut runtime: SharedDemiRuntime = SharedDemiRuntime::default();
+        let mut runtime = SharedDemiRuntime::default();
 
-        let qt: QToken = runtime
+        let qt = runtime
             .insert_nonpolling_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(0)).fuse()))?;
-        let _: QToken = runtime
+        let _ = runtime
             .insert_nonpolling_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(1)).fuse()))?;
-        let _: QToken = runtime
+        let _ = runtime
             .insert_nonpolling_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(2)).fuse()))?;
 
         let task = runtime.wait(qt, Duration::ZERO)?;
@@ -644,13 +644,13 @@ mod tests {
 
     #[test]
     fn poll_and_wait_for_middle_task() -> Result<()> {
-        let mut runtime: SharedDemiRuntime = SharedDemiRuntime::default();
+        let mut runtime = SharedDemiRuntime::default();
 
-        let _: QToken = runtime
+        let _ = runtime
             .insert_nonpolling_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(0)).fuse()))?;
-        let qt2: QToken = runtime
+        let qt2 = runtime
             .insert_nonpolling_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(1)).fuse()))?;
-        let _: QToken = runtime
+        let _ = runtime
             .insert_nonpolling_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(2)).fuse()))?;
 
         let task = runtime.wait(qt2, Duration::ZERO)?;
@@ -660,13 +660,13 @@ mod tests {
 
     #[test]
     fn poll_and_wait_for_last_task() -> Result<()> {
-        let mut runtime: SharedDemiRuntime = SharedDemiRuntime::default();
+        let mut runtime = SharedDemiRuntime::default();
 
-        let _: QToken = runtime
+        let _ = runtime
             .insert_nonpolling_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(0)).fuse()))?;
-        let _: QToken = runtime
+        let _ = runtime
             .insert_nonpolling_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(1)).fuse()))?;
-        let qt3: QToken = runtime
+        let qt3 = runtime
             .insert_nonpolling_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(2)).fuse()))?;
 
         let task = runtime.wait(qt3, Duration::ZERO)?;
@@ -676,15 +676,15 @@ mod tests {
 
     #[test]
     fn poll_and_wait_any_for_first_tasks() -> Result<()> {
-        let mut runtime: SharedDemiRuntime = SharedDemiRuntime::default();
+        let mut runtime = SharedDemiRuntime::default();
 
-        let qt: QToken = runtime
+        let qt = runtime
             .insert_nonpolling_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(0)).fuse()))?;
-        let qt2: QToken = runtime
+        let qt2 = runtime
             .insert_nonpolling_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(1)).fuse()))?;
-        let _: QToken = runtime
+        let _ = runtime
             .insert_nonpolling_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(2)).fuse()))?;
-        let qts: Vec<QToken> = vec![qt, qt2];
+        let qts = vec![qt, qt2];
         let task = runtime.wait_any(&qts, Duration::ZERO)?;
         ensure_eq!(task.2, QDesc::from(0));
         Ok(())
@@ -692,15 +692,15 @@ mod tests {
 
     #[test]
     fn poll_and_wait_any_for_last_tasks() -> Result<()> {
-        let mut runtime: SharedDemiRuntime = SharedDemiRuntime::default();
+        let mut runtime = SharedDemiRuntime::default();
 
-        let _: QToken = runtime
+        let _ = runtime
             .insert_nonpolling_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(0)).fuse()))?;
-        let qt2: QToken = runtime
+        let qt2 = runtime
             .insert_nonpolling_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(1)).fuse()))?;
-        let qt3: QToken = runtime
+        let qt3 = runtime
             .insert_nonpolling_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(2)).fuse()))?;
-        let qts: Vec<QToken> = vec![qt2, qt3];
+        let qts = vec![qt2, qt3];
         let task = runtime.wait_any(&qts, Duration::ZERO)?;
         ensure_eq!(task.2, QDesc::from(1));
         Ok(())
@@ -708,7 +708,7 @@ mod tests {
 
     #[bench]
     fn insert_io_coroutine_bench(b: &mut Bencher) {
-        let mut runtime: SharedDemiRuntime = SharedDemiRuntime::default();
+        let mut runtime = SharedDemiRuntime::default();
 
         b.iter(|| {
             runtime.insert_nonpolling_coroutine("dummy coroutine", Box::pin(dummy_coroutine(10, QDesc::from(0)).fuse()))
@@ -717,7 +717,7 @@ mod tests {
 
     #[bench]
     fn insert_background_coroutine_bench(b: &mut Bencher) {
-        let mut runtime: SharedDemiRuntime = SharedDemiRuntime::default();
+        let mut runtime = SharedDemiRuntime::default();
 
         b.iter(|| {
             runtime.insert_nonpolling_coroutine(
@@ -730,8 +730,8 @@ mod tests {
     #[bench]
     fn wait_any_nonpolling_coroutine_bench(b: &mut Bencher) {
         const NUM_TASKS: usize = 1024;
-        let mut qts: [QToken; NUM_TASKS] = [QToken::from(0); NUM_TASKS];
-        let mut runtime: SharedDemiRuntime = SharedDemiRuntime::default();
+        let mut qts = [QToken::from(0); NUM_TASKS];
+        let mut runtime = SharedDemiRuntime::default();
         // Insert a large number of coroutines.
         for qt in qts.iter_mut().take(NUM_TASKS) {
             *qt = expect_ok!(
@@ -750,8 +750,8 @@ mod tests {
     #[bench]
     fn wait_any_io_polling_coroutine_bench(b: &mut Bencher) {
         const NUM_TASKS: usize = 1024;
-        let mut qts: [QToken; NUM_TASKS] = [QToken::from(0); NUM_TASKS];
-        let mut runtime: SharedDemiRuntime = SharedDemiRuntime::default();
+        let mut qts = [QToken::from(0); NUM_TASKS];
+        let mut runtime = SharedDemiRuntime::default();
         // Insert a large number of coroutines.
         for qt in qts.iter_mut().take(NUM_TASKS) {
             *qt = expect_ok!(

--- a/src/runtime/poll.rs
+++ b/src/runtime/poll.rs
@@ -46,7 +46,7 @@ impl Future for PollFuture {
     /// A yield for just one cycle. The first time that this future is polled, it is not ready but the next time it
     /// runs.
     fn poll(self: Pin<&mut Self>, context: &mut Context) -> Poll<Self::Output> {
-        let self_: &mut Self = self.get_mut();
+        let self_ = self.get_mut();
         if self_.state == YieldState::Running {
             // Set our state
             self_.state = YieldState::Yielded;

--- a/src/runtime/timer.rs
+++ b/src/runtime/timer.rs
@@ -18,13 +18,9 @@ use ::std::{
     time::{Duration, Instant},
 };
 
-//======================================================================================================================
-// Thread local variable
-//======================================================================================================================
-
 thread_local! {
-/// This is our shared sense of time. It is explicitly moved forward ONLY by the runtime and used to trigger time outs.
-static THREAD_TIME: SharedTimer = SharedTimer::default();
+    /// This is our shared sense of time. It is explicitly moved forward ONLY by the runtime and used to trigger time outs.
+    static THREAD_TIME: SharedTimer = SharedTimer::default();
 }
 
 //======================================================================================================================
@@ -91,8 +87,7 @@ impl SharedTimer {
             if now < entry.expiry {
                 break;
             }
-            let entry: TimerQueueEntry =
-                expect_some!(self.heap.pop(), "should have an entry because we were able to peek").0;
+            let entry = expect_some!(self.heap.pop(), "should have an entry because we were able to peek").0;
             entry.waker.wake_by_ref();
         }
         self.now = now;
@@ -106,7 +101,7 @@ impl SharedTimer {
         let id = self.last_id;
         self.last_id.increment();
 
-        let entry: TimerQueueEntry = TimerQueueEntry { expiry, id, waker };
+        let entry = TimerQueueEntry { expiry, id, waker };
         self.heap.push(Reverse(entry));
         id
     }
@@ -141,7 +136,7 @@ pub fn global_get_time() -> Instant {
 
 /// Blocks until the system time moves
 pub async fn wait(timeout: Duration) {
-    let now: Instant = global_get_time();
+    let now = global_get_time();
     wait_until(now + timeout).await
 }
 
@@ -208,15 +203,14 @@ impl Future for YieldPoint {
     type Output = ();
 
     fn poll(self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
-        let self_: &mut Self = self.get_mut();
+        let self_ = self.get_mut();
         match self_.state {
             YieldState::Running => {
                 // If the timer expired while we were running and before we yielded, just return.
                 if self_.expiry <= global_get_time() {
                     Poll::Ready(())
                 } else {
-                    let id: YieldPointId =
-                        THREAD_TIME.with(|s| s.clone().add_timeout(self_.expiry, context.waker().clone()));
+                    let id = THREAD_TIME.with(|s| s.clone().add_timeout(self_.expiry, context.waker().clone()));
                     self_.state = YieldState::Yielded(id);
                     Poll::Pending
                 }

--- a/src/runtime/types/memory.rs
+++ b/src/runtime/types/memory.rs
@@ -65,7 +65,6 @@ mod test {
     use crate::runtime::types::memory::*;
     use std::mem;
 
-    /// Tests if the `demi_sgaseg_t` structure has the expected size.
     #[test]
     fn test_size_demi_sgaseg_t() -> Result<(), anyhow::Error> {
         // Size of a void pointer.
@@ -74,7 +73,7 @@ mod test {
         const DATA_BUF_PTR_SIZE: usize = 8;
         // Size of a u32.
         const DATA_LEN_SIZE: usize = 4;
-        // Size of a demi_sgaseg_t structure.
+
         crate::ensure_eq!(
             mem::size_of::<demi_sgaseg_t>(),
             RESERVED_METADATA_SIZE + DATA_BUF_PTR_SIZE + DATA_LEN_SIZE
@@ -82,7 +81,6 @@ mod test {
         Ok(())
     }
 
-    /// Tests if the `demi_sga_t` structure has the expected size.
     #[test]
     fn test_size_demi_sgarray_t() -> Result<(), anyhow::Error> {
         // Size of a u32.
@@ -91,7 +89,7 @@ mod test {
         const ELEMENTS_SIZE: usize = mem::size_of::<demi_sgaseg_t>() * DEMI_SGARRAY_MAXLEN;
         // Size of a SockAddr structure.
         const SOCKADDR_SRC_SIZE: usize = 16;
-        // Size of a demi_sgarray_t structure.
+
         crate::ensure_eq!(
             mem::size_of::<demi_sgarray_t>(),
             NUM_SEGMENTS_SIZE + ELEMENTS_SIZE + SOCKADDR_SRC_SIZE

--- a/src/runtime/types/mod.rs
+++ b/src/runtime/types/mod.rs
@@ -36,7 +36,6 @@ pub type demi_log_callback_t = extern "C" fn(
     u32,
 );
 
-/// Demikernel Arguments
 #[repr(C, packed)]
 pub struct demi_args_t {
     pub argc: core::ffi::c_int,
@@ -63,7 +62,6 @@ impl Default for demi_args_t {
 #[cfg(test)]
 mod test {
 
-    /// Tests if the `DemiArgs` structure has the expected size.
     #[test]
     fn test_size_demi_args() -> Result<(), anyhow::Error> {
         // Size of a void pointer.
@@ -73,11 +71,10 @@ mod test {
         // Size of a c char.
         const DEMIARGS_CALLBACK_SIZE: usize = 8;
 
-        // The expected size of the `DemiArgs` structure.
+        // Expected size
         const DEMIARGS_SIZE: usize =
             DEMIARGS_ARGC_SIZE + DEMIARGS_ARGV_SIZE + DEMIARGS_CALLBACK_SIZE + DEMIARGS_CALLBACK_SIZE;
 
-        // Check if the sizes match.
         assert_eq!(std::mem::size_of::<crate::runtime::types::demi_args_t>(), DEMIARGS_SIZE);
 
         Ok(())

--- a/src/runtime/types/ops.rs
+++ b/src/runtime/types/ops.rs
@@ -57,31 +57,28 @@ mod test {
     use crate::runtime::types::ops::*;
     use ::std::mem;
 
-    /// Tests if `demi_accept_result_t` has the expected size.
     #[test]
     fn test_size_demi_accept_result_t() -> Result<(), anyhow::Error> {
         // Size of a u32.
         const QD_SIZE: usize = 4;
         // Size of a sockaddr structure.
         const ADDR_SIZE: usize = 16;
-        // Size of a demi_accept_result_t structure.
+
         crate::ensure_eq!(mem::size_of::<demi_accept_result_t>(), QD_SIZE + ADDR_SIZE);
         Ok(())
     }
 
-    /// Tests if `demi_qr_value_t` has the expected size.
     #[test]
     fn test_size_demi_qr_value_t() -> Result<(), anyhow::Error> {
         // Size of a demi_sgarray_t structure.
         const SGA_SIZE: usize = mem::size_of::<demi_sgarray_t>();
         // Size of a demi_accept_result_t structure.
         const ARES_SIZE: usize = mem::size_of::<demi_accept_result_t>();
-        // Size of a demi_qr_value_t structure.
+
         crate::ensure_eq!(mem::size_of::<demi_qr_value_t>(), std::cmp::max(SGA_SIZE, ARES_SIZE));
         Ok(())
     }
 
-    /// Tests if `demi_qresult_t` has the expected size.
     #[test]
     fn test_size_demi_qresult_t() -> Result<(), anyhow::Error> {
         const QR_OPCODE_SIZE: usize = 4;


### PR DESCRIPTION
This makes the logic pop out easily to the reader.