### PR TITLE
scheduler: cleanup: simplify logic and cleanup

### DIFF
--- a/src/catnap/linux/transport.rs
+++ b/src/catnap/linux/transport.rs
@@ -89,7 +89,7 @@ impl SharedCatnapTransport {
             options: TcpSocketOptions::new(config)?,
         }));
         let mut me2 = me.clone();
-        runtime.insert_polling_coroutine(
+        runtime.schedule_polling_coroutine(
             "bgc::catnap::transport::epoll",
             Box::pin(async move { me2.poll().await }.fuse()),
         )?;

--- a/src/catnap/linux/transport.rs
+++ b/src/catnap/linux/transport.rs
@@ -89,7 +89,7 @@ impl SharedCatnapTransport {
             options: TcpSocketOptions::new(config)?,
         }));
         let mut me2 = me.clone();
-        runtime.insert_io_polling_coroutine(
+        runtime.insert_polling_coroutine(
             "bgc::catnap::transport::epoll",
             Box::pin(async move { me2.poll().await }.fuse()),
         )?;

--- a/src/catnap/win/overlapped.rs
+++ b/src/catnap/win/overlapped.rs
@@ -474,7 +474,7 @@ mod tests {
         })
         .fuse();
 
-        let server_task = runtime.insert_coroutine("ioc_server", Box::pin(server)).unwrap();
+        let server_task = runtime.schedule_coroutine("ioc_server", Box::pin(server)).unwrap();
         post_completion(&iocp, overlapped.as_mut().marshal(), COMPLETION_KEY)?;
 
         iocp.process_events()?;
@@ -582,7 +582,7 @@ mod tests {
         );
 
         let mut runtime = SharedDemiRuntime::default();
-        let server_task = runtime.insert_coroutine("ioc_server", server).unwrap();
+        let server_task = runtime.schedule_coroutine("ioc_server", server).unwrap();
 
         let mut wait_for_state = |state| -> Result<(), Fail> {
             while server_state_view.load(Ordering::Relaxed) < state {
@@ -687,7 +687,7 @@ mod tests {
         .fuse();
 
         let mut runtime = SharedDemiRuntime::default();
-        let server_task = runtime.insert_coroutine("ioc_server", Box::pin(server)).unwrap();
+        let server_task = runtime.schedule_coroutine("ioc_server", Box::pin(server)).unwrap();
 
         ensure_eq!(
             server_state_view.load(Ordering::Relaxed),

--- a/src/catnap/win/overlapped.rs
+++ b/src/catnap/win/overlapped.rs
@@ -474,9 +474,7 @@ mod tests {
         })
         .fuse();
 
-        let server_task = runtime
-            .insert_nonpolling_coroutine("ioc_server", Box::pin(server))
-            .unwrap();
+        let server_task = runtime.insert_coroutine("ioc_server", Box::pin(server)).unwrap();
         post_completion(&iocp, overlapped.as_mut().marshal(), COMPLETION_KEY)?;
 
         iocp.process_events()?;
@@ -584,7 +582,7 @@ mod tests {
         );
 
         let mut runtime = SharedDemiRuntime::default();
-        let server_task = runtime.insert_nonpolling_coroutine("ioc_server", server).unwrap();
+        let server_task = runtime.insert_coroutine("ioc_server", server).unwrap();
 
         let mut wait_for_state = |state| -> Result<(), Fail> {
             while server_state_view.load(Ordering::Relaxed) < state {
@@ -689,9 +687,7 @@ mod tests {
         .fuse();
 
         let mut runtime = SharedDemiRuntime::default();
-        let server_task = runtime
-            .insert_nonpolling_coroutine("ioc_server", Box::pin(server))
-            .unwrap();
+        let server_task = runtime.insert_coroutine("ioc_server", Box::pin(server)).unwrap();
 
         ensure_eq!(
             server_state_view.load(Ordering::Relaxed),
@@ -702,7 +698,6 @@ mod tests {
         let iocp_ref = unsafe { &mut *iocp.get() };
         iocp_ref.process_events()?;
 
-        // Poll the runtime again, which
         let result = loop {
             // Move time forward, which should time out the operation.
             runtime.advance_clock(Instant::now());

--- a/src/catnap/win/transport.rs
+++ b/src/catnap/win/transport.rs
@@ -78,7 +78,7 @@ impl SharedCatnapTransport {
             runtime: runtime.clone(),
         }));
 
-        runtime.insert_io_polling_coroutine(
+        runtime.insert_polling_coroutine(
             "bgc::catnap::transport::epoll",
             Box::pin({
                 let mut me = me.clone();

--- a/src/catnap/win/transport.rs
+++ b/src/catnap/win/transport.rs
@@ -78,7 +78,7 @@ impl SharedCatnapTransport {
             runtime: runtime.clone(),
         }));
 
-        runtime.insert_polling_coroutine(
+        runtime.schedule_polling_coroutine(
             "bgc::catnap::transport::epoll",
             Box::pin({
                 let mut me = me.clone();

--- a/src/demikernel/libos/network/libos.rs
+++ b/src/demikernel/libos/network/libos.rs
@@ -162,7 +162,7 @@ impl<T: NetworkTransport> SharedNetworkLibOS<T> {
             let coroutine = Box::pin(self.clone().accept_coroutine(qd).fuse());
             self.runtime
                 .clone()
-                .insert_coroutine("ioc::network::libos::accept", coroutine)
+                .schedule_coroutine("ioc::network::libos::accept", coroutine)
         };
 
         queue.accept(coroutine_constructor)
@@ -213,7 +213,7 @@ impl<T: NetworkTransport> SharedNetworkLibOS<T> {
             let coroutine = Box::pin(self.clone().connect_coroutine(qd, remote).fuse());
             self.runtime
                 .clone()
-                .insert_coroutine("ioc::network::libos::connect", coroutine)
+                .schedule_coroutine("ioc::network::libos::connect", coroutine)
         };
 
         queue.connect(coroutine_constructor)
@@ -253,7 +253,7 @@ impl<T: NetworkTransport> SharedNetworkLibOS<T> {
             let coroutine = Box::pin(self.clone().close_coroutine(qd).fuse());
             self.runtime
                 .clone()
-                .insert_coroutine("ioc::network::libos::close", coroutine)
+                .schedule_coroutine("ioc::network::libos::close", coroutine)
         };
 
         queue.close(coroutine_constructor)
@@ -322,7 +322,7 @@ impl<T: NetworkTransport> SharedNetworkLibOS<T> {
             let coroutine = Box::pin(self.clone().push_coroutine(qd, bufs, None).fuse());
             self.runtime
                 .clone()
-                .insert_coroutine("ioc::network::libos::push", coroutine)
+                .schedule_coroutine("ioc::network::libos::push", coroutine)
         };
 
         queue.push(coroutine_constructor)
@@ -370,7 +370,7 @@ impl<T: NetworkTransport> SharedNetworkLibOS<T> {
             let coroutine = Box::pin(self.clone().push_coroutine(qd, bufs, Some(remote)).fuse());
             self.runtime
                 .clone()
-                .insert_coroutine("ioc::network::libos::pushto", coroutine)
+                .schedule_coroutine("ioc::network::libos::pushto", coroutine)
         };
 
         queue.push(coroutine_constructor)
@@ -390,7 +390,7 @@ impl<T: NetworkTransport> SharedNetworkLibOS<T> {
             let coroutine = Box::pin(self.clone().pop_coroutine(qd, size).fuse());
             self.runtime
                 .clone()
-                .insert_coroutine("ioc::network::libos::pop", coroutine)
+                .schedule_coroutine("ioc::network::libos::pop", coroutine)
         };
 
         queue.pop(coroutine_constructor)

--- a/src/demikernel/libos/network/libos.rs
+++ b/src/demikernel/libos/network/libos.rs
@@ -162,7 +162,7 @@ impl<T: NetworkTransport> SharedNetworkLibOS<T> {
             let coroutine = Box::pin(self.clone().accept_coroutine(qd).fuse());
             self.runtime
                 .clone()
-                .insert_nonpolling_coroutine("ioc::network::libos::accept", coroutine)
+                .insert_coroutine("ioc::network::libos::accept", coroutine)
         };
 
         queue.accept(coroutine_constructor)
@@ -213,7 +213,7 @@ impl<T: NetworkTransport> SharedNetworkLibOS<T> {
             let coroutine = Box::pin(self.clone().connect_coroutine(qd, remote).fuse());
             self.runtime
                 .clone()
-                .insert_nonpolling_coroutine("ioc::network::libos::connect", coroutine)
+                .insert_coroutine("ioc::network::libos::connect", coroutine)
         };
 
         queue.connect(coroutine_constructor)
@@ -253,7 +253,7 @@ impl<T: NetworkTransport> SharedNetworkLibOS<T> {
             let coroutine = Box::pin(self.clone().close_coroutine(qd).fuse());
             self.runtime
                 .clone()
-                .insert_nonpolling_coroutine("ioc::network::libos::close", coroutine)
+                .insert_coroutine("ioc::network::libos::close", coroutine)
         };
 
         queue.close(coroutine_constructor)
@@ -322,7 +322,7 @@ impl<T: NetworkTransport> SharedNetworkLibOS<T> {
             let coroutine = Box::pin(self.clone().push_coroutine(qd, bufs, None).fuse());
             self.runtime
                 .clone()
-                .insert_nonpolling_coroutine("ioc::network::libos::push", coroutine)
+                .insert_coroutine("ioc::network::libos::push", coroutine)
         };
 
         queue.push(coroutine_constructor)
@@ -370,7 +370,7 @@ impl<T: NetworkTransport> SharedNetworkLibOS<T> {
             let coroutine = Box::pin(self.clone().push_coroutine(qd, bufs, Some(remote)).fuse());
             self.runtime
                 .clone()
-                .insert_nonpolling_coroutine("ioc::network::libos::pushto", coroutine)
+                .insert_coroutine("ioc::network::libos::pushto", coroutine)
         };
 
         queue.push(coroutine_constructor)
@@ -390,7 +390,7 @@ impl<T: NetworkTransport> SharedNetworkLibOS<T> {
             let coroutine = Box::pin(self.clone().pop_coroutine(qd, size).fuse());
             self.runtime
                 .clone()
-                .insert_nonpolling_coroutine("ioc::network::libos::pop", coroutine)
+                .insert_coroutine("ioc::network::libos::pop", coroutine)
         };
 
         queue.pop(coroutine_constructor)

--- a/src/inetstack/mod.rs
+++ b/src/inetstack/mod.rs
@@ -83,7 +83,7 @@ impl SharedInetStack {
             runtime: runtime.clone(),
             layer4_endpoint,
         }));
-        runtime.insert_polling_coroutine("bgc::inetstack::poll", Box::pin(me.clone().poll().fuse()))?;
+        runtime.schedule_polling_coroutine("bgc::inetstack::poll", Box::pin(me.clone().poll().fuse()))?;
         Ok(me)
     }
 

--- a/src/inetstack/mod.rs
+++ b/src/inetstack/mod.rs
@@ -83,11 +83,11 @@ impl SharedInetStack {
             runtime: runtime.clone(),
             layer4_endpoint,
         }));
-        runtime.insert_io_polling_coroutine("bgc::inetstack::poll", Box::pin(me.clone().poll().fuse()))?;
+        runtime.insert_polling_coroutine("bgc::inetstack::poll", Box::pin(me.clone().poll().fuse()))?;
         Ok(me)
     }
 
-    /// Scheduler will poll all futures that are ready to make progress.
+    /// Scheduler will run all futures that are ready to make progress.
     /// Then ask the runtime to receive new data which we will forward to the engine to parse and
     /// route to the correct protocol.
     pub async fn poll(mut self) {

--- a/src/inetstack/protocols/layer3/arp/peer.rs
+++ b/src/inetstack/protocols/layer3/arp/peer.rs
@@ -82,7 +82,7 @@ impl SharedArpPeer {
             recv_queue: AsyncQueue::<DemiBuffer>::default(),
         }));
         // This is a future returned by the async function.
-        runtime.insert_coroutine("bgc::inetstack::arp::background", Box::pin(peer.clone().poll().fuse()))?;
+        runtime.schedule_coroutine("bgc::inetstack::arp::background", Box::pin(peer.clone().poll().fuse()))?;
         Ok(peer.clone())
     }
 

--- a/src/inetstack/protocols/layer3/arp/peer.rs
+++ b/src/inetstack/protocols/layer3/arp/peer.rs
@@ -82,7 +82,7 @@ impl SharedArpPeer {
             recv_queue: AsyncQueue::<DemiBuffer>::default(),
         }));
         // This is a future returned by the async function.
-        runtime.insert_nonpolling_coroutine("bgc::inetstack::arp::background", Box::pin(peer.clone().poll().fuse()))?;
+        runtime.insert_coroutine("bgc::inetstack::arp::background", Box::pin(peer.clone().poll().fuse()))?;
         Ok(peer.clone())
     }
 

--- a/src/inetstack/protocols/layer3/arp/tests.rs
+++ b/src/inetstack/protocols/layer3/arp/tests.rs
@@ -52,7 +52,7 @@ fn arp_immediate_reply() -> Result<()> {
     // Move clock forward and poll the engine.
     now += Duration::from_micros(1);
     engine.advance_clock(now);
-    engine.get_runtime().poll_background_tasks();
+    engine.get_runtime().run_background_tasks();
 
     // Check if the ARP cache outputs a reply message.
     let mut buffers = engine.pop_expected_frames(1);
@@ -120,7 +120,7 @@ fn arp_cache_update() -> Result<()> {
     // Move clock forward and poll the engine.
     now += Duration::from_micros(1);
     engine.advance_clock(now);
-    engine.get_runtime().poll_background_tasks();
+    engine.get_runtime().run_background_tasks();
 
     // Check if the ARP cache has been updated.
     let cache = engine.get_transport().export_arp_cache();
@@ -154,13 +154,10 @@ fn arp_cache_timeout() -> Result<()> {
     let mut engine = new_engine(now, test_helpers::ALICE_CONFIG_PATH)?;
     let mut inetstack = engine.get_transport();
     let coroutine = Box::pin(async move { inetstack.arp_query(other_remote_ipv4).await }.fuse());
-    let _qt = engine
-        .get_runtime()
-        .clone()
-        .insert_nonpolling_coroutine("arp query", coroutine)?;
+    let _qt = engine.get_runtime().clone().insert_coroutine("arp query", coroutine)?;
 
     for _ in 0..(ARP_RETRY_COUNT + 1) {
-        engine.get_runtime().poll_foreground_tasks();
+        engine.get_runtime().run_foreground_tasks();
         // Check if the ARP cache outputs a reply message.
         let buffers = engine.pop_expected_frames(1);
         crate::ensure_eq!(buffers.len(), 1);

--- a/src/inetstack/protocols/layer3/arp/tests.rs
+++ b/src/inetstack/protocols/layer3/arp/tests.rs
@@ -154,7 +154,10 @@ fn arp_cache_timeout() -> Result<()> {
     let mut engine = new_engine(now, test_helpers::ALICE_CONFIG_PATH)?;
     let mut inetstack = engine.get_transport();
     let coroutine = Box::pin(async move { inetstack.arp_query(other_remote_ipv4).await }.fuse());
-    let _qt = engine.get_runtime().clone().insert_coroutine("arp query", coroutine)?;
+    let _qt = engine
+        .get_runtime()
+        .clone()
+        .schedule_coroutine("arp query", coroutine)?;
 
     for _ in 0..(ARP_RETRY_COUNT + 1) {
         engine.get_runtime().run_foreground_tasks();

--- a/src/inetstack/protocols/layer3/icmpv4/peer.rs
+++ b/src/inetstack/protocols/layer3/icmpv4/peer.rs
@@ -99,8 +99,7 @@ impl SharedIcmpv4Peer {
             rng,
             inflight: HashMap::<(u16, u16), InflightRequest>::new(),
         }));
-        runtime
-            .insert_nonpolling_coroutine("bgc::inetstack::icmp::background", Box::pin(peer.clone().poll().fuse()))?;
+        runtime.insert_coroutine("bgc::inetstack::icmp::background", Box::pin(peer.clone().poll().fuse()))?;
         Ok(peer)
     }
 

--- a/src/inetstack/protocols/layer3/icmpv4/peer.rs
+++ b/src/inetstack/protocols/layer3/icmpv4/peer.rs
@@ -99,7 +99,7 @@ impl SharedIcmpv4Peer {
             rng,
             inflight: HashMap::<(u16, u16), InflightRequest>::new(),
         }));
-        runtime.insert_coroutine("bgc::inetstack::icmp::background", Box::pin(peer.clone().poll().fuse()))?;
+        runtime.schedule_coroutine("bgc::inetstack::icmp::background", Box::pin(peer.clone().poll().fuse()))?;
         Ok(peer)
     }
 

--- a/src/inetstack/protocols/layer4/tcp/established/mod.rs
+++ b/src/inetstack/protocols/layer4/tcp/established/mod.rs
@@ -173,7 +173,7 @@ impl SharedEstablishedSocket {
             me.receive(header, data);
         }
         let me2 = me.clone();
-        runtime.insert_coroutine(
+        runtime.schedule_coroutine(
             "bgc::inetstack::tcp::established::background",
             Box::pin(async move { me2.background().await }.fuse()),
         )?;

--- a/src/inetstack/protocols/layer4/tcp/established/mod.rs
+++ b/src/inetstack/protocols/layer4/tcp/established/mod.rs
@@ -173,7 +173,7 @@ impl SharedEstablishedSocket {
             me.receive(header, data);
         }
         let me2 = me.clone();
-        runtime.insert_nonpolling_coroutine(
+        runtime.insert_coroutine(
             "bgc::inetstack::tcp::established::background",
             Box::pin(async move { me2.background().await }.fuse()),
         )?;

--- a/src/inetstack/protocols/layer4/tcp/passive_open.rs
+++ b/src/inetstack/protocols/layer4/tcp/passive_open.rs
@@ -191,7 +191,7 @@ impl SharedPassiveSocket {
             .fuse();
         match self
             .runtime
-            .insert_nonpolling_coroutine("bgc::inetstack::tcp::passiveopen::background", Box::pin(future))
+            .insert_coroutine("bgc::inetstack::tcp::passiveopen::background", Box::pin(future))
         {
             Ok(qt) => qt,
             Err(e) => {

--- a/src/inetstack/protocols/layer4/tcp/passive_open.rs
+++ b/src/inetstack/protocols/layer4/tcp/passive_open.rs
@@ -191,7 +191,7 @@ impl SharedPassiveSocket {
             .fuse();
         match self
             .runtime
-            .insert_coroutine("bgc::inetstack::tcp::passiveopen::background", Box::pin(future))
+            .schedule_coroutine("bgc::inetstack::tcp::passiveopen::background", Box::pin(future))
         {
             Ok(qt) => qt,
             Err(e) => {

--- a/src/inetstack/test_helpers/engine.rs
+++ b/src/inetstack/test_helpers/engine.rs
@@ -182,7 +182,6 @@ impl SharedEngine {
         self.libos.get_transport().clone()
     }
 
-    // Just poll the scheduler to process some packets.
     fn run_scheduler(&mut self) {
         match self.get_runtime().wait_any(&[], Duration::ZERO) {
             Ok(_) => unreachable!("Should not have completed a task without qtokens passed in"),

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -131,19 +131,16 @@ impl SharedDemiRuntime {
         }))
     }
 
-    /// Inserts the background `coroutine` named `task_name` into the scheduler. There should only be one of these
-    /// because we should never be polling with more than one coroutine.
-    pub fn insert_io_polling_coroutine<F: FusedFuture<Output = ()> + 'static>(
+    /// There should only be one of these.
+    pub fn insert_polling_coroutine<F: FusedFuture<Output = ()> + 'static>(
         &mut self,
         task_name: &'static str,
         coroutine: Pin<Box<F>>,
     ) -> Result<QToken, Fail> {
-        self.insert_and_poll_coroutine(task_name, self.background_group_id, coroutine)
+        self.insert_coroutine_inner(task_name, self.background_group_id, coroutine)
     }
 
-    /// Inserts the background `coroutine` named `task_name` into the scheduler. There should only be one of these
-    /// because we should never be polling with more than one coroutine.
-    pub fn insert_nonpolling_coroutine<F: FusedFuture + 'static>(
+    pub fn insert_coroutine<F: FusedFuture + 'static>(
         &mut self,
         task_name: &'static str,
         coroutine: Pin<Box<F>>,
@@ -151,11 +148,11 @@ impl SharedDemiRuntime {
     where
         F::Output: Unpin + Clone + Any,
     {
-        self.insert_and_poll_coroutine(task_name, self.foreground_group_id, coroutine)
+        self.insert_coroutine_inner(task_name, self.foreground_group_id, coroutine)
     }
 
-    /// Inserts a coroutine of type T and task and polls it once.
-    fn insert_and_poll_coroutine<F: FusedFuture + 'static>(
+    /// Inserts a coroutine of type T and task and runs it once.
+    fn insert_coroutine_inner<F: FusedFuture + 'static>(
         &mut self,
         task_name: &'static str,
         group_id: SchedulerId,
@@ -168,18 +165,18 @@ impl SharedDemiRuntime {
         #[cfg(feature = "profiler")]
         let coroutine = coroutine_timer!(task_name, coroutine);
         let task = TaskWithResult::<F::Output>::new(task_name, coroutine);
-        match self.scheduler.insert_and_poll_task(group_id, task) {
+        match self.scheduler.insert(group_id, task) {
             Some(InsertResult::Inserted(task_id)) => {
                 let qt = self.qtoken_to_scheduler_id.insert_with_new_id(task_id).unwrap();
                 self.scheduler
-                    .get_mut_task(group_id, task_id)
+                    .get_task_mut(group_id, task_id)
                     .unwrap()
                     .set_id(qt.into());
                 // Stash the newly allocated qtoken in the task.
                 Ok(qt)
             },
             Some(InsertResult::Completed(mut boxed_task)) => {
-                trace!("Completed while inserting coroutine: {:?}", boxed_task.get_name());
+                trace!("Completed while inserting coroutine: {:?}", boxed_task.name());
                 // Place into id map so that the application can retrive the result later.
                 let qt = self.qtoken_to_scheduler_id.insert_with_new_id(0_u64.into()).unwrap();
                 boxed_task.set_id(qt.into());
@@ -195,7 +192,7 @@ impl SharedDemiRuntime {
             },
             None => {
                 let cause = format!("cannot schedule coroutine (task_name={:?})", &task_name);
-                error!("insert_nonpolling_coroutine(): {}", cause);
+                error!("insert_coroutine(): {}", cause);
                 Err(Fail::new(libc::EAGAIN, &cause))
             },
         }
@@ -282,7 +279,7 @@ impl SharedDemiRuntime {
                 self.run_scheduler();
             }
             while let Some(mut task) = self.completed_tasks.pop_front() {
-                let qt = expect_some!(task.get_id(), "should have been set on insert").into();
+                let qt = expect_some!(task.id(), "should have been set on insert").into();
                 let (qd, result) = expect_some!(task.get_result(), "coroutine not finished");
                 self.qtoken_to_scheduler_id.remove(&qt);
 
@@ -304,12 +301,8 @@ impl SharedDemiRuntime {
     /// completed task queue and then try again. Returns None if there are still no completed tasks after polling the
     /// scheduler.
     pub fn run_scheduler(&mut self) {
-        // 1. Run each of the background tasks once.
-        self.poll_background_tasks();
-        // 2. Run all foreground tasks until none are ready.
-        let completed_tasks = self.poll_foreground_tasks();
-
-        // 3. Update the list of previously completed tasks.
+        self.run_background_tasks();
+        let completed_tasks = self.run_foreground_tasks();
         self.completed_tasks = VecDeque::from(completed_tasks);
     }
 
@@ -408,33 +401,21 @@ impl SharedDemiRuntime {
         self.socket_id_to_qdesc_map.is_in_use(socket_addrv4)
     }
 
-    pub fn poll_background_tasks(&mut self) {
-        let background_group_id = self.background_group_id;
-        // Ignore any results from tasks that completed because background tasks do not return anything.
-        self.scheduler
-            .poll_group_once(background_group_id, Some(TIMER_RESOLUTION));
+    // Ignore any results because background tasks do not return anything.
+    pub fn run_background_tasks(&mut self) {
+        let id = self.background_group_id;
+        self.scheduler.run_once(id, Some(TIMER_RESOLUTION));
     }
 
-    pub fn poll_foreground_tasks(&mut self) -> Vec<OperationTask> {
-        let foreground_group_id = self.foreground_group_id;
-
-        let completed_tasks = self
-            .scheduler
-            .poll_group_until_unrunnable(foreground_group_id, Some(TIMER_RESOLUTION));
-
-        completed_tasks
+    pub fn run_foreground_tasks(&mut self) -> Vec<OperationTask> {
+        let id = self.foreground_group_id;
+        self.scheduler
+            .run(id, Some(TIMER_RESOLUTION))
             .into_iter()
-            .filter_map(|boxed_task| -> Option<OperationTask> {
-                let qt: QToken = expect_some!(boxed_task.get_id(), "should have been set on insert").into();
-                trace!(
-                    "Completed while polling coroutine (qt={:?}): {:?}",
-                    qt,
-                    boxed_task.get_name()
-                );
-
-                // OperationTasks return a value to the application, so we must stash these for later. Otherwise, we
-                // just discard the return value of the completed coroutine.
-                OperationTask::try_from(boxed_task.as_any()).ok()
+            .filter_map(|task| -> Option<OperationTask> {
+                let qt: QToken = expect_some!(task.id(), "should have been set on insert").into();
+                trace!("Completed coroutine (qt={:?}): {:?}", qt, task.name());
+                OperationTask::try_from(task.as_any()).ok()
             })
             .collect()
     }
@@ -595,7 +576,6 @@ impl DerefMut for SharedDemiRuntime {
 // Traits
 //======================================================================================================================
 
-/// Demikernel Runtime
 pub trait Runtime: Clone + Unpin + 'static {}
 
 //======================================================================================================================
@@ -627,15 +607,12 @@ mod tests {
     }
 
     #[test]
-    fn poll_and_wait_for_first_task() -> Result<()> {
+    fn insert_and_wait_for_first_task() -> Result<()> {
         let mut runtime = SharedDemiRuntime::default();
 
-        let qt = runtime
-            .insert_nonpolling_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(0)).fuse()))?;
-        let _ = runtime
-            .insert_nonpolling_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(1)).fuse()))?;
-        let _ = runtime
-            .insert_nonpolling_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(2)).fuse()))?;
+        let qt = runtime.insert_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(0)).fuse()))?;
+        let _ = runtime.insert_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(1)).fuse()))?;
+        let _ = runtime.insert_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(2)).fuse()))?;
 
         let task = runtime.wait(qt, Duration::ZERO)?;
         ensure_eq!(task.0, QDesc::from(0));
@@ -643,15 +620,12 @@ mod tests {
     }
 
     #[test]
-    fn poll_and_wait_for_middle_task() -> Result<()> {
+    fn insert_and_wait_for_middle_task() -> Result<()> {
         let mut runtime = SharedDemiRuntime::default();
 
-        let _ = runtime
-            .insert_nonpolling_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(0)).fuse()))?;
-        let qt2 = runtime
-            .insert_nonpolling_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(1)).fuse()))?;
-        let _ = runtime
-            .insert_nonpolling_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(2)).fuse()))?;
+        let _ = runtime.insert_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(0)).fuse()))?;
+        let qt2 = runtime.insert_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(1)).fuse()))?;
+        let _ = runtime.insert_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(2)).fuse()))?;
 
         let task = runtime.wait(qt2, Duration::ZERO)?;
         ensure_eq!(task.0, QDesc::from(1));
