### PR TITLE
feat: implement getsockname()   #72

### DIFF
--- a/src/demikernel/bindings.rs
+++ b/src/demikernel/bindings.rs
@@ -646,11 +646,63 @@ pub unsafe extern "C" fn demi_sgafree(sga: *mut demi_sgarray_t) -> c_int {
     }
 }
 
-#[allow(unused)]
+/// # Safety
+///
+/// The `addr` argument must be a valid pointer to a `sockaddr` structure, and `addrlen` must be a valid pointer to a
+/// `Socklen` value that specifies the size of the `sockaddr` structure.
 #[no_mangle]
-pub extern "C" fn demi_getsockname(qd: c_int, saddr: *mut sockaddr, size: *mut Socklen) -> c_int {
-    // TODO: Implement this system call.
-    libc::ENOSYS
+pub unsafe extern "C" fn demi_getsockname(qd: c_int, addr: *mut SockAddr, addrlen: *mut Socklen) -> c_int {
+    trace!("demi_getsockname()");
+
+    if addr.is_null() {
+        warn!("demi_getsockname() addr value is a null pointer");
+        return libc::EINVAL;
+    }
+
+    if addrlen.is_null() {
+        warn!("demi_getsockname(): addrlen value is a null pointer");
+        return libc::EINVAL;
+    }
+
+    let expected_len = mem::size_of::<SockAddrIn>() as Socklen;
+
+    if unsafe { *addrlen < expected_len } {
+        warn!("demi_getsockname(): addrlen does not match size of SockAddrIn");
+        return libc::EINVAL;
+    }
+
+    let ret = match do_syscall(|libos| libos.getsockname(qd.into())) {
+        Ok(result) => result,
+        Err(e) => {
+            trace!("demi_getsockname() failed: {:?}", e);
+            return e.errno;
+        },
+    };
+
+    match ret {
+        Ok(sockaddr) => {
+            let result = socketaddrv4_to_sockaddr(&sockaddr);
+            let result_length = mem::size_of::<SockAddr>();
+            unsafe {
+                if (result_length as Socklen) < *addrlen {
+                    *addrlen = result_length as Socklen;
+                }
+
+                // Need to pass dst as c_void pointer or else we get a stack-smashing error
+                ptr::copy_nonoverlapping(
+                    &result as *const sockaddr as *const c_void,
+                    addr as *mut c_void,
+                    *addrlen as usize,
+                );
+            }
+
+            0
+        },
+        Err(e) => {
+            trace!("demi_getsockname() failed: {:?}", e);
+            e.errno
+        },
+    }
 }
 
 /// # Safety

--- a/src/demikernel/libos/mod.rs
+++ b/src/demikernel/libos/mod.rs
@@ -145,6 +145,12 @@ impl LibOS {
         }
     }
 
+    pub fn getsockname(&mut self, sockqd: QDesc) -> Result<SocketAddrV4, Fail> {
+        match self {
+            LibOS::NetworkLibOS(libos) => libos.getsockname(sockqd),
+        }
+    }
+
     #[allow(unused_variables)]
     pub fn bind(&mut self, sockqd: QDesc, local: SocketAddr) -> Result<(), Fail> {
         match self {

--- a/src/demikernel/libos/network/libos.rs
+++ b/src/demikernel/libos/network/libos.rs
@@ -98,6 +98,11 @@ impl<T: NetworkTransport> SharedNetworkLibOS<T> {
         self.get_shared_queue(&qd)?.getpeername()
     }
 
+    pub fn getsockname(&mut self, qd: QDesc) -> Result<SocketAddrV4, Fail> {
+        trace!("getsockname() qd={:?}", qd);
+        self.get_shared_queue(&qd)?.getsockname()
+    }
+
     /// This function contains the LibOS-level functionality needed to bind a SharedNetworkQueue to a local address.
     pub fn bind(&mut self, qd: QDesc, socket_addr: SocketAddr) -> Result<(), Fail> {
         trace!("bind() qd={:?}, local={:?}", qd, socket_addr);

--- a/src/demikernel/libos/network/queue.rs
+++ b/src/demikernel/libos/network/queue.rs
@@ -91,6 +91,20 @@ impl<T: NetworkTransport> SharedNetworkQueue<T> {
         self.transport.clone().getpeername(&mut self.socket)
     }
 
+    /// Gets the local address bound to the socket.
+    pub fn getsockname(&mut self) -> Result<SocketAddrV4, Fail> {
+        match self.local() {
+            Some(addr) => {
+                // We only support IPv4 addresses in demikernel
+                match addr {
+                    SocketAddr::V4(addr_v4) => Ok(addr_v4),
+                    SocketAddr::V6(_) => Err(Fail::new(libc::ENOTSUP, "IPv6 not supported")),
+                }
+            },
+            None => Err(Fail::new(libc::ENOTCONN, "socket is not bound to any address")),
+        }
+    }
+
     /// Binds the target queue to `local` address.
     pub fn bind(&mut self, local: SocketAddr) -> Result<(), Fail> {
         self.state_machine.may_bind()?;


### PR DESCRIPTION
This PR implements the missing `getsockname()` function.

Changes:
- Added `getsockname()` to LibOS interface
- Implemented support in `SharedNetworkQueue` to retrieve local socket address
- Updated `demi_getsockname()` C binding with validation, buffer checks, and error handling
- Ensured consistency with existing `getpeername()` implementation

Key Points:
- Memory safety ensured with proper pointer and buffer handling
- Error handling follows Demikernel conventions (`EINVAL`, `ENOTCONN`, `ENOTSUP`)
- Supports IPv4 (consistent with current design)
- Includes debug tracing for troubleshooting

Fixes #72