### PR TITLE
runtime: Add max buffer size to inetstack from the network runtime

### DIFF
--- a/src/inetstack/mod.rs
+++ b/src/inetstack/mod.rs
@@ -294,6 +294,10 @@ impl NetworkTransport for SharedInetStack {
 /// This implements the memory runtime trait for the inetstack. Other libOSes without a network runtime can directly
 /// use OS memory but the inetstack requires specialized memory allocated by the lower-level runtime.
 impl DemiMemoryAllocator for SharedInetStack {
+    fn max_buffer_size_bytes(&self) -> usize {
+        self.layer4_endpoint.max_buffer_size_bytes()
+    }
+
     fn allocate_demi_buffer(&self, size: usize) -> Result<DemiBuffer, Fail> {
         self.layer4_endpoint.allocate_demi_buffer(size)
     }

--- a/src/inetstack/protocols/layer2/mod.rs
+++ b/src/inetstack/protocols/layer2/mod.rs
@@ -129,6 +129,10 @@ impl DerefMut for SharedLayer2Endpoint {
 }
 
 impl DemiMemoryAllocator for SharedLayer2Endpoint {
+    fn max_buffer_size_bytes(&self) -> usize {
+        self.layer1_endpoint.max_buffer_size_bytes()
+    }
+
     fn allocate_demi_buffer(&self, size: usize) -> Result<DemiBuffer, Fail> {
         self.layer1_endpoint.allocate_demi_buffer(size)
     }

--- a/src/inetstack/protocols/layer3/mod.rs
+++ b/src/inetstack/protocols/layer3/mod.rs
@@ -193,6 +193,10 @@ impl DerefMut for SharedLayer3Endpoint {
 
 /// Memory Runtime Trait Implementation for Layer 3.
 impl DemiMemoryAllocator for SharedLayer3Endpoint {
+    fn max_buffer_size_bytes(&self) -> usize {
+        self.layer2_endpoint.max_buffer_size_bytes()
+    }
+
     fn allocate_demi_buffer(&self, size: usize) -> Result<DemiBuffer, Fail> {
         self.layer2_endpoint.allocate_demi_buffer(size)
     }

--- a/src/inetstack/protocols/layer4/mod.rs
+++ b/src/inetstack/protocols/layer4/mod.rs
@@ -394,6 +394,10 @@ impl Peer {
 //======================================================================================================================
 
 impl DemiMemoryAllocator for Peer {
+    fn max_buffer_size_bytes(&self) -> usize {
+        self.layer3_endpoint.max_buffer_size_bytes()
+    }
+
     fn allocate_demi_buffer(&self, size: usize) -> Result<DemiBuffer, Fail> {
         self.layer3_endpoint.allocate_demi_buffer(size)
     }


### PR DESCRIPTION
This PR fixes an issue where the inetstack was using the default implementation of `max_buffer_size_bytes()` rather than getting it from the underlying physical layer. For example, in Catnip, this meant that we were not using the configured DPDK max_body_size.