@@ -659,15 +633,12 @@ mod tests {
     }
 
     #[test]
-    fn poll_and_wait_for_last_task() -> Result<()> {
+    fn insert_and_wait_for_last_task() -> Result<()> {
         let mut runtime = SharedDemiRuntime::default();
 
-        let _ = runtime
-            .insert_nonpolling_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(0)).fuse()))?;
-        let _ = runtime
-            .insert_nonpolling_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(1)).fuse()))?;
-        let qt3 = runtime
-            .insert_nonpolling_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(2)).fuse()))?;
+        let _ = runtime.insert_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(0)).fuse()))?;
+        let _ = runtime.insert_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(1)).fuse()))?;
+        let qt3 = runtime.insert_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(2)).fuse()))?;
 
         let task = runtime.wait(qt3, Duration::ZERO)?;
         ensure_eq!(task.0, QDesc::from(2));
@@ -675,15 +646,12 @@ mod tests {
     }
 
     #[test]
-    fn poll_and_wait_any_for_first_tasks() -> Result<()> {
+    fn insert_and_wait_any_for_first_tasks() -> Result<()> {
         let mut runtime = SharedDemiRuntime::default();
 
-        let qt = runtime
-            .insert_nonpolling_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(0)).fuse()))?;
-        let qt2 = runtime
-            .insert_nonpolling_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(1)).fuse()))?;
-        let _ = runtime
-            .insert_nonpolling_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(2)).fuse()))?;
+        let qt = runtime.insert_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(0)).fuse()))?;
+        let qt2 = runtime.insert_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(1)).fuse()))?;
+        let _ = runtime.insert_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(2)).fuse()))?;
         let qts = vec![qt, qt2];
         let task = runtime.wait_any(&qts, Duration::ZERO)?;
         ensure_eq!(task.2, QDesc::from(0));
@@ -691,15 +659,12 @@ mod tests {
     }
 
     #[test]
-    fn poll_and_wait_any_for_last_tasks() -> Result<()> {
+    fn insert_and_wait_any_for_last_tasks() -> Result<()> {
         let mut runtime = SharedDemiRuntime::default();
 
-        let _ = runtime
-            .insert_nonpolling_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(0)).fuse()))?;
-        let qt2 = runtime
-            .insert_nonpolling_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(1)).fuse()))?;
-        let qt3 = runtime
-            .insert_nonpolling_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(2)).fuse()))?;
+        let _ = runtime.insert_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(0)).fuse()))?;
+        let qt2 = runtime.insert_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(1)).fuse()))?;
+        let qt3 = runtime.insert_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(2)).fuse()))?;
         let qts = vec![qt2, qt3];
         let task = runtime.wait_any(&qts, Duration::ZERO)?;
         ensure_eq!(task.2, QDesc::from(1));
@@ -707,20 +672,18 @@ mod tests {
     }
 
     #[bench]
-    fn insert_io_coroutine_bench(b: &mut Bencher) {
-        let mut runtime = SharedDemiRuntime::default();
-
-        b.iter(|| {
-            runtime.insert_nonpolling_coroutine("dummy coroutine", Box::pin(dummy_coroutine(10, QDesc::from(0)).fuse()))
-        });
-    }
-
-    #[bench]
     fn insert_background_coroutine_bench(b: &mut Bencher) {
         let mut runtime = SharedDemiRuntime::default();
 
+        b.iter(|| runtime.insert_coroutine("dummy coroutine", Box::pin(dummy_coroutine(10, QDesc::from(0)).fuse())));
+    }
+
+    #[bench]
+    fn insert_coroutine_bench(b: &mut Bencher) {
+        let mut runtime = SharedDemiRuntime::default();
+
         b.iter(|| {
-            runtime.insert_nonpolling_coroutine(
+            runtime.insert_coroutine(
                 "dummy background coroutine",
                 Box::pin(dummy_background_coroutine().fuse()),
             )
@@ -728,14 +691,14 @@ mod tests {
     }
 
     #[bench]
-    fn wait_any_nonpolling_coroutine_bench(b: &mut Bencher) {
+    fn wait_any_coroutine_bench(b: &mut Bencher) {
         const NUM_TASKS: usize = 1024;
         let mut qts = [QToken::from(0); NUM_TASKS];
         let mut runtime = SharedDemiRuntime::default();
         // Insert a large number of coroutines.
         for qt in qts.iter_mut().take(NUM_TASKS) {
             *qt = expect_ok!(
-                runtime.insert_nonpolling_coroutine(
+                runtime.insert_coroutine(
                     "dummy coroutine",
                     Box::pin(dummy_coroutine(1000000000, QDesc::from(0)).fuse())
                 ),
@@ -748,14 +711,14 @@ mod tests {
     }
 
     #[bench]
-    fn wait_any_io_polling_coroutine_bench(b: &mut Bencher) {
+    fn wait_any_polling_coroutine_bench(b: &mut Bencher) {
         const NUM_TASKS: usize = 1024;
         let mut qts = [QToken::from(0); NUM_TASKS];
         let mut runtime = SharedDemiRuntime::default();
         // Insert a large number of coroutines.
         for qt in qts.iter_mut().take(NUM_TASKS) {
             *qt = expect_ok!(
-                runtime.insert_io_polling_coroutine(
+                runtime.insert_polling_coroutine(
                     "dummy background coroutine",
                     Box::pin(dummy_background_coroutine().fuse()),
                 ),

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -41,7 +41,7 @@ use crate::{
         network::{socket::SocketId, SocketIdToQDescMap},
         poll::PollFuture,
         queue::{IoQueue, IoQueueTable},
-        scheduler::{InsertResult, SharedScheduler, TaskWithResult},
+        scheduler::{ScheduleResult, SharedScheduler, TaskWithResult},
     },
 };
 use ::futures::{future::FusedFuture, select_biased, Future, FutureExt};
@@ -73,7 +73,7 @@ const DEFAULT_RESULT_STORAGE_CAPACITY: usize = 1024;
 
 pub struct DemiRuntime {
     qtable: IoQueueTable,
-    // Holds the mapping between qtoken and task id. Initialized to invalid id until we insert the task into the
+    // Holds the mapping between qtoken and task id. Initialized to invalid id until we schedule the task into the
     // scheduler and get the real id.
     qtoken_to_scheduler_id: Id64Map<QToken, SchedulerId>,
     scheduler: SharedScheduler,
@@ -132,15 +132,15 @@ impl SharedDemiRuntime {
     }
 
     /// There should only be one of these.
-    pub fn insert_polling_coroutine<F: FusedFuture<Output = ()> + 'static>(
+    pub fn schedule_polling_coroutine<F: FusedFuture<Output = ()> + 'static>(
         &mut self,
         task_name: &'static str,
         coroutine: Pin<Box<F>>,
     ) -> Result<QToken, Fail> {
-        self.insert_coroutine_inner(task_name, self.background_group_id, coroutine)
+        self.schedule_coroutine_inner(task_name, self.background_group_id, coroutine)
     }
 
-    pub fn insert_coroutine<F: FusedFuture + 'static>(
+    pub fn schedule_coroutine<F: FusedFuture + 'static>(
         &mut self,
         task_name: &'static str,
         coroutine: Pin<Box<F>>,
@@ -148,11 +148,11 @@ impl SharedDemiRuntime {
     where
         F::Output: Unpin + Clone + Any,
     {
-        self.insert_coroutine_inner(task_name, self.foreground_group_id, coroutine)
+        self.schedule_coroutine_inner(task_name, self.foreground_group_id, coroutine)
     }
 
-    /// Inserts a coroutine of type T and task and runs it once.
-    fn insert_coroutine_inner<F: FusedFuture + 'static>(
+    /// Schedules a coroutine of type T and task and runs it once.
+    fn schedule_coroutine_inner<F: FusedFuture + 'static>(
         &mut self,
         task_name: &'static str,
         group_id: SchedulerId,
@@ -161,12 +161,12 @@ impl SharedDemiRuntime {
     where
         F::Output: Unpin + Clone + Any,
     {
-        trace!("Inserting coroutine: {:?}", task_name);
+        trace!("Scheduling coroutine: {:?}", task_name);
         #[cfg(feature = "profiler")]
         let coroutine = coroutine_timer!(task_name, coroutine);
         let task = TaskWithResult::<F::Output>::new(task_name, coroutine);
-        match self.scheduler.insert(group_id, task) {
-            Some(InsertResult::Inserted(task_id)) => {
+        match self.scheduler.schedule(group_id, task) {
+            Some(ScheduleResult::Scheduled(task_id)) => {
                 let qt = self.qtoken_to_scheduler_id.insert_with_new_id(task_id).unwrap();
                 self.scheduler
                     .get_task_mut(group_id, task_id)
@@ -175,8 +175,8 @@ impl SharedDemiRuntime {
                 // Stash the newly allocated qtoken in the task.
                 Ok(qt)
             },
-            Some(InsertResult::Completed(mut boxed_task)) => {
-                trace!("Completed while inserting coroutine: {:?}", boxed_task.name());
+            Some(ScheduleResult::Completed(mut boxed_task)) => {
+                trace!("Completed while scheduling coroutine: {:?}", boxed_task.name());
                 // Place into id map so that the application can retrive the result later.
                 let qt = self.qtoken_to_scheduler_id.insert_with_new_id(0_u64.into()).unwrap();
                 boxed_task.set_id(qt.into());
@@ -192,7 +192,7 @@ impl SharedDemiRuntime {
             },
             None => {
                 let cause = format!("cannot schedule coroutine (task_name={:?})", &task_name);
-                error!("insert_coroutine(): {}", cause);
+                error!("schedule_coroutine(): {}", cause);
                 Err(Fail::new(libc::EAGAIN, &cause))
             },
         }
@@ -279,7 +279,7 @@ impl SharedDemiRuntime {
                 self.run_scheduler();
             }
             while let Some(mut task) = self.completed_tasks.pop_front() {
-                let qt = expect_some!(task.id(), "should have been set on insert").into();
+                let qt = expect_some!(task.id(), "should have been set on schedule").into();
                 let (qd, result) = expect_some!(task.get_result(), "coroutine not finished");
                 self.qtoken_to_scheduler_id.remove(&qt);
 
@@ -413,7 +413,7 @@ impl SharedDemiRuntime {
             .run(id, Some(TIMER_RESOLUTION))
             .into_iter()
             .filter_map(|task| -> Option<OperationTask> {
-                let qt: QToken = expect_some!(task.id(), "should have been set on insert").into();
+                let qt: QToken = expect_some!(task.id(), "should have been set on schedule").into();
                 trace!("Completed coroutine (qt={:?}): {:?}", qt, task.name());
                 OperationTask::try_from(task.as_any()).ok()
             })
@@ -607,12 +607,12 @@ mod tests {
     }
 
     #[test]
-    fn insert_and_wait_for_first_task() -> Result<()> {
+    fn schedule_and_wait_for_first_task() -> Result<()> {
         let mut runtime = SharedDemiRuntime::default();
 
-        let qt = runtime.insert_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(0)).fuse()))?;
-        let _ = runtime.insert_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(1)).fuse()))?;
-        let _ = runtime.insert_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(2)).fuse()))?;
+        let qt = runtime.schedule_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(0)).fuse()))?;
+        let _ = runtime.schedule_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(1)).fuse()))?;
+        let _ = runtime.schedule_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(2)).fuse()))?;
 
         let task = runtime.wait(qt, Duration::ZERO)?;
         ensure_eq!(task.0, QDesc::from(0));
@@ -620,12 +620,12 @@ mod tests {
     }
 
     #[test]
-    fn insert_and_wait_for_middle_task() -> Result<()> {
+    fn schedule_and_wait_for_middle_task() -> Result<()> {
         let mut runtime = SharedDemiRuntime::default();
 
-        let _ = runtime.insert_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(0)).fuse()))?;
-        let qt2 = runtime.insert_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(1)).fuse()))?;
-        let _ = runtime.insert_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(2)).fuse()))?;
+        let _ = runtime.schedule_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(0)).fuse()))?;
+        let qt2 = runtime.schedule_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(1)).fuse()))?;
+        let _ = runtime.schedule_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(2)).fuse()))?;
 
         let task = runtime.wait(qt2, Duration::ZERO)?;
         ensure_eq!(task.0, QDesc::from(1));
@@ -633,12 +633,12 @@ mod tests {
     }
 
     #[test]
-    fn insert_and_wait_for_last_task() -> Result<()> {
+    fn schedule_and_wait_for_last_task() -> Result<()> {
         let mut runtime = SharedDemiRuntime::default();
 
-        let _ = runtime.insert_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(0)).fuse()))?;
-        let _ = runtime.insert_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(1)).fuse()))?;
-        let qt3 = runtime.insert_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(2)).fuse()))?;
+        let _ = runtime.schedule_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(0)).fuse()))?;
+        let _ = runtime.schedule_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(1)).fuse()))?;
+        let qt3 = runtime.schedule_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(2)).fuse()))?;
 
         let task = runtime.wait(qt3, Duration::ZERO)?;
         ensure_eq!(task.0, QDesc::from(2));
@@ -646,12 +646,12 @@ mod tests {
     }
 
     #[test]
-    fn insert_and_wait_any_for_first_tasks() -> Result<()> {
+    fn schedule_and_wait_any_for_first_tasks() -> Result<()> {
         let mut runtime = SharedDemiRuntime::default();
 
-        let qt = runtime.insert_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(0)).fuse()))?;
-        let qt2 = runtime.insert_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(1)).fuse()))?;
-        let _ = runtime.insert_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(2)).fuse()))?;
+        let qt = runtime.schedule_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(0)).fuse()))?;
+        let qt2 = runtime.schedule_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(1)).fuse()))?;
+        let _ = runtime.schedule_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(2)).fuse()))?;
         let qts = vec![qt, qt2];
         let task = runtime.wait_any(&qts, Duration::ZERO)?;
         ensure_eq!(task.2, QDesc::from(0));
@@ -659,12 +659,12 @@ mod tests {
     }
 
     #[test]
-    fn insert_and_wait_any_for_last_tasks() -> Result<()> {
+    fn schedule_and_wait_any_for_last_tasks() -> Result<()> {
         let mut runtime = SharedDemiRuntime::default();
 
-        let _ = runtime.insert_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(0)).fuse()))?;
-        let qt2 = runtime.insert_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(1)).fuse()))?;
-        let qt3 = runtime.insert_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(2)).fuse()))?;
+        let _ = runtime.schedule_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(0)).fuse()))?;
+        let qt2 = runtime.schedule_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(1)).fuse()))?;
+        let qt3 = runtime.schedule_coroutine("dummy coroutine", Box::pin(dummy_coroutine(1, QDesc::from(2)).fuse()))?;
         let qts = vec![qt2, qt3];
         let task = runtime.wait_any(&qts, Duration::ZERO)?;
         ensure_eq!(task.2, QDesc::from(1));
@@ -672,18 +672,18 @@ mod tests {
     }
 
     #[bench]
-    fn insert_background_coroutine_bench(b: &mut Bencher) {
+    fn schedule_background_coroutine_bench(b: &mut Bencher) {
         let mut runtime = SharedDemiRuntime::default();
 
-        b.iter(|| runtime.insert_coroutine("dummy coroutine", Box::pin(dummy_coroutine(10, QDesc::from(0)).fuse())));
+        b.iter(|| runtime.schedule_coroutine("dummy coroutine", Box::pin(dummy_coroutine(10, QDesc::from(0)).fuse())));
     }
 
     #[bench]
-    fn insert_coroutine_bench(b: &mut Bencher) {
+    fn schedule_coroutine_bench(b: &mut Bencher) {
         let mut runtime = SharedDemiRuntime::default();
 
         b.iter(|| {
-            runtime.insert_coroutine(
+            runtime.schedule_coroutine(
                 "dummy background coroutine",
                 Box::pin(dummy_background_coroutine().fuse()),
             )
@@ -695,14 +695,14 @@ mod tests {
         const NUM_TASKS: usize = 1024;
         let mut qts = [QToken::from(0); NUM_TASKS];
         let mut runtime = SharedDemiRuntime::default();
-        // Insert a large number of coroutines.
+        // Schedule a large number of coroutines.
         for qt in qts.iter_mut().take(NUM_TASKS) {
             *qt = expect_ok!(
-                runtime.insert_coroutine(
+                runtime.schedule_coroutine(
                     "dummy coroutine",
                     Box::pin(dummy_coroutine(1000000000, QDesc::from(0)).fuse())
                 ),
-                "should be able to insert tasks"
+                "should be able to schedule tasks"
             );
         }
 
@@ -715,14 +715,14 @@ mod tests {
         const NUM_TASKS: usize = 1024;
         let mut qts = [QToken::from(0); NUM_TASKS];
         let mut runtime = SharedDemiRuntime::default();
-        // Insert a large number of coroutines.
+        // Schedule a large number of coroutines.
         for qt in qts.iter_mut().take(NUM_TASKS) {
             *qt = expect_ok!(
-                runtime.insert_polling_coroutine(
+                runtime.schedule_polling_coroutine(
                     "dummy background coroutine",
                     Box::pin(dummy_background_coroutine().fuse()),
                 ),
-                "should be able to insert tasks"
+                "should be able to schedule tasks"
             );
         }
 

--- a/src/runtime/scheduler/group.rs
+++ b/src/runtime/scheduler/group.rs
@@ -17,7 +17,7 @@ use crate::{
     runtime::scheduler::{
         page::{WakerPageRef, WakerRef},
         waker64::{WAKER_BIT_LENGTH, WAKER_BIT_LENGTH_SHIFT},
-        InsertResult, Task,
+        ScheduleResult, Task,
     },
 };
 use ::bit_iter::BitIter;
@@ -49,7 +49,6 @@ pub struct TaskGroup {
 //======================================================================================================================
 
 impl TaskGroup {
-    /// Remove task by handle.
     pub fn remove(&mut self, idx: usize) -> Option<Box<dyn Task>> {
         let (page_idx, offset) = self.locate(idx)?;
         self.pages[page_idx].clear(offset);
@@ -68,7 +67,7 @@ impl TaskGroup {
         }
     }
 
-    pub fn insert(&mut self, task: Box<dyn Task>) -> Option<InsertResult> {
+    pub fn schedule(&mut self, task: Box<dyn Task>) -> Option<ScheduleResult> {
         let name = task.name();
         let idx = self.tasks.insert(task)?;
 
@@ -77,11 +76,11 @@ impl TaskGroup {
         let (page_idx, offset) = self.locate(idx)?;
         self.pages[page_idx].initialize(offset);
 
-        trace!("insert(): name={:?}, idx={:?}", name, idx);
+        trace!("schedule(): name={:?}, idx={:?}", name, idx);
 
         match self.run_task(idx) {
-            Some(task) => Some(InsertResult::Completed(task)),
-            None => Some(InsertResult::Inserted(idx.into())),
+            Some(task) => Some(ScheduleResult::Completed(task)),
+            None => Some(ScheduleResult::Scheduled(idx.into())),
         }
     }
 

--- a/src/runtime/scheduler/group.rs
+++ b/src/runtime/scheduler/group.rs
@@ -25,8 +25,7 @@ use ::futures::Future;
 use ::std::{
     iter::Flatten,
     pin::Pin,
-    ptr::NonNull,
-    task::{Context, Poll, Waker},
+    task::{Context, Waker},
     vec::IntoIter,
 };
 
@@ -34,15 +33,14 @@ use ::std::{
 // Structures
 //======================================================================================================================
 
-/// This represents a resource management group. All tasks belong to a task group. By default, a task belongs to the
-/// same task group as the allocating task.
+/// Resource management group; all tasks belong to one.
+/// By default, tasks inherit the allocator's group.
 #[derive(Default)]
 pub struct TaskGroup {
-    /// Stores all the tasks that are held by the scheduler.
+    /// All scheduled tasks.
     tasks: PinSlab<Box<dyn Task>>,
-    /// Holds the waker bits for controlling task scheduling.
-    waker_page_refs: Vec<WakerPageRef>,
-    /// List of ready tasks.
+    /// Waker pages controlling scheduling.
+    pages: Vec<WakerPageRef>,
     ready_tasks: Flatten<IntoIter<Vec<usize>>>,
 }
 
@@ -51,170 +49,138 @@ pub struct TaskGroup {
 //======================================================================================================================
 
 impl TaskGroup {
-    /// Given a handle to a task, remove it from the scheduler.
-    pub fn remove(&mut self, pin_slab_index: usize) -> Option<Box<dyn Task>> {
-        // We should not have a scheduler handle that refers to an invalid id, so unwrap and expect are safe here.
-        let (waker_page_ref, waker_page_offset): (&WakerPageRef, usize) = {
-            let (waker_page_index, waker_page_offset) = self.get_waker_page_index_and_offset(pin_slab_index)?;
-            (&self.waker_page_refs[waker_page_index], waker_page_offset)
-        };
-        waker_page_ref.clear(waker_page_offset);
-        if let Some(task) = self.tasks.remove_unpin(pin_slab_index) {
+    /// Remove task by handle.
+    pub fn remove(&mut self, idx: usize) -> Option<Box<dyn Task>> {
+        let (page_idx, offset) = self.locate(idx)?;
+        self.pages[page_idx].clear(offset);
+
+        if let Some(task) = self.tasks.remove_unpin(idx) {
             trace!(
                 "remove(): name={:?}, id={:?}, pin_slab_index={:?}",
-                task.get_name(),
-                task.get_id(),
-                pin_slab_index
+                task.name(),
+                task.id(),
+                idx
             );
             Some(task)
         } else {
-            warn!("Unable to unpin and remove: pin_slab_index={:?}", pin_slab_index);
+            warn!("Unable to unpin and remove: pin_slab_index={:?}", idx);
             None
         }
     }
 
-    /// Insert a new task into our scheduler returning a handle corresponding to it.
-    pub fn insert_and_poll_task(&mut self, task: Box<dyn Task>) -> Option<InsertResult> {
-        let task_name: &'static str = task.get_name();
-        // The pin slab index can be reverse-computed in a page index and an offset within the page.
-        let pin_slab_index: usize = self.tasks.insert(task)?;
+    pub fn insert(&mut self, task: Box<dyn Task>) -> Option<InsertResult> {
+        let name = task.name();
+        let idx = self.tasks.insert(task)?;
 
-        self.add_new_pages_up_to_pin_slab_index(pin_slab_index);
+        self.grow_pages(idx);
 
-        // Initialize the appropriate page offset.
-        let (waker_page_ref, waker_page_offset): (&WakerPageRef, usize) = {
-            let (waker_page_index, waker_page_offset) = self.get_waker_page_index_and_offset(pin_slab_index)?;
-            (&self.waker_page_refs[waker_page_index], waker_page_offset)
-        };
-        waker_page_ref.initialize(waker_page_offset);
+        let (page_idx, offset) = self.locate(idx)?;
+        self.pages[page_idx].initialize(offset);
 
-        trace!("insert(): name={:?}, pin_slab_index={:?}", task_name, pin_slab_index);
+        trace!("insert(): name={:?}, idx={:?}", name, idx);
 
-        // Poll new task.
-        match self.poll_runnable_task(pin_slab_index) {
+        match self.run_task(idx) {
             Some(task) => Some(InsertResult::Completed(task)),
-            None => Some(InsertResult::Inserted(pin_slab_index.into())),
+            None => Some(InsertResult::Inserted(idx.into())),
         }
     }
 
-    pub fn get_mut_task(&mut self, pin_slab_index: usize) -> Option<Pin<&mut Box<dyn Task>>> {
-        self.tasks.get_pin_mut(pin_slab_index)
+    pub fn get_task_mut(&mut self, idx: usize) -> Option<Pin<&mut Box<dyn Task>>> {
+        self.tasks.get_pin_mut(idx)
     }
 
     /// Computes the page and page offset of a given task based on its total offset.
-    fn get_waker_page_index_and_offset(&self, pin_slab_index: usize) -> Option<(usize, usize)> {
+    fn locate(&self, pin_slab_index: usize) -> Option<(usize, usize)> {
         // This check ensures that slab slot is actually occupied but trusts that pin_slab_index is for this task.
         if !self.tasks.contains(pin_slab_index) {
             return None;
         }
-        let waker_page_index: usize = pin_slab_index >> WAKER_BIT_LENGTH_SHIFT;
-        let waker_page_offset: usize = Self::get_waker_page_offset(pin_slab_index);
-        Some((waker_page_index, waker_page_offset))
+        let index = pin_slab_index >> WAKER_BIT_LENGTH_SHIFT;
+        let offset = Self::get_page_offset(pin_slab_index);
+        Some((index, offset))
     }
 
-    /// Add new page(s) to hold this future's status if the current page is filled. This may result in addition of
-    /// multiple pages because of the gap between the pin slab index and the current page index.
-    fn add_new_pages_up_to_pin_slab_index(&mut self, pin_slab_index: usize) {
-        while pin_slab_index >= (self.waker_page_refs.len() << WAKER_BIT_LENGTH_SHIFT) {
-            self.waker_page_refs.push(WakerPageRef::default());
+    /// Grow pages to fit the given pin slab index.
+    fn grow_pages(&mut self, idx: usize) {
+        while idx >= (self.pages.len() << WAKER_BIT_LENGTH_SHIFT) {
+            self.pages.push(WakerPageRef::default());
         }
     }
 
-    pub fn get_num_waker_pages(&self) -> usize {
-        self.waker_page_refs.len()
-    }
-
-    fn get_waker_page_offset(pin_slab_index: usize) -> usize {
+    fn get_page_offset(pin_slab_index: usize) -> usize {
         pin_slab_index & (WAKER_BIT_LENGTH - 1)
     }
 
-    fn get_pin_slab_index(waker_page_index: usize, waker_page_offset: usize) -> usize {
-        (waker_page_index << WAKER_BIT_LENGTH_SHIFT) + waker_page_offset
+    fn get_pin_slab_index(page_idx: usize, page_offset: usize) -> usize {
+        (page_idx << WAKER_BIT_LENGTH_SHIFT) + page_offset
     }
 
-    fn get_pinned_task_ptr(&mut self, pin_slab_index: usize) -> Pin<&mut Box<dyn Task>> {
-        // Get the pinned ref.
-        expect_some!(
-            self.tasks.get_pin_mut(pin_slab_index),
-            "Invalid offset: {:?}",
-            pin_slab_index
-        )
+    fn pinned_task(&mut self, idx: usize) -> Pin<&mut Box<dyn Task>> {
+        expect_some!(self.tasks.get_pin_mut(idx), "Invalid offset: {:?}", idx)
     }
 
     pub fn get_waker(&self, task_offset: usize) -> Option<Waker> {
-        let (waker_page_index, waker_page_offset) = self.get_waker_page_index_and_offset(task_offset)?;
-
-        let raw_waker: NonNull<u8> = self.waker_page_refs[waker_page_index].as_raw_waker_ref(waker_page_offset);
+        let (index, offset) = self.locate(task_offset)?;
+        let raw_waker = self.pages[index].as_raw_waker_ref(offset);
         Some(unsafe { Waker::from_raw(WakerRef::new(raw_waker).into()) })
     }
 
-    pub fn poll_group(
-        &mut self,
-        max_iterations: Option<usize>,
-        keep_checking_for_new_tasks: bool,
-    ) -> Vec<Box<dyn Task>> {
-        let mut iterations_run: usize = 0;
-        // Return value.
-        let mut completed_tasks: Vec<Box<dyn Task>> = Vec::new();
-        // Definitely check for additional tasks on the first iteration, but then set to [keep_checking_for_new_tasks].
-        let mut check_for_additonal_tasks: bool = true;
+    // Always check for new tasks on the first iteration; afterward, based on refill.
+    pub fn run(&mut self, limit: Option<usize>, refill: bool) -> Vec<Box<dyn Task>> {
+        let mut iter = 0;
+        let mut tasks = Vec::new();
 
-        // Loop over the ready tasks.
-        while let Some(next_ready_task_offset) = self.get_next_runnable_task(check_for_additonal_tasks) {
-            if let Some(task) = self.poll_runnable_task(next_ready_task_offset) {
-                completed_tasks.push(task);
+        while let Some(offset) = self.next(iter == 0 || refill) {
+            if let Some(task) = self.run_task(offset) {
+                tasks.push(task);
             }
-            check_for_additonal_tasks = keep_checking_for_new_tasks;
-            match max_iterations {
-                Some(max_iterations) if iterations_run >= max_iterations => return completed_tasks,
-                _ => iterations_run += 1,
+
+            if limit.is_some_and(|max| iter >= max) {
+                return tasks;
             }
+
+            iter += 1
         }
-        completed_tasks
+
+        tasks
     }
 
-    /// Get the next runnable task. If no runnable tasks, it will check for new tasks if the [check_for_new_tasks] flag
-    /// is set, then try again.
-    fn get_next_runnable_task(&mut self, check_for_new_tasks: bool) -> Option<usize> {
-        match self.ready_tasks.next() {
-            Some(task) => Some(task),
-            None if check_for_new_tasks => {
-                self.ready_tasks = self.check_for_new_ready_tasks();
-                self.ready_tasks.next()
-            },
-            None => None,
+    fn next(&mut self, refill: bool) -> Option<usize> {
+        if let Some(task) = self.ready_tasks.next() {
+            return Some(task);
         }
+
+        if refill {
+            self.ready_tasks = self.refill_ready();
+            return self.ready_tasks.next();
+        }
+
+        None
     }
 
-    /// Go over the waker pages looking for new runnable tasks.
-    fn check_for_new_ready_tasks(&mut self) -> Flatten<IntoIter<Vec<usize>>> {
-        let mut indices: Vec<Vec<usize>> = vec![];
-        for i in 0..self.get_num_waker_pages() {
-            let notified: u64 = self.waker_page_refs[i].take_notified();
-            indices.push(
-                BitIter::from(notified)
-                    .map(|x| Self::get_pin_slab_index(i, x))
-                    .collect(),
-            )
+    /// Scan all waker pages for notified tasks.
+    fn refill_ready(&mut self) -> Flatten<IntoIter<Vec<usize>>> {
+        let mut out = vec![];
+
+        for i in 0..self.pages.len() {
+            let bits = self.pages[i].take_notified();
+            out.push(BitIter::from(bits).map(|x| Self::get_pin_slab_index(i, x)).collect())
         }
-        indices.into_iter().flatten()
+
+        out.into_iter().flatten()
     }
 
-    // Runs a single ready task. If the task completes after running, returns.
-    fn poll_runnable_task(&mut self, pin_slab_index: usize) -> Option<Box<dyn Task>> {
-        // Perform the actual work of running the task.
-        let poll_result: Poll<()> = {
-            let waker: Waker = self.get_waker(pin_slab_index)?;
-            let mut waker_context: Context = Context::from_waker(&waker);
-            let mut pinned_ptr = self.get_pinned_task_ptr(pin_slab_index);
-            let pinned_ref = unsafe { Pin::new_unchecked(&mut *pinned_ptr) };
+    // Poll a ready task; return it if done.
+    fn run_task(&mut self, idx: usize) -> Option<Box<dyn Task>> {
+        let waker = self.get_waker(idx)?;
+        let mut cx = Context::from_waker(&waker);
+        let mut ptr = self.pinned_task(idx);
+        let task = unsafe { Pin::new_unchecked(&mut *ptr) };
 
-            Future::poll(pinned_ref, &mut waker_context)
-        };
-
-        if poll_result == Poll::Ready(()) {
-            return self.remove(pin_slab_index);
+        if Future::poll(task, &mut cx).is_ready() {
+            return self.remove(idx);
         }
+
         None
     }
 }

--- a/src/runtime/scheduler/mod.rs
+++ b/src/runtime/scheduler/mod.rs
@@ -41,6 +41,6 @@ mod waker64;
 //======================================================================================================================
 
 pub use self::{
-    scheduler::{InsertResult, SchedulerId, SharedScheduler},
+    scheduler::{ScheduleResult, SchedulerId, SharedScheduler},
     task::{Task, TaskWithResult},
 };

--- a/src/runtime/scheduler/page/page.rs
+++ b/src/runtime/scheduler/page/page.rs
@@ -71,7 +71,7 @@ impl WakerPage {
     /// The reference count for the target page is left unmodified.
     pub fn clear(&self, ix: usize) {
         debug_assert!(ix < WAKER_BIT_LENGTH);
-        let mask: u64 = !(1 << ix);
+        let mask = !(1 << ix);
         self.notified.fetch_and(mask);
     }
 
@@ -90,7 +90,7 @@ impl WakerPage {
 
     /// Gets the reference count of the target [WakerPage].
     #[cfg(test)]
-    pub fn refcount_get(&self) -> u64 {
+    pub fn refcount(&self) -> u64 {
         self.refcount.load()
     }
 }
@@ -129,27 +129,27 @@ mod tests {
 
     #[bench]
     fn notify_bench(b: &mut Bencher) {
-        let pg: WakerPage = WakerPage::default();
-        let x: usize = rand::thread_rng().gen_range(0..WAKER_BIT_LENGTH);
+        let page = WakerPage::default();
+        let x = rand::thread_rng().gen_range(0..WAKER_BIT_LENGTH);
 
         b.iter(|| {
-            let ix: usize = black_box(x);
-            pg.notify(ix);
+            let ix = black_box(x);
+            page.notify(ix);
         });
     }
 
     #[bench]
     fn take_notified_bench(b: &mut Bencher) {
-        let pg: WakerPage = WakerPage::default();
+        let page = WakerPage::default();
 
         // Initialize 8 random bits.
         for _ in 0..8 {
-            let ix: usize = rand::thread_rng().gen_range(0..WAKER_BIT_LENGTH);
-            pg.initialize(ix);
+            let ix = rand::thread_rng().gen_range(0..WAKER_BIT_LENGTH);
+            page.initialize(ix);
         }
 
         b.iter(|| {
-            let x: u64 = pg.take_notified();
+            let x = page.take_notified();
             black_box(x);
         });
     }

--- a/src/runtime/scheduler/page/page_ref.rs
+++ b/src/runtime/scheduler/page/page_ref.rs
@@ -33,8 +33,8 @@ pub struct WakerPageRef(NonNull<WakerPage>);
 
 /// Associate Functions for Waker Page References
 impl WakerPageRef {
-    pub fn new(waker_page: NonNull<WakerPage>) -> Self {
-        Self(waker_page)
+    pub fn new(page: NonNull<WakerPage>) -> Self {
+        Self(page)
     }
 
     /// Casts the target [WakerPageRef] into a [NonNull<u8>].
@@ -61,12 +61,12 @@ impl WakerPageRef {
         debug_assert!(ix < WAKER_BIT_LENGTH);
 
         // Bump the refcount of the underlying waker page.
-        let self_: WakerPageRef = self.clone();
+        let self_ = self.clone();
         mem::forget(self_);
 
         unsafe {
             let base_ptr: *mut u8 = self.0.as_ptr().cast();
-            let ptr: NonNull<u8> = NonNull::new_unchecked(base_ptr.add(ix));
+            let ptr = NonNull::new_unchecked(base_ptr.add(ix));
             ptr
         }
     }
@@ -78,7 +78,7 @@ impl WakerPageRef {
 
 impl Clone for WakerPageRef {
     fn clone(&self) -> Self {
-        let old_refount: u64 = unsafe { self.0.as_ref().refcount_inc() };
+        let old_refount = unsafe { self.0.as_ref().refcount_inc() };
         debug_assert!(old_refount < u64::MAX);
         Self(self.0)
     }
@@ -107,9 +107,9 @@ impl Deref for WakerPageRef {
 
 impl Default for WakerPageRef {
     fn default() -> Self {
-        let layout: Layout = Layout::new::<WakerPage>();
+        let layout = Layout::new::<WakerPage>();
         assert_eq!(layout.align(), WAKER_PAGE_SIZE);
-        let mut ptr: NonNull<WakerPage> = expect_ok!(Global.allocate(layout), "Failed to allocate WakerPage").cast();
+        let mut ptr = expect_ok!(Global.allocate(layout), "Failed to allocate WakerPage").cast();
         unsafe {
             let page: &mut WakerPage = ptr.as_mut();
             page.reset();
@@ -126,92 +126,68 @@ impl Default for WakerPageRef {
 mod tests {
     use crate::runtime::scheduler::page::WakerPageRef;
     use ::anyhow::Result;
-    use ::std::ptr::NonNull;
 
     #[test]
     fn test_clone() -> Result<()> {
-        let p: WakerPageRef = WakerPageRef::default();
+        let page = WakerPageRef::default();
+        crate::ensure_eq!(page.refcount(), 1);
 
-        let refcount: u64 = p.refcount_get();
-        crate::ensure_eq!(refcount, 1);
+        // Clone page
+        let page_clone = page.clone();
+        crate::ensure_eq!(page_clone.refcount(), 2);
+        crate::ensure_eq!(page.refcount(), 2);
 
-        // Clone p
-        let p_clone: WakerPageRef = p.clone();
-        let refcount: u64 = p_clone.refcount_get();
-        crate::ensure_eq!(refcount, 2);
-        let refcount: u64 = p.refcount_get();
-        crate::ensure_eq!(refcount, 2);
+        // Clone page_clone
+        let page_clone_clone = page_clone.clone();
+        crate::ensure_eq!(page_clone_clone.refcount(), 3);
+        crate::ensure_eq!(page_clone.refcount(), 3);
+        crate::ensure_eq!(page.refcount(), 3);
 
-        // Clone p_clone
-        let p_clone_clone: WakerPageRef = p_clone.clone();
-        let refcount: u64 = p_clone_clone.refcount_get();
-        crate::ensure_eq!(refcount, 3);
-        let refcount: u64 = p_clone.refcount_get();
-        crate::ensure_eq!(refcount, 3);
-        let refcount: u64 = p.refcount_get();
-        crate::ensure_eq!(refcount, 3);
+        // Drop page_clone_clone
+        drop(page_clone_clone);
+        crate::ensure_eq!(page_clone.refcount(), 2);
+        crate::ensure_eq!(page.refcount(), 2);
 
-        // Drop p_clone_clone
-        drop(p_clone_clone);
-        let refcount: u64 = p_clone.refcount_get();
-        crate::ensure_eq!(refcount, 2);
-        let refcount: u64 = p.refcount_get();
-        crate::ensure_eq!(refcount, 2);
+        // Drop page_clone
+        drop(page_clone);
+        crate::ensure_eq!(page.refcount(), 1);
 
-        // Drop p_clone
-        drop(p_clone);
-        let refcount: u64 = p.refcount_get();
-        crate::ensure_eq!(refcount, 1);
+        // Clone page
+        let page_clone = page.clone();
+        crate::ensure_eq!(page_clone.refcount(), 2);
+        crate::ensure_eq!(page.refcount(), 2);
 
-        // Clone p
-        let p_clone: WakerPageRef = p.clone();
-        let refcount: u64 = p_clone.refcount_get();
-        crate::ensure_eq!(refcount, 2);
-        let refcount: u64 = p.refcount_get();
-        crate::ensure_eq!(refcount, 2);
+        // Clone page again
+        let page_clone_clone = page.clone();
+        crate::ensure_eq!(page_clone_clone.refcount(), 3);
+        crate::ensure_eq!(page_clone.refcount(), 3);
+        crate::ensure_eq!(page.refcount(), 3);
 
-        // Clone p again
-        let p_clone_clone: WakerPageRef = p.clone();
-        let refcount: u64 = p_clone_clone.refcount_get();
-        crate::ensure_eq!(refcount, 3);
-        let refcount: u64 = p_clone.refcount_get();
-        crate::ensure_eq!(refcount, 3);
-        let refcount: u64 = p.refcount_get();
-        crate::ensure_eq!(refcount, 3);
+        // Drop page
+        drop(page);
+        crate::ensure_eq!(page_clone_clone.refcount(), 2);
+        crate::ensure_eq!(page_clone.refcount(), 2);
 
-        // Drop p
-        drop(p);
-        let refcount: u64 = p_clone_clone.refcount_get();
-        crate::ensure_eq!(refcount, 2);
-        let refcount: u64 = p_clone.refcount_get();
-        crate::ensure_eq!(refcount, 2);
-
-        // Drop p_clone_clone
-        drop(p_clone_clone);
-        let refcount: u64 = p_clone.refcount_get();
-        crate::ensure_eq!(refcount, 1);
+        // Drop page_clone_clone
+        drop(page_clone_clone);
+        crate::ensure_eq!(page_clone.refcount(), 1);
 
         Ok(())
     }
 
     #[test]
     fn test_into() -> Result<()> {
-        let p: WakerPageRef = WakerPageRef::default();
+        let page = WakerPageRef::default();
+        crate::ensure_eq!(page.refcount(), 1);
 
-        let refcount: u64 = p.refcount_get();
-        crate::ensure_eq!(refcount, 1);
+        let _ = page.as_raw_waker_ref(0);
+        crate::ensure_eq!(page.refcount(), 2);
 
-        let _: NonNull<u8> = p.as_raw_waker_ref(0);
-        let refcount: u64 = p.refcount_get();
-        crate::ensure_eq!(refcount, 2);
+        let _ = page.as_raw_waker_ref(31);
+        crate::ensure_eq!(page.refcount(), 3);
 
-        let _: NonNull<u8> = p.as_raw_waker_ref(31);
-        let refcount: u64 = p.refcount_get();
-        crate::ensure_eq!(refcount, 3);
-
-        let _: NonNull<u8> = p.as_raw_waker_ref(63);
-        let refcount: u64 = p.refcount_get();
-        crate::ensure_eq!(refcount, 4);
+        let _ = page.as_raw_waker_ref(63);
+        crate::ensure_eq!(page.refcount(), 4);
 
         Ok(())
     }

--- a/src/runtime/scheduler/page/waker_ref.rs
+++ b/src/runtime/scheduler/page/waker_ref.rs
@@ -35,10 +35,10 @@ impl WakerRef {
     ///
     /// For more information on this hack see comments on [crate::page::WakerPageRef].
     fn base_ptr(&self) -> (NonNull<WakerPage>, usize) {
-        let ptr: *mut u8 = self.0.as_ptr();
-        let forward_offset: usize = ptr.align_offset(WAKER_PAGE_SIZE);
-        let mut base_ptr: *mut u8 = ptr;
-        let mut offset: usize = 0;
+        let ptr = self.0.as_ptr();
+        let forward_offset = ptr.align_offset(WAKER_PAGE_SIZE);
+        let mut base_ptr = ptr;
+        let mut offset = 0;
         if forward_offset != 0 {
             offset = WAKER_PAGE_SIZE - forward_offset;
             base_ptr = ptr.wrapping_sub(offset);
@@ -48,8 +48,8 @@ impl WakerRef {
 
     /// Sets the notification flag for the task that associated with the target [WakerRef].
     fn wake_by_ref(&self) {
-        let (base_ptr, ix): (NonNull<WakerPage>, usize) = self.base_ptr();
-        let base: &WakerPage = unsafe { &*base_ptr.as_ptr() };
+        let (base_ptr, ix) = self.base_ptr();
+        let base = unsafe { &*base_ptr.as_ptr() };
         base.notify(ix);
     }
 
@@ -60,9 +60,9 @@ impl WakerRef {
 
     /// Gets the reference count of the target [WakerRef].
     #[cfg(test)]
-    pub fn refcount_get(&self) -> u64 {
-        let (base_ptr, _): (NonNull<WakerPage>, _) = self.base_ptr();
-        unsafe { base_ptr.as_ref().refcount_get() }
+    pub fn refcount(&self) -> u64 {
+        let (base_ptr, _) = self.base_ptr();
+        unsafe { base_ptr.as_ref().refcount() }
     }
 }
 
@@ -72,12 +72,12 @@ impl WakerRef {
 
 impl Clone for WakerRef {
     fn clone(&self) -> Self {
-        let (base_ptr, _): (NonNull<WakerPage>, _) = self.base_ptr();
-        let p: WakerPageRef = WakerPageRef::new(base_ptr);
+        let (base_ptr, _) = self.base_ptr();
+        let page_ref = WakerPageRef::new(base_ptr);
         // Increment reference count.
-        mem::forget(p.clone());
+        mem::forget(page_ref.clone());
         // This is not a double increment.
-        mem::forget(p);
+        mem::forget(page_ref);
         WakerRef(self.0)
     }
 }
@@ -92,8 +92,8 @@ impl Drop for WakerRef {
 
 impl Into<RawWaker> for WakerRef {
     fn into(self) -> RawWaker {
-        let ptr: *const () = self.0.cast().as_ptr() as *const ();
-        let waker: RawWaker = RawWaker::new(ptr, &VTABLE);
+        let ptr = self.0.cast().as_ptr() as *const ();
+        let waker = RawWaker::new(ptr, &VTABLE);
         // Increment reference count.
         mem::forget(self);
         waker
@@ -101,29 +101,27 @@ impl Into<RawWaker> for WakerRef {
 }
 
 unsafe fn waker_ref_clone(ptr: *const ()) -> RawWaker {
-    let p: WakerRef = WakerRef(NonNull::new_unchecked(ptr as *const u8 as *mut u8));
-    let q: WakerRef = p.clone();
+    let waker_ref = WakerRef(NonNull::new_unchecked(ptr as *const u8 as *mut u8));
+    let out = waker_ref.clone();
     // Increment reference count.
-    mem::forget(p);
-    q.into()
+    mem::forget(waker_ref);
+    out.into()
 }
 
 unsafe fn waker_ref_wake(ptr: *const ()) {
-    let p = WakerRef(NonNull::new_unchecked(ptr as *const u8 as *mut u8));
-    p.wake();
+    WakerRef(NonNull::new_unchecked(ptr as *const u8 as *mut u8)).wake();
 }
 
 unsafe fn waker_ref_wake_by_ref(ptr: *const ()) {
-    let p: WakerRef = WakerRef(NonNull::new_unchecked(ptr as *const u8 as *mut u8));
-    p.wake_by_ref();
+    let waker_ref = WakerRef(NonNull::new_unchecked(ptr as *const u8 as *mut u8));
+    waker_ref.wake_by_ref();
     // Increment reference count.
-    mem::forget(p);
+    mem::forget(waker_ref);
 }
 
 unsafe fn waker_ref_drop(ptr: *const ()) {
-    let p: WakerRef = WakerRef(NonNull::new_unchecked(ptr as *const u8 as *mut u8));
     // Decrement reference count.
-    drop(p);
+    drop(WakerRef(NonNull::new_unchecked(ptr as *const u8 as *mut u8)));
 }
 
 /// Raw Waker Trait Implementation for Waker References
@@ -142,131 +140,122 @@ mod tests {
     };
     use ::anyhow::Result;
     use ::rand::Rng;
-    use ::std::ptr::NonNull;
     use ::test::{black_box, Bencher};
 
     #[test]
     fn test_refcount() -> Result<()> {
-        let p: WakerPageRef = WakerPageRef::default();
-        crate::ensure_eq!(p.refcount_get(), 1);
+        let page = WakerPageRef::default();
+        crate::ensure_eq!(page.refcount(), 1);
 
-        let p_clone: NonNull<u8> = p.as_raw_waker_ref(0);
-        let refcount: u64 = p.refcount_get();
-        crate::ensure_eq!(refcount, 2);
-        let q: WakerRef = WakerRef::new(p_clone);
-        let refcount: u64 = q.refcount_get();
-        crate::ensure_eq!(refcount, 2);
-        let refcount: u64 = p.refcount_get();
-        crate::ensure_eq!(refcount, 2);
+        let page_clone = page.as_raw_waker_ref(0);
+        crate::ensure_eq!(page.refcount(), 2);
 
-        let r: WakerRef = WakerRef::new(p.as_raw_waker_ref(31));
-        let refcount: u64 = r.refcount_get();
-        crate::ensure_eq!(refcount, 3);
-        let refcount: u64 = p.refcount_get();
-        crate::ensure_eq!(refcount, 3);
+        let waker_ref1 = WakerRef::new(page_clone);
+        crate::ensure_eq!(waker_ref1.refcount(), 2);
+        crate::ensure_eq!(page.refcount(), 2);
 
-        let s: WakerRef = r.clone();
-        let refcount: u64 = s.refcount_get();
-        crate::ensure_eq!(refcount, 4);
-        let refcount: u64 = p.refcount_get();
-        crate::ensure_eq!(refcount, 4);
+        let waker_ref2 = WakerRef::new(page.as_raw_waker_ref(31));
+        crate::ensure_eq!(waker_ref2.refcount(), 3);
+        crate::ensure_eq!(page.refcount(), 3);
 
-        drop(s);
-        let refcount: u64 = p.refcount_get();
-        crate::ensure_eq!(refcount, 3);
+        let waker_ref3 = waker_ref2.clone();
+        crate::ensure_eq!(waker_ref3.refcount(), 4);
+        crate::ensure_eq!(page.refcount(), 4);
 
-        drop(r);
-        let refcount: u64 = p.refcount_get();
-        crate::ensure_eq!(refcount, 2);
+        drop(waker_ref3);
+        crate::ensure_eq!(page.refcount(), 3);
 
-        drop(q);
-        let refcount: u64 = p.refcount_get();
-        crate::ensure_eq!(refcount, 1);
+        drop(waker_ref2);
+        crate::ensure_eq!(page.refcount(), 2);
+
+        drop(waker_ref1);
+        crate::ensure_eq!(page.refcount(), 1);
 
         Ok(())
     }
 
     #[test]
     fn test_wake() -> Result<()> {
-        let p: WakerPageRef = WakerPageRef::default();
-        crate::ensure_eq!(p.refcount_get(), 1);
+        let page = WakerPageRef::default();
+        crate::ensure_eq!(page.refcount(), 1);
 
-        let q: WakerRef = WakerRef::new(p.as_raw_waker_ref(0));
-        crate::ensure_eq!(p.refcount_get(), 2);
-        let r: WakerRef = WakerRef::new(p.as_raw_waker_ref(31));
-        crate::ensure_eq!(p.refcount_get(), 3);
-        let s: WakerRef = WakerRef::new(p.as_raw_waker_ref(15));
-        crate::ensure_eq!(p.refcount_get(), 4);
+        let waker_ref1 = WakerRef::new(page.as_raw_waker_ref(0));
+        crate::ensure_eq!(page.refcount(), 2);
 
-        q.wake();
-        crate::ensure_eq!(p.take_notified(), 1 << 0);
-        crate::ensure_eq!(p.refcount_get(), 3);
+        let waker_ref2 = WakerRef::new(page.as_raw_waker_ref(31));
+        crate::ensure_eq!(page.refcount(), 3);
 
-        r.wake();
-        s.wake();
-        crate::ensure_eq!(p.take_notified(), 1 << 15 | 1 << 31);
-        crate::ensure_eq!(p.refcount_get(), 1);
+        let waker_ref3 = WakerRef::new(page.as_raw_waker_ref(15));
+        crate::ensure_eq!(page.refcount(), 4);
+
+        waker_ref1.wake();
+        crate::ensure_eq!(page.take_notified(), 1 << 0);
+        crate::ensure_eq!(page.refcount(), 3);
+
+        waker_ref2.wake();
+        waker_ref3.wake();
+        crate::ensure_eq!(page.take_notified(), 1 << 15 | 1 << 31);
+        crate::ensure_eq!(page.refcount(), 1);
 
         Ok(())
     }
 
     #[test]
     fn test_wake_by_ref() -> Result<()> {
-        let p: WakerPageRef = WakerPageRef::default();
-        crate::ensure_eq!(p.refcount_get(), 1);
+        let page = WakerPageRef::default();
+        crate::ensure_eq!(page.refcount(), 1);
 
-        let q: WakerRef = WakerRef::new(p.as_raw_waker_ref(0));
-        crate::ensure_eq!(p.refcount_get(), 2);
-        let r: WakerRef = WakerRef::new(p.as_raw_waker_ref(31));
-        crate::ensure_eq!(p.refcount_get(), 3);
-        let s: WakerRef = WakerRef::new(p.as_raw_waker_ref(15));
-        crate::ensure_eq!(p.refcount_get(), 4);
+        let waker_ref1 = WakerRef::new(page.as_raw_waker_ref(0));
+        crate::ensure_eq!(page.refcount(), 2);
 
-        q.wake_by_ref();
-        crate::ensure_eq!(p.take_notified(), 1 << 0);
-        crate::ensure_eq!(p.refcount_get(), 4);
+        let waker_ref2 = WakerRef::new(page.as_raw_waker_ref(31));
+        crate::ensure_eq!(page.refcount(), 3);
 
-        r.wake_by_ref();
-        s.wake_by_ref();
-        crate::ensure_eq!(p.take_notified(), 1 << 15 | 1 << 31);
-        crate::ensure_eq!(p.refcount_get(), 4);
+        let waker_ref3 = WakerRef::new(page.as_raw_waker_ref(15));
+        crate::ensure_eq!(page.refcount(), 4);
 
-        drop(s);
-        let refcount: u64 = p.refcount_get();
-        crate::ensure_eq!(refcount, 3);
+        waker_ref1.wake_by_ref();
+        crate::ensure_eq!(page.take_notified(), 1 << 0);
+        crate::ensure_eq!(page.refcount(), 4);
 
-        drop(r);
-        let refcount: u64 = p.refcount_get();
-        crate::ensure_eq!(refcount, 2);
+        waker_ref2.wake_by_ref();
+        waker_ref3.wake_by_ref();
+        crate::ensure_eq!(page.take_notified(), 1 << 15 | 1 << 31);
+        crate::ensure_eq!(page.refcount(), 4);
 
-        drop(q);
-        let refcount: u64 = p.refcount_get();
-        crate::ensure_eq!(refcount, 1);
+        drop(waker_ref3);
+        crate::ensure_eq!(page.refcount(), 3);
+
+        drop(waker_ref2);
+        crate::ensure_eq!(page.refcount(), 2);
+
+        drop(waker_ref1);
+        crate::ensure_eq!(page.refcount(), 1);
 
         Ok(())
     }
 
     #[bench]
     fn wake_bench(b: &mut Bencher) {
-        let p: WakerPageRef = WakerPageRef::default();
-        let ix: usize = rand::thread_rng().gen_range(0..WAKER_BIT_LENGTH);
+        let page = WakerPageRef::default();
+        let ix = rand::thread_rng().gen_range(0..WAKER_BIT_LENGTH);
 
         b.iter(|| {
-            let raw_page_ref: NonNull<u8> = black_box(p.as_raw_waker_ref(ix));
-            let q: WakerRef = WakerRef::new(raw_page_ref);
-            q.wake();
+            let raw_page_ref = black_box(page.as_raw_waker_ref(ix));
+            let waker_ref = WakerRef::new(raw_page_ref);
+            waker_ref.wake();
         });
     }
 
     #[bench]
     fn wake_by_ref_bench(b: &mut Bencher) {
-        let p: WakerPageRef = WakerPageRef::default();
-        let ix: usize = rand::thread_rng().gen_range(0..WAKER_BIT_LENGTH);
+        let page = WakerPageRef::default();
+        let ix = rand::thread_rng().gen_range(0..WAKER_BIT_LENGTH);
 
         b.iter(|| {
-            let raw_page_ref: NonNull<u8> = black_box(p.as_raw_waker_ref(ix));
-            let q: WakerRef = WakerRef::new(raw_page_ref);
-            q.wake_by_ref();
+            let raw_page_ref = black_box(page.as_raw_waker_ref(ix));
+            let waker_ref = WakerRef::new(raw_page_ref);
+            waker_ref.wake_by_ref();
         });
     }
 }

--- a/src/runtime/scheduler/scheduler.rs
+++ b/src/runtime/scheduler/scheduler.rs
@@ -39,10 +39,10 @@ pub struct SchedulerId(pub usize);
 #[derive(Clone, Default)]
 pub struct SharedScheduler(SharedObject<Scheduler>);
 
-/// Possible outcomes for inserting a task.
+/// Possible outcomes for scheduling a task.
 #[derive(Debug)]
-pub enum InsertResult {
-    Inserted(SchedulerId),
+pub enum ScheduleResult {
+    Scheduled(SchedulerId),
     Completed(Box<dyn Task>),
 }
 
@@ -59,8 +59,8 @@ impl Scheduler {
         self.groups.get_mut(id.into())
     }
 
-    pub fn insert<T: Task>(&mut self, group_id: SchedulerId, task: T) -> Option<InsertResult> {
-        self.get_group_mut(group_id)?.insert(Box::new(task))
+    pub fn schedule<T: Task>(&mut self, group_id: SchedulerId, task: T) -> Option<ScheduleResult> {
+        self.get_group_mut(group_id)?.schedule(Box::new(task))
     }
 
     pub fn get_task_mut(&mut self, group_id: SchedulerId, task_id: SchedulerId) -> Option<Pin<&mut Box<dyn Task>>> {
@@ -128,7 +128,7 @@ impl From<SchedulerId> for u64 {
 #[cfg(test)]
 mod tests {
     use crate::runtime::scheduler::{
-        scheduler::{InsertResult, Scheduler, SchedulerId},
+        scheduler::{ScheduleResult, Scheduler, SchedulerId},
         task::TaskWithResult,
     };
     use ::anyhow::Result;
@@ -174,13 +174,13 @@ mod tests {
         let mut scheduler = Scheduler::default();
         let group_id = scheduler.create_group();
 
-        // Insert a single future in the scheduler. This future shall complete with a single poll operation.
+        // Schedule a single future in the scheduler. This future shall complete with a single poll operation.
         let task = DummyTask::new("testing", Box::pin(DummyCoroutine::new(1).fuse()));
-        let Some(InsertResult::Inserted(_)) = scheduler.insert(group_id, task) else {
-            anyhow::bail!("insert() failed")
+        let Some(ScheduleResult::Scheduled(_)) = scheduler.schedule(group_id, task) else {
+            anyhow::bail!("schedule() failed")
         };
 
-        // All futures are inserted in the scheduler with notification flag set.
+        // All futures are scheduled in the scheduler with notification flag set.
         // By polling once, our future should complete.
         if scheduler.run_once(group_id, None).pop().is_none() {
             anyhow::bail!("task should have completed")
@@ -194,14 +194,14 @@ mod tests {
         let mut scheduler = Scheduler::default();
         let group_id = scheduler.create_group();
 
-        // Insert a single future in the scheduler. This future shall complete
+        // Schedule a single future in the scheduler. This future shall complete
         // with two poll operations.
         let task = DummyTask::new("testing", Box::pin(DummyCoroutine::new(2).fuse()));
-        let Some(InsertResult::Inserted(_)) = scheduler.insert(group_id, task) else {
-            anyhow::bail!("insert() failed")
+        let Some(ScheduleResult::Scheduled(_)) = scheduler.schedule(group_id, task) else {
+            anyhow::bail!("schedule() failed")
         };
 
-        // All futures are inserted in the scheduler with notification flag set.
+        // All futures are scheduled in the scheduler with notification flag set.
         // By polling once, this future should make a transition.
         let result = scheduler.run_once(group_id, None).pop();
         crate::ensure_eq!(result.is_some(), false);
@@ -219,13 +219,13 @@ mod tests {
         let mut scheduler = Scheduler::default();
         let group_id = scheduler.create_group();
 
-        // Insert a single future in the scheduler. This future shall complete with a single poll operation.
+        // Schedule a single future in the scheduler. This future shall complete with a single poll operation.
         let task = DummyTask::new("testing", Box::pin(DummyCoroutine::new(1).fuse()));
-        let Some(InsertResult::Inserted(_)) = scheduler.insert(group_id, task) else {
-            anyhow::bail!("insert() failed")
+        let Some(ScheduleResult::Scheduled(_)) = scheduler.schedule(group_id, task) else {
+            anyhow::bail!("schedule() failed")
         };
 
-        // All futures are inserted in the scheduler with notification flag set.
+        // All futures are scheduled in the scheduler with notification flag set.
         // By polling until the task completes, our future should complete.
         if scheduler.run(group_id, None).pop().is_none() {
             anyhow::bail!("task should have completed")
@@ -235,14 +235,14 @@ mod tests {
     }
 
     #[bench]
-    fn insert_bench(b: &mut Bencher) {
+    fn schedule_bench(b: &mut Bencher) {
         let mut scheduler = Scheduler::default();
         let group_id = scheduler.create_group();
 
         b.iter(|| {
             let task = DummyTask::new("testing", Box::pin(black_box(DummyCoroutine::new(1).fuse())));
-            let Some(InsertResult::Inserted(task_id)) = scheduler.insert(group_id, task) else {
-                panic!("couldn't insert future in scheduler");
+            let Some(ScheduleResult::Scheduled(task_id)) = scheduler.schedule(group_id, task) else {
+                panic!("couldn't schedule future in scheduler");
             };
             black_box(task_id);
         });
@@ -258,10 +258,10 @@ mod tests {
 
         for val in 1..NUM_TASKS {
             let task = DummyTask::new("testing", Box::pin(DummyCoroutine::new(val).fuse()));
-            match scheduler.insert(group_id, task) {
-                Some(InsertResult::Completed(_)) => panic!("task should not have completed"),
-                Some(InsertResult::Inserted(task_id)) => task_ids.push(task_id),
-                None => panic!("insert() failed"),
+            match scheduler.schedule(group_id, task) {
+                Some(ScheduleResult::Completed(_)) => panic!("task should not have completed"),
+                Some(ScheduleResult::Scheduled(task_id)) => task_ids.push(task_id),
+                None => panic!("schedule() failed"),
             };
         }
 
@@ -280,10 +280,10 @@ mod tests {
 
         for val in 1..NUM_TASKS {
             let task = DummyTask::new("testing", Box::pin(DummyCoroutine::new(val).fuse()));
-            match scheduler.insert(group_id, task) {
-                Some(InsertResult::Completed(_)) => panic!("task should not have completed"),
-                Some(InsertResult::Inserted(task_id)) => task_ids.push(task_id),
-                None => panic!("insert() failed"),
+            match scheduler.schedule(group_id, task) {
+                Some(ScheduleResult::Completed(_)) => panic!("task should not have completed"),
+                Some(ScheduleResult::Scheduled(task_id)) => task_ids.push(task_id),
+                None => panic!("schedule() failed"),
             };
         }
 

--- a/src/runtime/scheduler/scheduler.rs
+++ b/src/runtime/scheduler/scheduler.rs
@@ -55,40 +55,27 @@ impl Scheduler {
         self.groups.insert(TaskGroup::default()).into()
     }
 
-    fn get_mut_group(&mut self, id: SchedulerId) -> Option<&mut TaskGroup> {
+    fn get_group_mut(&mut self, id: SchedulerId) -> Option<&mut TaskGroup> {
         self.groups.get_mut(id.into())
     }
 
-    /// The parent id can either be the id of the group or another task in the same group.
-    pub fn insert_and_poll_task<T: Task>(&mut self, group_id: SchedulerId, task: T) -> Option<InsertResult> {
-        let group: &mut TaskGroup = self.get_mut_group(group_id)?;
-        group.insert_and_poll_task(Box::new(task))
+    pub fn insert<T: Task>(&mut self, group_id: SchedulerId, task: T) -> Option<InsertResult> {
+        self.get_group_mut(group_id)?.insert(Box::new(task))
     }
 
-    pub fn get_mut_task(&mut self, group_id: SchedulerId, task_id: SchedulerId) -> Option<Pin<&mut Box<dyn Task>>> {
-        let group: &mut TaskGroup = self.get_mut_group(group_id)?;
-        group.get_mut_task(task_id.into())
+    pub fn get_task_mut(&mut self, group_id: SchedulerId, task_id: SchedulerId) -> Option<Pin<&mut Box<dyn Task>>> {
+        self.get_group_mut(group_id)?.get_task_mut(task_id.into())
     }
 
-    /// Polls all ready tasks in this group until there are no runnable ones. Do not use this function on coroutines
-    /// that use poll_yield, unless max_iterations is set.
-    pub fn poll_group_until_unrunnable(
-        &mut self,
-        group_id: SchedulerId,
-        max_iterations: Option<usize>,
-    ) -> Vec<Box<dyn Task>> {
-        // Expect is safe here because something has really gone wrong if we are polling a group that doesn't exist.
-        let group: &mut TaskGroup = self.get_mut_group(group_id).expect("group being polled doesn't exist");
-
-        // Keep polling the group and checking for runnable tasks until there are none left.
-        group.poll_group(max_iterations, true)
+    /// Do not use this function on coroutines that use poll_yield, unless limit is set.
+    pub fn run(&mut self, id: SchedulerId, limit: Option<usize>) -> Vec<Box<dyn Task>> {
+        let group = self.get_group_mut(id).expect("group missing");
+        group.run(limit, true)
     }
 
-    /// Polls all of the ready tasks in this group. Only check for new tasks at the beginning.
-    pub fn poll_group_once(&mut self, group_id: SchedulerId, max_iterations: Option<usize>) -> Vec<Box<dyn Task>> {
-        // Expect is safe here because something has really gone wrong if we are polling a group that doesn't exist.
-        let group: &mut TaskGroup = self.get_mut_group(group_id).expect("group being polled doesn't exist");
-        group.poll_group(max_iterations, false)
+    pub fn run_once(&mut self, id: SchedulerId, limit: Option<usize>) -> Vec<Box<dyn Task>> {
+        let group = self.get_group_mut(id).expect("group missing");
+        group.run(limit, false)
     }
 }
 
@@ -149,7 +136,7 @@ mod tests {
     use ::std::{
         future::Future,
         pin::Pin,
-        task::{Context, Poll, Waker},
+        task::{Context, Poll},
     };
     use ::test::{black_box, Bencher};
 
@@ -160,19 +147,19 @@ mod tests {
 
     impl DummyCoroutine {
         pub fn new(val: usize) -> Self {
-            let f: Self = Self { val };
+            let f = Self { val };
             f
         }
     }
     impl Future for DummyCoroutine {
         type Output = ();
 
-        fn poll(self: Pin<&mut Self>, ctx: &mut Context) -> Poll<Self::Output> {
+        fn poll(self: Pin<&mut Self>, context: &mut Context) -> Poll<Self::Output> {
             match self.as_ref().val {
                 0 => Poll::Ready(()),
                 _ => {
                     self.get_mut().val -= 1;
-                    let waker: &Waker = ctx.waker();
+                    let waker = context.waker();
                     waker.wake_by_ref();
                     Poll::Pending
                 },
@@ -183,19 +170,19 @@ mod tests {
     type DummyTask = TaskWithResult<()>;
 
     #[test]
-    fn poll_group_with_one_small_task_completes_it() -> Result<()> {
-        let mut scheduler: Scheduler = Scheduler::default();
-        let group_id: SchedulerId = scheduler.create_group();
+    fn run_group_with_one_small_task_completes_it() -> Result<()> {
+        let mut scheduler = Scheduler::default();
+        let group_id = scheduler.create_group();
 
         // Insert a single future in the scheduler. This future shall complete with a single poll operation.
-        let task: DummyTask = DummyTask::new("testing", Box::pin(DummyCoroutine::new(1).fuse()));
-        let Some(InsertResult::Inserted(_)) = scheduler.insert_and_poll_task(group_id, task) else {
+        let task = DummyTask::new("testing", Box::pin(DummyCoroutine::new(1).fuse()));
+        let Some(InsertResult::Inserted(_)) = scheduler.insert(group_id, task) else {
             anyhow::bail!("insert() failed")
         };
 
         // All futures are inserted in the scheduler with notification flag set.
         // By polling once, our future should complete.
-        if scheduler.poll_group_once(group_id, None).pop().is_none() {
+        if scheduler.run_once(group_id, None).pop().is_none() {
             anyhow::bail!("task should have completed")
         }
 
@@ -203,24 +190,24 @@ mod tests {
     }
 
     #[test]
-    fn poll_group_twice_with_one_long_task_completes_it() -> Result<()> {
-        let mut scheduler: Scheduler = Scheduler::default();
-        let group_id: SchedulerId = scheduler.create_group();
+    fn run_group_twice_with_one_long_task_completes_it() -> Result<()> {
+        let mut scheduler = Scheduler::default();
+        let group_id = scheduler.create_group();
 
         // Insert a single future in the scheduler. This future shall complete
         // with two poll operations.
-        let task: DummyTask = DummyTask::new("testing", Box::pin(DummyCoroutine::new(2).fuse()));
-        let Some(InsertResult::Inserted(_)) = scheduler.insert_and_poll_task(group_id, task) else {
+        let task = DummyTask::new("testing", Box::pin(DummyCoroutine::new(2).fuse()));
+        let Some(InsertResult::Inserted(_)) = scheduler.insert(group_id, task) else {
             anyhow::bail!("insert() failed")
         };
 
         // All futures are inserted in the scheduler with notification flag set.
         // By polling once, this future should make a transition.
-        let result = scheduler.poll_group_once(group_id, None).pop();
+        let result = scheduler.run_once(group_id, None).pop();
         crate::ensure_eq!(result.is_some(), false);
 
         // This shall make the future ready.
-        if scheduler.poll_group_once(group_id, None).pop().is_none() {
+        if scheduler.run_once(group_id, None).pop().is_none() {
             anyhow::bail!("task should have completed");
         }
 
@@ -228,19 +215,19 @@ mod tests {
     }
 
     #[test]
-    fn poll_until_unrunnable_with_one_long_task_completes_it() -> Result<()> {
-        let mut scheduler: Scheduler = Scheduler::default();
-        let group_id: SchedulerId = scheduler.create_group();
+    fn run_until_unrunnable_with_one_long_task_completes_it() -> Result<()> {
+        let mut scheduler = Scheduler::default();
+        let group_id = scheduler.create_group();
 
         // Insert a single future in the scheduler. This future shall complete with a single poll operation.
-        let task: DummyTask = DummyTask::new("testing", Box::pin(DummyCoroutine::new(1).fuse()));
-        let Some(InsertResult::Inserted(_)) = scheduler.insert_and_poll_task(group_id, task) else {
+        let task = DummyTask::new("testing", Box::pin(DummyCoroutine::new(1).fuse()));
+        let Some(InsertResult::Inserted(_)) = scheduler.insert(group_id, task) else {
             anyhow::bail!("insert() failed")
         };
 
         // All futures are inserted in the scheduler with notification flag set.
         // By polling until the task completes, our future should complete.
-        if scheduler.poll_group_until_unrunnable(group_id, None).pop().is_none() {
+        if scheduler.run(group_id, None).pop().is_none() {
             anyhow::bail!("task should have completed")
         }
 
@@ -249,12 +236,12 @@ mod tests {
 
     #[bench]
     fn insert_bench(b: &mut Bencher) {
-        let mut scheduler: Scheduler = Scheduler::default();
-        let group_id: SchedulerId = scheduler.create_group();
+        let mut scheduler = Scheduler::default();
+        let group_id = scheduler.create_group();
 
         b.iter(|| {
-            let task: DummyTask = DummyTask::new("testing", Box::pin(black_box(DummyCoroutine::new(1).fuse())));
-            let Some(InsertResult::Inserted(task_id)) = scheduler.insert_and_poll_task(group_id, task) else {
+            let task = DummyTask::new("testing", Box::pin(black_box(DummyCoroutine::new(1).fuse())));
+            let Some(InsertResult::Inserted(task_id)) = scheduler.insert(group_id, task) else {
                 panic!("couldn't insert future in scheduler");
             };
             black_box(task_id);
@@ -262,16 +249,16 @@ mod tests {
     }
 
     #[bench]
-    fn benchmark_poll_one_task_at_a_time(b: &mut Bencher) {
-        let mut scheduler: Scheduler = Scheduler::default();
-        let group_id: SchedulerId = scheduler.create_group();
+    fn benchmark_run_one_task_at_a_time(b: &mut Bencher) {
+        let mut scheduler = Scheduler::default();
+        let group_id = scheduler.create_group();
 
         const NUM_TASKS: usize = 1024;
-        let mut task_ids: Vec<SchedulerId> = Vec::<SchedulerId>::with_capacity(NUM_TASKS);
+        let mut task_ids = Vec::<SchedulerId>::with_capacity(NUM_TASKS);
 
         for val in 1..NUM_TASKS {
-            let task: DummyTask = DummyTask::new("testing", Box::pin(DummyCoroutine::new(val).fuse()));
-            match scheduler.insert_and_poll_task(group_id, task) {
+            let task = DummyTask::new("testing", Box::pin(DummyCoroutine::new(val).fuse()));
+            match scheduler.insert(group_id, task) {
                 Some(InsertResult::Completed(_)) => panic!("task should not have completed"),
                 Some(InsertResult::Inserted(task_id)) => task_ids.push(task_id),
                 None => panic!("insert() failed"),
@@ -279,21 +266,21 @@ mod tests {
         }
 
         b.iter(|| {
-            black_box(scheduler.poll_group_once(group_id, None));
+            black_box(scheduler.run_once(group_id, None));
         });
     }
 
     #[bench]
-    fn poll_many_tasks_until_done_bench(b: &mut Bencher) {
-        let mut scheduler: Scheduler = Scheduler::default();
-        let group_id: SchedulerId = scheduler.create_group();
+    fn run_many_tasks_until_done_bench(b: &mut Bencher) {
+        let mut scheduler = Scheduler::default();
+        let group_id = scheduler.create_group();
 
         const NUM_TASKS: usize = 8;
-        let mut task_ids: Vec<SchedulerId> = Vec::<SchedulerId>::with_capacity(NUM_TASKS);
+        let mut task_ids = Vec::<SchedulerId>::with_capacity(NUM_TASKS);
 
         for val in 1..NUM_TASKS {
-            let task: DummyTask = DummyTask::new("testing", Box::pin(DummyCoroutine::new(val).fuse()));
-            match scheduler.insert_and_poll_task(group_id, task) {
+            let task = DummyTask::new("testing", Box::pin(DummyCoroutine::new(val).fuse()));
+            match scheduler.insert(group_id, task) {
                 Some(InsertResult::Completed(_)) => panic!("task should not have completed"),
                 Some(InsertResult::Inserted(task_id)) => task_ids.push(task_id),
                 None => panic!("insert() failed"),
@@ -301,7 +288,7 @@ mod tests {
         }
 
         b.iter(|| {
-            black_box(scheduler.poll_group_until_unrunnable(group_id, None));
+            black_box(scheduler.run(group_id, None));
         });
     }
 }

--- a/src/runtime/scheduler/task.rs
+++ b/src/runtime/scheduler/task.rs
@@ -43,9 +43,9 @@ use ::std::{
 /// Task runs a single coroutine to completion and stores the result for later. Thus, it implements Future but
 /// never directly returns anything.
 pub trait Task: FusedFuture<Output = ()> + Unpin + Any + Debug {
-    fn get_name(&self) -> &'static str;
+    fn name(&self) -> &'static str;
     fn as_any(self: Box<Self>) -> Box<dyn Any>;
-    fn get_id(&self) -> Option<u64>;
+    fn id(&self) -> Option<u64>;
     fn set_id(&mut self, id: u64);
 }
 
@@ -108,7 +108,7 @@ impl<R: Unpin + Clone + Any> TryFrom<Box<dyn Any>> for TaskWithResult<R> {
 
 impl<R: Unpin + Clone + Any> Task for TaskWithResult<R> {
     // The coroutine type that this task will run.
-    fn get_name(&self) -> &'static str {
+    fn name(&self) -> &'static str {
         self.name
     }
 
@@ -116,7 +116,7 @@ impl<R: Unpin + Clone + Any> Task for TaskWithResult<R> {
         self
     }
 
-    fn get_id(&self) -> Option<u64> {
+    fn id(&self) -> Option<u64> {
         self.task_id
     }
 
@@ -127,7 +127,7 @@ impl<R: Unpin + Clone + Any> Task for TaskWithResult<R> {
 
 impl<R: Unpin + Clone + Any> Debug for TaskWithResult<R> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.get_name())
+        f.write_str(self.name())
     }
 }
 
@@ -137,12 +137,12 @@ impl<R: Unpin + Clone + Any> Future for TaskWithResult<R> {
 
     /// Polls the coroutine.
     fn poll(self: Pin<&mut Self>, ctx: &mut Context) -> Poll<()> {
-        let self_: &mut Self = self.get_mut();
+        let self_ = self.get_mut();
         if self_.result.is_some() {
             debug!("Task cancelled before complete");
             return Poll::Ready(());
         }
-        let result: <Self as TaskWith>::ResultType = match Future::poll(self_.coroutine.as_mut(), ctx) {
+        let result = match Future::poll(self_.coroutine.as_mut(), ctx) {
             Poll::Pending => return Poll::Pending,
             Poll::Ready(r) => r,
         };

--- a/src/runtime/scheduler/waker64.rs
+++ b/src/runtime/scheduler/waker64.rs
@@ -59,8 +59,8 @@ impl Waker64 {
     /// If the operation does not overflow, the old value is returned.
     /// Otherwise, `None` is returned instead.
     pub fn fetch_sub(&self, val: u64) -> Option<u64> {
-        let s: &mut u64 = unsafe { &mut *self.0.get() };
-        let old: u64 = *s;
+        let s = unsafe { &mut *self.0.get() };
+        let old = *s;
         if val > *s {
             return None;
         }
@@ -101,67 +101,67 @@ mod tests {
 
     #[bench]
     fn fetch_and_bench(b: &mut Bencher) {
-        let x: u64 = rand::thread_rng().gen_range(0..64);
-        let w64: Waker64 = Waker64::new(0);
+        let x = rand::thread_rng().gen_range(0..64);
+        let w64 = Waker64::new(0);
 
         b.iter(|| {
-            let val: u64 = black_box(x);
+            let val = black_box(x);
             w64.fetch_and(val);
         });
     }
 
     #[bench]
     fn fetch_or_bench(b: &mut Bencher) {
-        let x: u64 = rand::thread_rng().gen_range(0..64);
-        let w64: Waker64 = Waker64::new(0);
+        let x = rand::thread_rng().gen_range(0..64);
+        let w64 = Waker64::new(0);
 
         b.iter(|| {
-            let val: u64 = black_box(x);
+            let val = black_box(x);
             w64.fetch_or(val);
         });
     }
 
     #[bench]
     fn fetch_add_bench(b: &mut Bencher) {
-        let x: u64 = rand::thread_rng().gen_range(0..64);
-        let w64: Waker64 = Waker64::new(0);
+        let x = rand::thread_rng().gen_range(0..64);
+        let w64 = Waker64::new(0);
 
         b.iter(|| {
-            let val: u64 = black_box(x);
+            let val = black_box(x);
             w64.fetch_add(val);
         });
     }
 
     #[bench]
     fn fetch_sub_bench(b: &mut Bencher) {
-        let x: u64 = rand::thread_rng().gen_range(0..64);
+        let x = rand::thread_rng().gen_range(0..64);
 
         b.iter(|| {
-            let val: u64 = black_box(x);
-            let w64: Waker64 = Waker64::new(64);
+            let val = black_box(x);
+            let w64 = Waker64::new(64);
             expect_some!(w64.fetch_sub(val), "fetch_sub() overflowed");
         });
     }
 
     #[bench]
     fn load_bench(b: &mut Bencher) {
-        let x: u64 = rand::thread_rng().gen_range(0..64);
-        let w64: Waker64 = Waker64::new(x);
+        let x = rand::thread_rng().gen_range(0..64);
+        let w64 = Waker64::new(x);
 
         b.iter(|| {
-            let val: u64 = w64.load();
+            let val = w64.load();
             black_box(val);
         });
     }
 
     #[bench]
     fn swap_bench(b: &mut Bencher) {
-        let x: u64 = rand::thread_rng().gen_range(0..64);
-        let w64: Waker64 = Waker64::new(0);
+        let x = rand::thread_rng().gen_range(0..64);
+        let w64 = Waker64::new(0);
 
         b.iter(|| {
-            let val: u64 = black_box(x);
-            let oldval: u64 = w64.swap(val);
+            let val = black_box(x);
+            let oldval = w64.swap(val);
             black_box(oldval);
         });
     }

--- a/tests/rust/tcp-tests/accept/mod.rs
+++ b/tests/rust/tcp-tests/accept/mod.rs
@@ -106,7 +106,7 @@ fn accept_listening_socket(libos: &mut LibOS, local: &SocketAddr) -> Result<()> 
     // Succeed to close socket.
     libos.close(sockqd)?;
 
-    // Poll again to check that the accept() returns an err.
+    // Wait again to check that the accept() returns an err.
     match libos.wait(qt, None) {
         Ok(qr) if check_for_network_error(&qr) => {},
         Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_FAILED => anyhow::bail!(
@@ -140,7 +140,7 @@ fn accept_connecting_socket(libos: &mut LibOS, remote: &SocketAddr) -> Result<()
     // Succeed to close socket.
     libos.close(sockqd)?;
 
-    // Poll again to check that the connect() returns an err.
+    // Wait again to check that the connect() returns an err.
     match libos.wait(qt, None) {
         Ok(qr) if check_for_network_error(&qr) => Ok(()),
         Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_FAILED => anyhow::bail!(

--- a/tests/rust/tcp-tests/async_close/mod.rs
+++ b/tests/rust/tcp-tests/async_close/mod.rs
@@ -62,7 +62,7 @@ fn async_close_and_wait_twice_1(libos: &mut LibOS) -> Result<()> {
     // Succeed to close socket.
     let qt: QToken = libos.async_close(sockqd)?;
 
-    // Poll once to ensure the async_close() coroutine runs and finishes the close.
+    // Wait once to ensure the async_close() coroutine runs and finishes the close.
     match libos.wait(qt, None) {
         Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_CLOSE && qr.qr_ret == 0 => {},
         Ok(_) => anyhow::bail!("wait() should succeed with async_close()"),
@@ -143,7 +143,7 @@ fn async_close_unbound_socket(libos: &mut LibOS) -> Result<()> {
     // Succeed to close socket.
     let qt: QToken = libos.async_close(sockqd)?;
 
-    // Poll once to ensure the async_close() coroutine runs and finishes the close.
+    // Wait once to ensure the async_close() coroutine runs and finishes the close.
     match libos.wait(qt, None) {
         Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_CLOSE && qr.qr_ret == 0 => Ok(()),
         Ok(_) => anyhow::bail!("wait() should succeed with async_close()"),
@@ -160,7 +160,7 @@ fn async_close_bound_socket(libos: &mut LibOS, local: &SocketAddr) -> Result<()>
     // Succeed to close socket.
     let qt: QToken = libos.async_close(sockqd)?;
 
-    // Poll once to ensure the async_close() coroutine runs and finishes the close.
+    // Wait once to ensure the async_close() coroutine runs and finishes the close.
     match libos.wait(qt, None) {
         Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_CLOSE && qr.qr_ret == 0 => Ok(()),
         Ok(_) => anyhow::bail!("wait() should succeed with async_close()"),
@@ -178,7 +178,7 @@ fn async_close_listening_socket(libos: &mut LibOS, local: &SocketAddr) -> Result
     // Succeed to close socket.
     let qt: QToken = libos.async_close(sockqd)?;
 
-    // Poll once to ensure the async_close() coroutine runs and finishes the close.
+    // Wait once to ensure the async_close() coroutine runs and finishes the close.
     match libos.wait(qt, None) {
         Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_CLOSE && qr.qr_ret == 0 => Ok(()),
         Ok(_) => anyhow::bail!("wait() should succeed with async_close()"),

--- a/tests/rust/tcp-tests/connect/mod.rs
+++ b/tests/rust/tcp-tests/connect/mod.rs
@@ -73,7 +73,7 @@ fn connect_unbound_socket(libos: &mut LibOS, remote: &SocketAddr) -> Result<()> 
 
     // Succeed to close socket.
     libos.close(sockqd)?;
-    // Poll again to check that the connect() co-routine returns an err, either canceled or refused.
+    // Wait again to check that the connect() co-routine returns an err, either canceled or refused.
     match libos.wait(qt, None) {
         Ok(qr) if check_for_network_error(&qr) => Ok(()),
         Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_FAILED => anyhow::bail!(
@@ -104,7 +104,7 @@ fn connect_to_bad_remote(libos: &mut LibOS) -> Result<()> {
     // Succeed to connect socket.
     let qt: QToken = libos.connect(sockqd, remote)?;
 
-    // Poll for enough time to get the connection refused.
+    // Wait for enough time to get the connection refused.
     match libos.wait(qt, Some(Duration::from_secs(75))) {
         Ok(qr) if check_for_network_error(&qr) => {},
         Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_FAILED => anyhow::bail!(
@@ -139,7 +139,7 @@ fn connect_bound_socket(libos: &mut LibOS, local: &SocketAddr, remote: &SocketAd
     // Succeed to close socket.
     libos.close(sockqd)?;
 
-    // Poll again to check that the connect() co-routine returns an err, either canceled or refused.
+    // Wait again to check that the connect() co-routine returns an err, either canceled or refused.
     match libos.wait(qt, None) {
         Ok(qr) if check_for_network_error(&qr) => Ok(()),
         Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_FAILED => anyhow::bail!(
@@ -192,7 +192,7 @@ fn connect_connecting_socket(libos: &mut LibOS, remote: &SocketAddr) -> Result<(
     // Succeed to close socket.
     libos.close(sockqd)?;
 
-    // Poll again to check that the connect() co-routine returns an err, either canceled or refused.
+    // Wait again to check that the connect() co-routine returns an err, either canceled or refused.
     match libos.wait(qt, None) {
         Ok(qr) if check_for_network_error(&qr) => Ok(()),
         Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_FAILED => anyhow::bail!(
@@ -228,7 +228,7 @@ fn connect_accepting_socket(libos: &mut LibOS, local: &SocketAddr, remote: &Sock
     // Succeed to close socket.
     libos.close(sockqd)?;
 
-    // Poll again to check that the accept() co-routine completed with an error and was properly canceled.
+    // Wait again to check that the accept() co-routine completed with an error and was properly canceled.
     match libos.wait(qt, None) {
         Ok(qr) if check_for_network_error(&qr) => Ok(()),
         Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_FAILED => anyhow::bail!(

--- a/tests/rust/tcp-tests/listen/mod.rs
+++ b/tests/rust/tcp-tests/listen/mod.rs
@@ -175,7 +175,7 @@ fn listen_connecting_socket(libos: &mut LibOS, local: &SocketAddr, remote: &Sock
     // Close the socket.
     libos.close(sockqd)?;
 
-    // Poll again to check that the connect() co-routine returns an err, either canceled or refused.
+    // Wait again to check that the connect() co-routine returns an err, either canceled or refused.
     match libos.wait(qt, None) {
         Ok(qr) if check_for_network_error(&qr) => Ok(()),
         Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_FAILED => anyhow::bail!(
@@ -211,7 +211,7 @@ fn listen_accepting_socket(libos: &mut LibOS, local: &SocketAddr) -> Result<()> 
     // Close the socket.
     libos.close(sockqd)?;
 
-    // Poll again to check that the qtoken returns an err.
+    // Wait again to check that the qtoken returns an err.
     match libos.wait(qt, None) {
         Ok(qr) if check_for_network_error(&qr) => Ok(()),
         Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_FAILED => anyhow::bail!(

--- a/tests/rust/tcp-tests/wait/mod.rs
+++ b/tests/rust/tcp-tests/wait/mod.rs
@@ -68,7 +68,7 @@ fn wait_after_close_accepting_socket(libos: &mut LibOS, local: &SocketAddr) -> R
     // Succeed to close socket.
     libos.close(sockqd)?;
 
-    // Poll again to check that the accept() coroutine returns an err and was properly canceled.
+    // Wait again to check that the accept() coroutine returns an err and was properly canceled.
     match libos.wait(qt, None) {
         Ok(qr) if check_for_network_error(&qr) => Ok(()),
         Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_FAILED => anyhow::bail!(
@@ -94,7 +94,7 @@ fn wait_after_close_connecting_socket(libos: &mut LibOS, remote: &SocketAddr) ->
     // Succeed to close socket.
     libos.close(sockqd)?;
 
-    // Poll again to check that the connect() co-routine returns an err, either canceled or refused.
+    // Wait to check that the connect() co-routine returns an err, either canceled or refused.
     match libos.wait(qt, None) {
         Ok(qr) if check_for_network_error(&qr) => Ok(()),
         Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_FAILED => anyhow::bail!(
@@ -122,14 +122,14 @@ fn wait_after_async_close_accepting_socket(libos: &mut LibOS, local: &SocketAddr
     // Succeed to close socket.
     let qt_close: QToken = libos.async_close(sockqd)?;
 
-    // Poll once to ensure the async_close() coroutine runs and finishes the close.
+    // Wait once to ensure the async_close() coroutine runs and finishes the close.
     match libos.wait(qt_close, None) {
         Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_CLOSE && qr.qr_ret == 0 => {},
         Ok(_) => anyhow::bail!("wait() should succeed with async_close()"),
         Err(_) => anyhow::bail!("wait() should succeed with async_close()"),
     }
 
-    // Poll again to check that the accept() co-routine completed with an error and was properly canceled.
+    // Wait again to check that the accept() co-routine completed with an error and was properly canceled.
     match libos.wait(qt, None) {
         Ok(qr) if check_for_network_error(&qr) => Ok(()),
         Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_FAILED => anyhow::bail!(
@@ -155,14 +155,14 @@ fn wait_after_async_close_connecting_socket(libos: &mut LibOS, remote: &SocketAd
     // Succeed to close socket.
     let qt_close: QToken = libos.async_close(sockqd)?;
 
-    // Poll once to ensure the async_close() coroutine runs and finishes the close.
+    // Wait once to ensure the async_close() coroutine runs and finishes the close.
     match libos.wait(qt_close, None) {
         Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_CLOSE && qr.qr_ret == 0 => {},
         Ok(_) => anyhow::bail!("wait() should succeed with async_close()"),
         Err(_) => anyhow::bail!("wait() should succeed"),
     }
 
-    // Poll again to check that the connect() co-routine completed with an error, either canceled or refused.
+    // Wait again to check that the connect() co-routine completed with an error, either canceled or refused.
     match libos.wait(qt, None) {
         Ok(qr) if check_for_network_error(&qr) => Ok(()),
         Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_FAILED => anyhow::bail!(
@@ -219,7 +219,7 @@ fn wait_for_accept_after_issuing_async_close(libos: &mut LibOS, local: &SocketAd
     // Close the socket.
     let qt_close: QToken = libos.async_close(sockqd)?;
 
-    // Poll once to ensure the async_close() coroutine runs and finishes the close.
+    // Wait once to ensure the async_close() coroutine runs and finishes the close.
     match libos.wait(qt_close, None) {
         Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_CLOSE && qr.qr_ret == 0 => {},
         Ok(_) => anyhow::bail!("wait() should succeed with async_close()"),
@@ -268,7 +268,7 @@ fn wait_for_connect_after_issuing_async_close(libos: &mut LibOS, remote: &Socket
         Err(_) => anyhow::bail!("wait() should not time out"),
     }
 
-    // Poll once to ensure the async_close() coroutine runs and finishes the close.
+    // Wait once to ensure the async_close() coroutine runs and finishes the close.
     match libos.wait(qt_close, None) {
         Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_CLOSE && qr.qr_ret == 0 => Ok(()),
         Ok(_) => anyhow::bail!("wait() should succeed with async_close()"),


### PR DESCRIPTION
Simplify scheduler and group logic, clearer naming and reduced syntactic clutter.